### PR TITLE
Add Navidrome library selector

### DIFF
--- a/.github/workflows/phone-debug.yml
+++ b/.github/workflows/phone-debug.yml
@@ -15,6 +15,8 @@ jobs:
   build-phone:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
 
     steps:
       - name: Checkout repository

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepository.kt
@@ -19,6 +19,7 @@ import com.lostf1sh.pixelplayeross.data.database.SourceType
 import com.lostf1sh.pixelplayeross.data.database.toSong
 import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeCredentials
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeMusicFolder
 import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeSong
 import com.lostf1sh.pixelplayeross.data.network.navidrome.NavidromeApiService
 import com.lostf1sh.pixelplayeross.data.network.navidrome.NavidromeResponseParser
@@ -165,6 +166,9 @@ class NavidromeRepository @Inject constructor(
     val username: String?
         get() = prefs.getString(KEY_USERNAME, null)
 
+    val selectedMusicFolderIdsFlow: Flow<Set<String>> =
+        userPreferencesRepository.navidromeSelectedMusicFolderIdsFlow
+
     var lastFullSyncTime: Long
         get() = prefs.getLong(KEY_LAST_FULL_SYNC, 0L)
         set(value) = prefs.edit { putLong(KEY_LAST_FULL_SYNC, value) }
@@ -235,7 +239,25 @@ class NavidromeRepository @Inject constructor(
 
         musicDao.clearAllNavidromeSongs()
         dao.clearAllPlaylists()
+        userPreferencesRepository.clearNavidromeSelectedMusicFolderIds()
         _isLoggedInFlow.value = false
+    }
+
+    suspend fun getMusicFolders(): Result<List<NavidromeMusicFolder>> {
+        if (!isLoggedIn) {
+            return Result.failure(Exception("Not logged in"))
+        }
+
+        return withContext(Dispatchers.IO) {
+            api.getMusicFolders().map { folders ->
+                NavidromeResponseParser.parseMusicFolders(folders)
+                    .filter { it.id.isNotBlank() }
+            }
+        }
+    }
+
+    suspend fun setSelectedMusicFolderIds(folderIds: Set<String>) {
+        userPreferencesRepository.setNavidromeSelectedMusicFolderIds(folderIds.filter { it.isNotBlank() }.toSet())
     }
 
     // ─── Playlists ────────────────────────────────────────────────────────
@@ -415,7 +437,31 @@ class NavidromeRepository @Inject constructor(
                 val pageSize = 500
                 
                 onProgress?.invoke(0.1f, context.getString(R.string.dash_status_fetching_albums))
-                val fetchedAlbums = fetchAllAlbums(pageSize)
+                val musicFolders = getMusicFolders().getOrElse { error ->
+                    Timber.w(error, "$TAG: Failed to load music folders; falling back to all-library sync")
+                    emptyList()
+                }
+                val selectedFolderIds = selectedNavidromeMusicFolderIds(
+                    availableFolders = musicFolders,
+                    savedFolderIds = userPreferencesRepository.navidromeSelectedMusicFolderIdsFlow.first()
+                )
+                val folderFilterIds = if (
+                    musicFolders.isNotEmpty() &&
+                    selectedFolderIds.isNotEmpty() &&
+                    selectedFolderIds.size < musicFolders.size
+                ) {
+                    selectedFolderIds
+                } else {
+                    emptySet()
+                }
+
+                val fetchedAlbums = if (folderFilterIds.isEmpty()) {
+                    fetchAllAlbums(pageSize)
+                } else {
+                    folderFilterIds.flatMap { folderId ->
+                        fetchAllAlbums(pageSize, musicFolderId = folderId)
+                    }
+                }
 
                 // Fetch songs for each album in parallel
                 val totalAlbums = fetchedAlbums.size
@@ -489,7 +535,7 @@ class NavidromeRepository @Inject constructor(
     /**
      * Fetch all albums from server with pagination.
      */
-    private suspend fun fetchAllAlbums(pageSize: Int): List<JSONObject> {
+    private suspend fun fetchAllAlbums(pageSize: Int, musicFolderId: String? = null): List<JSONObject> {
         val allAlbums = mutableListOf<JSONObject>()
         var offset = 0
 
@@ -497,7 +543,8 @@ class NavidromeRepository @Inject constructor(
             val albumsResult = api.getAlbumList(
                 type = "alphabeticalByName",
                 size = pageSize,
-                offset = offset
+                offset = offset,
+                musicFolderId = musicFolderId
             )
 
             val albumJsons = albumsResult.getOrNull()
@@ -1004,6 +1051,17 @@ internal fun navidromePlaylistsWithLibraryFallback(
             lastSyncTime = nowMs
         )
     )
+}
+
+internal fun selectedNavidromeMusicFolderIds(
+    availableFolders: List<NavidromeMusicFolder>,
+    savedFolderIds: Set<String>
+): Set<String> {
+    val availableIds = availableFolders.map { it.id }.filter { it.isNotBlank() }.toSet()
+    if (availableIds.isEmpty()) return emptySet()
+
+    val validSavedIds = savedFolderIds.intersect(availableIds)
+    return validSavedIds.ifEmpty { availableIds }
 }
 
 // ─── Extension Functions ────────────────────────────────────────────────────

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/network/navidrome/NavidromeResponseParser.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/network/navidrome/NavidromeResponseParser.kt
@@ -28,6 +28,10 @@ object NavidromeResponseParser {
         )
     }
 
+    fun parseMusicFolders(jsonArray: List<JSONObject>): List<NavidromeMusicFolder> {
+        return jsonArray.map { parseMusicFolder(it) }
+    }
+
     // ─── Artist Parsing ──────────────────────────────────────────────────
 
     /**

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepository.kt
@@ -128,6 +128,8 @@ constructor(
         val IS_FOLDERS_PLAYLIST_VIEW = booleanPreferencesKey("is_folders_playlist_view")
         val HIDE_LOCAL_MEDIA = booleanPreferencesKey("hide_local_media")
         val FOLDERS_SOURCE = stringPreferencesKey("folders_source")
+        val NAVIDROME_SELECTED_MUSIC_FOLDER_IDS =
+                stringSetPreferencesKey("navidrome_selected_music_folder_ids")
         val FOLDER_BACK_GESTURE_NAVIGATION = booleanPreferencesKey("folder_back_gesture_navigation")
         val USE_SMOOTH_CORNERS = booleanPreferencesKey("use_smooth_corners")
         val KEEP_PLAYING_IN_BACKGROUND = booleanPreferencesKey("keep_playing_in_background")
@@ -1501,6 +1503,12 @@ constructor(
             FolderSource.fromStorageKey(preferences[PreferencesKeys.FOLDERS_SOURCE])
         }
 
+    val navidromeSelectedMusicFolderIdsFlow: Flow<Set<String>> = dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.NAVIDROME_SELECTED_MUSIC_FOLDER_IDS].orEmpty()
+        }
+        .distinctUntilChanged()
+
     val folderBackGestureNavigationFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
             preferences[PreferencesKeys.FOLDER_BACK_GESTURE_NAVIGATION] ?: true
@@ -1532,6 +1540,22 @@ constructor(
     suspend fun setFoldersSource(source: FolderSource) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.FOLDERS_SOURCE] = source.storageKey
+        }
+    }
+
+    suspend fun setNavidromeSelectedMusicFolderIds(folderIds: Set<String>) {
+        dataStore.edit { preferences ->
+            if (folderIds.isEmpty()) {
+                preferences.remove(PreferencesKeys.NAVIDROME_SELECTED_MUSIC_FOLDER_IDS)
+            } else {
+                preferences[PreferencesKeys.NAVIDROME_SELECTED_MUSIC_FOLDER_IDS] = folderIds
+            }
+        }
+    }
+
+    suspend fun clearNavidromeSelectedMusicFolderIds() {
+        dataStore.edit { preferences ->
+            preferences.remove(PreferencesKeys.NAVIDROME_SELECTED_MUSIC_FOLDER_IDS)
         }
     }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
@@ -16,11 +16,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Logout
+import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.CloudQueue
 import androidx.compose.material.icons.rounded.CloudSync
 import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.LibraryMusic
 import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.RadioButtonUnchecked
+import androidx.compose.material.icons.rounded.SelectAll
 import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -37,6 +43,8 @@ import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.database.NavidromePlaylistEntity
 import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.data.navidrome.NavidromeRepository
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeMusicFolder
+import com.lostf1sh.pixelplayeross.data.navidrome.selectedNavidromeMusicFolderIds
 import com.lostf1sh.pixelplayeross.presentation.components.SmartImage
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import com.lostf1sh.pixelplayeross.utils.formatTimeAgo
@@ -56,6 +64,10 @@ fun NavidromeDashboardScreen(
     val syncMessage by viewModel.syncMessage.collectAsStateWithLifecycle()
     val selectedPlaylistSongs by viewModel.selectedPlaylistSongs.collectAsStateWithLifecycle()
     val selectedPlaylistName by viewModel.selectedPlaylistName.collectAsStateWithLifecycle()
+    val musicFolders by viewModel.musicFolders.collectAsStateWithLifecycle()
+    val musicFoldersLoadFailed by viewModel.musicFoldersLoadFailed.collectAsStateWithLifecycle()
+    val selectedMusicFolderIds by viewModel.selectedMusicFolderIds.collectAsStateWithLifecycle()
+    val librarySelectionNeedsSync by viewModel.librarySelectionNeedsSync.collectAsStateWithLifecycle()
 
     val cardShape = AbsoluteSmoothCornerShape(
         cornerRadiusTR = 20.dp, cornerRadiusTL = 20.dp,
@@ -102,9 +114,14 @@ fun NavidromeDashboardScreen(
             syncMessage = syncMessage,
             selectedPlaylistSongs = selectedPlaylistSongs,
             selectedPlaylistName = selectedPlaylistName,
+            musicFolders = musicFolders,
+            musicFoldersLoadFailed = musicFoldersLoadFailed,
+            selectedMusicFolderIds = selectedMusicFolderIds,
+            librarySelectionNeedsSync = librarySelectionNeedsSync,
             username = viewModel.username,
             lastSyncTime = viewModel.lastSyncTime,
             onSyncAll = { viewModel.syncAllPlaylistsAndSongs() },
+            onSelectMusicFolders = { viewModel.setSelectedMusicFolderIds(it) },
             onSyncPlaylist = { viewModel.syncPlaylistSongs(it) },
             onDeletePlaylist = { viewModel.deletePlaylist(it) },
             onLoadPlaylistSongs = { playlist -> viewModel.loadPlaylistSongs(playlist.id, playlist.name) },
@@ -126,9 +143,14 @@ private fun DashboardContent(
     syncMessage: String?,
     selectedPlaylistSongs: List<Song>,
     selectedPlaylistName: String?,
+    musicFolders: List<NavidromeMusicFolder>,
+    musicFoldersLoadFailed: Boolean,
+    selectedMusicFolderIds: Set<String>,
+    librarySelectionNeedsSync: Boolean,
     username: String?,
     lastSyncTime: Long,
     onSyncAll: () -> Unit,
+    onSelectMusicFolders: (Set<String>) -> Unit,
     onSyncPlaylist: (String) -> Unit,
     onDeletePlaylist: (String) -> Unit,
     onLoadPlaylistSongs: (NavidromePlaylistEntity) -> Unit,
@@ -266,6 +288,11 @@ private fun DashboardContent(
 
         SubsonicMenuCard(
             isSyncing = isSyncing,
+            musicFolders = musicFolders,
+            musicFoldersLoadFailed = musicFoldersLoadFailed,
+            selectedMusicFolderIds = selectedMusicFolderIds,
+            librarySelectionNeedsSync = librarySelectionNeedsSync,
+            onSelectMusicFolders = onSelectMusicFolders,
             onSyncAll = onSyncAll,
             onLogout = onLogout,
             cardShape = cardShape
@@ -384,10 +411,40 @@ private fun DashboardContent(
 @Composable
 private fun SubsonicMenuCard(
     isSyncing: Boolean,
+    musicFolders: List<NavidromeMusicFolder>,
+    musicFoldersLoadFailed: Boolean,
+    selectedMusicFolderIds: Set<String>,
+    librarySelectionNeedsSync: Boolean,
+    onSelectMusicFolders: (Set<String>) -> Unit,
     onSyncAll: () -> Unit,
     onLogout: () -> Unit,
     cardShape: AbsoluteSmoothCornerShape
 ) {
+    var showLibrarySelector by remember { mutableStateOf(false) }
+    val effectiveSelectedIds = selectedNavidromeMusicFolderIds(musicFolders, selectedMusicFolderIds)
+    val selectedFolderNames = remember(musicFolders, effectiveSelectedIds) {
+        musicFolders.filter { it.id in effectiveSelectedIds }.map { it.name }
+    }
+    val librarySummary = when {
+        musicFoldersLoadFailed -> stringResource(R.string.dash_libraries_load_failed)
+        musicFolders.isEmpty() -> stringResource(R.string.dash_libraries_all)
+        effectiveSelectedIds.size == musicFolders.size -> stringResource(R.string.dash_libraries_all)
+        else -> stringResource(
+            R.string.dash_libraries_selected_count,
+            effectiveSelectedIds.size,
+            musicFolders.size
+        )
+    }
+
+    if (showLibrarySelector) {
+        LibrarySelectorSheet(
+            musicFolders = musicFolders,
+            selectedMusicFolderIds = selectedMusicFolderIds,
+            onDismiss = { showLibrarySelector = false },
+            onSelectionChange = onSelectMusicFolders
+        )
+    }
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -412,6 +469,17 @@ private fun SubsonicMenuCard(
                 style = MaterialTheme.typography.bodySmall,
                 fontFamily = RoundedSans,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            NavidromeLibrarySummaryPanel(
+                librarySummary = librarySummary,
+                selectedFolderNames = selectedFolderNames,
+                selectedCount = effectiveSelectedIds.size,
+                totalCount = musicFolders.size,
+                loadFailed = musicFoldersLoadFailed,
+                needsSync = librarySelectionNeedsSync,
+                enabled = !isSyncing && musicFolders.size > 1,
+                onClick = { showLibrarySelector = true }
             )
             Spacer(modifier = Modifier.height(16.dp))
             Row(
@@ -463,6 +531,337 @@ private fun SubsonicMenuCard(
                     Text(stringResource(R.string.dash_action_disconnect), fontFamily = RoundedSans)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun NavidromeLibrarySummaryPanel(
+    librarySummary: String,
+    selectedFolderNames: List<String>,
+    selectedCount: Int,
+    totalCount: Int,
+    loadFailed: Boolean,
+    needsSync: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    val containerColor = if (needsSync) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.72f)
+    } else {
+        MaterialTheme.colorScheme.surfaceContainer
+    }
+    val iconContainerColor = if (loadFailed) {
+        MaterialTheme.colorScheme.errorContainer
+    } else {
+        MaterialTheme.colorScheme.primaryContainer
+    }
+    val iconColor = if (loadFailed) {
+        MaterialTheme.colorScheme.onErrorContainer
+    } else {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(enabled = enabled, onClick = onClick),
+        shape = RoundedCornerShape(18.dp),
+        color = containerColor,
+        tonalElevation = if (needsSync) 3.dp else 0.dp
+    ) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(46.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(iconContainerColor),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = if (loadFailed) Icons.Rounded.Warning else Icons.Rounded.LibraryMusic,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = iconColor
+                    )
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.dash_libraries_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontFamily = RoundedSans,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = librarySummary,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontFamily = RoundedSans,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                if (enabled) {
+                    AssistChip(
+                        onClick = onClick,
+                        label = {
+                            Text(
+                                stringResource(R.string.dash_libraries_change),
+                                fontFamily = RoundedSans
+                            )
+                        },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Rounded.Folder,
+                                contentDescription = null,
+                                modifier = Modifier.size(AssistChipDefaults.IconSize)
+                            )
+                        }
+                    )
+                }
+            }
+
+            if (needsSync || selectedFolderNames.isNotEmpty() || totalCount > 0) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (needsSync) {
+                        SuggestionChip(
+                            onClick = {},
+                            enabled = false,
+                            label = {
+                                Text(
+                                    stringResource(R.string.dash_libraries_sync_needed),
+                                    fontFamily = RoundedSans
+                                )
+                            },
+                            icon = {
+                                Icon(
+                                    Icons.Rounded.Sync,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SuggestionChipDefaults.IconSize)
+                                )
+                            }
+                        )
+                    }
+
+                    if (totalCount > 0) {
+                        AssistChip(
+                            onClick = {},
+                            enabled = false,
+                            label = {
+                                Text(
+                                    stringResource(
+                                        R.string.dash_libraries_selected_count,
+                                        selectedCount,
+                                        totalCount
+                                    ),
+                                    fontFamily = RoundedSans
+                                )
+                            }
+                        )
+                    }
+
+                    selectedFolderNames.take(3).forEach { folderName ->
+                        FilterChip(
+                            selected = true,
+                            onClick = {},
+                            label = {
+                                Text(
+                                    folderName,
+                                    fontFamily = RoundedSans,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Rounded.CheckCircle,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(FilterChipDefaults.IconSize)
+                                )
+                            }
+                        )
+                    }
+
+                    val hiddenCount = (selectedFolderNames.size - 3).coerceAtLeast(0)
+                    if (hiddenCount > 0) {
+                        AssistChip(
+                            onClick = {},
+                            enabled = false,
+                            label = {
+                                Text(
+                                    stringResource(R.string.dash_libraries_more_count, hiddenCount),
+                                    fontFamily = RoundedSans
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LibrarySelectorSheet(
+    musicFolders: List<NavidromeMusicFolder>,
+    selectedMusicFolderIds: Set<String>,
+    onDismiss: () -> Unit,
+    onSelectionChange: (Set<String>) -> Unit
+) {
+    val availableIds = remember(musicFolders) { musicFolders.map { it.id }.toSet() }
+    val effectiveSelectedIds = selectedNavidromeMusicFolderIds(musicFolders, selectedMusicFolderIds)
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.dash_libraries_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontFamily = RoundedSans,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.dash_libraries_sheet_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = RoundedSans,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LibrarySelectorChoice(
+                icon = Icons.Rounded.SelectAll,
+                title = stringResource(R.string.dash_libraries_all),
+                subtitle = stringResource(R.string.dash_libraries_all_subtitle),
+                checked = effectiveSelectedIds.size == musicFolders.size,
+                onClick = { onSelectionChange(availableIds) }
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            musicFolders.forEach { folder ->
+                LibrarySelectorChoice(
+                    icon = Icons.Rounded.Folder,
+                    title = folder.name,
+                    subtitle = stringResource(R.string.dash_libraries_folder_subtitle),
+                    checked = folder.id in effectiveSelectedIds,
+                    onClick = {
+                        val nextIds = if (folder.id in effectiveSelectedIds) {
+                            effectiveSelectedIds - folder.id
+                        } else {
+                            effectiveSelectedIds + folder.id
+                        }
+                        onSelectionChange(nextIds)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibrarySelectorChoice(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onClick: () -> Unit
+) {
+    val containerColor = if (checked) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceContainer
+    }
+    val contentColor = if (checked) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(18.dp),
+        color = containerColor,
+        tonalElevation = if (checked) 3.dp else 0.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(
+                        if (checked) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.surfaceContainerHighest
+                        }
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(23.dp),
+                    tint = if (checked) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                )
+            }
+            Spacer(modifier = Modifier.width(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontFamily = RoundedSans,
+                    fontWeight = FontWeight.SemiBold,
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = RoundedSans,
+                    color = contentColor.copy(alpha = 0.72f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Icon(
+                imageVector = if (checked) Icons.Rounded.CheckCircle else Icons.Rounded.RadioButtonUnchecked,
+                contentDescription = null,
+                modifier = Modifier.size(26.dp),
+                tint = if (checked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkManager
 import com.lostf1sh.pixelplayeross.data.database.NavidromePlaylistEntity
 import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.data.navidrome.NavidromeRepository
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeMusicFolder
 import com.lostf1sh.pixelplayeross.data.worker.NavidromeSyncWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -43,6 +44,18 @@ class NavidromeDashboardViewModel @Inject constructor(
     private val _selectedPlaylistName = MutableStateFlow<String?>(null)
     val selectedPlaylistName: StateFlow<String?> = _selectedPlaylistName.asStateFlow()
 
+    private val _musicFolders = MutableStateFlow<List<NavidromeMusicFolder>>(emptyList())
+    val musicFolders: StateFlow<List<NavidromeMusicFolder>> = _musicFolders.asStateFlow()
+
+    private val _musicFoldersLoadFailed = MutableStateFlow(false)
+    val musicFoldersLoadFailed: StateFlow<Boolean> = _musicFoldersLoadFailed.asStateFlow()
+
+    val selectedMusicFolderIds: StateFlow<Set<String>> = repository.selectedMusicFolderIdsFlow
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
+
+    private val _librarySelectionNeedsSync = MutableStateFlow(false)
+    val librarySelectionNeedsSync: StateFlow<Boolean> = _librarySelectionNeedsSync.asStateFlow()
+
     private var selectedPlaylistJob: Job? = null
 
     val username: String? get() = repository.username
@@ -52,6 +65,7 @@ class NavidromeDashboardViewModel @Inject constructor(
 
     init {
         observeSyncWorker()
+        loadMusicFolders()
         // Auto sync full library (songs + playlists) if it's been more than 24 hours
         val lastSync = repository.lastFullSyncTime
         val currentTime = System.currentTimeMillis()
@@ -75,6 +89,7 @@ class NavidromeDashboardViewModel @Inject constructor(
                     WorkInfo.State.SUCCEEDED -> {
                         _isSyncing.value = false
                         _syncProgress.value = null
+                        _librarySelectionNeedsSync.value = false
                     }
                     WorkInfo.State.FAILED -> {
                         _isSyncing.value = false
@@ -96,6 +111,28 @@ class NavidromeDashboardViewModel @Inject constructor(
             ExistingWorkPolicy.KEEP,
             NavidromeSyncWorker.startAllSync()
         )
+    }
+
+    fun loadMusicFolders() {
+        viewModelScope.launch {
+            repository.getMusicFolders()
+                .onSuccess { folders ->
+                    _musicFolders.value = folders
+                    _musicFoldersLoadFailed.value = false
+                }
+                .onFailure {
+                    // Music-folder discovery is optional; sync falls back to the server-wide library.
+                    _musicFolders.value = emptyList()
+                    _musicFoldersLoadFailed.value = true
+                }
+        }
+    }
+
+    fun setSelectedMusicFolderIds(folderIds: Set<String>) {
+        viewModelScope.launch {
+            repository.setSelectedMusicFolderIds(folderIds)
+            _librarySelectionNeedsSync.value = true
+        }
     }
 
     fun syncPlaylistSongs(playlistId: String) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AboutScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AboutScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.Public
 import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -148,6 +149,7 @@ private val AboutMaintainers = listOf(
 
 private const val SourceRepoUrl = "https://github.com/lostf1sh/PixelPlayerOSS"
 private const val FDroidUrl = "https://f-droid.org/packages/com.lostf1sh.pixelplayeross/"
+private const val SponsorUrl = "https://github.com/sponsors/lostf1sh"
 
 private data class ProjectLink(
     val id: String,
@@ -306,6 +308,16 @@ fun AboutScreen(
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
                         .padding(top = 8.dp),
+                )
+            }
+
+            item(key = "support_card") {
+                AboutSupportCard(
+                    onSponsorClick = { openUrl(context, SponsorUrl) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 12.dp),
                 )
             }
 
@@ -503,6 +515,113 @@ private fun CommunitySignalsRow() {
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun AboutSupportCard(
+    onSponsorClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = AbsoluteSmoothCornerShape(30.dp, 60)
+
+    Surface(
+        modifier = modifier,
+        shape = shape,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        tonalElevation = 4.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primary,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.rounded_favorite_24),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.padding(12.dp).size(24.dp),
+                    )
+                }
+
+                Spacer(Modifier.width(12.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.about_support_eyebrow),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.78f),
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = stringResource(R.string.about_support_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            Text(
+                text = stringResource(R.string.about_support_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.86f),
+            )
+
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                listOf(
+                    stringResource(R.string.about_support_chip_foss),
+                    stringResource(R.string.about_support_chip_ci),
+                    stringResource(R.string.about_support_chip_streaming),
+                ).forEach { label ->
+                    Surface(
+                        shape = AbsoluteSmoothCornerShape(16.dp, 60),
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.10f),
+                    ) {
+                        Text(
+                            text = label,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+
+            FilledTonalButton(
+                onClick = onSponsorClick,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.github),
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.about_support_cta),
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
     }

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -217,6 +217,16 @@
     <string name="dash_quick_actions">Quick actions</string>
     <string name="dash_quick_actions_subsonic_subtitle">Manage Navidrome, Airsonic and other Subsonic-compatible servers.</string>
     <string name="dash_quick_actions_jellyfin_subtitle">Manage your Jellyfin server connection.</string>
+    <string name="dash_libraries_title">Libraries</string>
+    <string name="dash_libraries_all">All libraries</string>
+    <string name="dash_libraries_selected_count">%1$d of %2$d selected</string>
+    <string name="dash_libraries_more_count">+%1$d more</string>
+    <string name="dash_libraries_change">Change</string>
+    <string name="dash_libraries_load_failed">Could not load libraries; sync uses all</string>
+    <string name="dash_libraries_sheet_subtitle">Choose which server libraries are included when syncing the main library.</string>
+    <string name="dash_libraries_all_subtitle">Include every library exposed by this server</string>
+    <string name="dash_libraries_folder_subtitle">Include this library in the next library sync</string>
+    <string name="dash_libraries_sync_needed">Sync library to apply changes</string>
     <string name="dash_status_syncing">Syncing</string>
     <string name="dash_action_sync_library">Sync library</string>
     <string name="dash_action_disconnect">Disconnect</string>

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -181,14 +181,14 @@
 
     <!-- About -->
     <string name="about_app_name">PixelPlayerOSS</string>
-    <string name="about_tagline">Free and open-source edition of the PixelPlayer music player.</string>
+    <string name="about_tagline">Local-first music, self-hosted streaming, and Material 3 craft in one FOSS player.</string>
     <string name="about_version_format">Version v%1$s</string>
     <string name="about_contributions_format">%1$d contrib.</string>
     <string name="screen_about">About</string>
     <string name="about_maintainer_title">Maintainers</string>
     <string name="about_maintainer_subtitle">FOSS and original/non-FOSS maintainership.</string>
     <string name="about_project_title">Project</string>
-    <string name="about_project_subtitle">Source code and download listing.</string>
+    <string name="about_project_subtitle">Source, releases, and community entry points.</string>
     <string name="about_link_source_title">Source code</string>
     <string name="about_link_source_subtitle">github.com/lostf1sh/PixelPlayerOSS</string>
     <string name="about_link_fdroid_title">F-Droid</string>
@@ -197,6 +197,13 @@
     <string name="about_signal_open_source">Open source</string>
     <string name="about_signal_community_first">Community-first</string>
     <string name="about_signal_material3">Material 3 expressive</string>
+    <string name="about_support_eyebrow">GitHub Sponsors</string>
+    <string name="about_support_title">Support PixelPlayerOSS</string>
+    <string name="about_support_body">Help keep the FOSS edition maintained, reviewed, and tested for real Android devices.</string>
+    <string name="about_support_chip_foss">FOSS maintenance</string>
+    <string name="about_support_chip_ci">CI and releases</string>
+    <string name="about_support_chip_streaming">Self-hosted music</string>
+    <string name="about_support_cta">Sponsor on GitHub</string>
     <string name="cd_open_github_profile">Open GitHub profile</string>
     <string name="cd_open_telegram_profile">Open Telegram profile</string>
     <string name="cd_contributor_avatar">Avatar of %1$s</string>

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepositoryTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.lostf1sh.pixelplayeross.data.navidrome
 
 import com.google.common.truth.Truth.assertThat
 import com.lostf1sh.pixelplayeross.data.database.NavidromePlaylistEntity
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeMusicFolder
 import org.junit.jupiter.api.Test
 
 class NavidromeRepositoryTest {
@@ -44,5 +45,60 @@ class NavidromeRepositoryTest {
         )
 
         assertThat(playlists).containsExactly(remotePlaylist)
+    }
+
+    @Test
+    fun `selected music folders defaults to all available folders when saved selection is empty`() {
+        val folders = listOf(
+            NavidromeMusicFolder(id = "flac", name = "FLAC"),
+            NavidromeMusicFolder(id = "mp3", name = "MP3")
+        )
+
+        val selectedIds = selectedNavidromeMusicFolderIds(
+            availableFolders = folders,
+            savedFolderIds = emptySet()
+        )
+
+        assertThat(selectedIds).containsExactly("flac", "mp3")
+    }
+
+    @Test
+    fun `selected music folders keeps valid saved subset`() {
+        val folders = listOf(
+            NavidromeMusicFolder(id = "flac", name = "FLAC"),
+            NavidromeMusicFolder(id = "mp3", name = "MP3")
+        )
+
+        val selectedIds = selectedNavidromeMusicFolderIds(
+            availableFolders = folders,
+            savedFolderIds = setOf("flac")
+        )
+
+        assertThat(selectedIds).containsExactly("flac")
+    }
+
+    @Test
+    fun `selected music folders falls back to all when saved ids are stale`() {
+        val folders = listOf(
+            NavidromeMusicFolder(id = "flac", name = "FLAC"),
+            NavidromeMusicFolder(id = "mp3", name = "MP3")
+        )
+
+        val selectedIds = selectedNavidromeMusicFolderIds(
+            availableFolders = folders,
+            savedFolderIds = setOf("old")
+        )
+
+        assertThat(selectedIds).containsExactly("flac", "mp3")
+    }
+
+    @Test
+    fun `selected music folders returns empty when server exposes no folders`() {
+        val selectedIds = selectedNavidromeMusicFolderIds(
+            availableFolders = emptyList(),
+            savedFolderIds = setOf("flac")
+        )
+
+        assertThat(selectedIds).isEmpty()
     }
 }

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepositoryTest.kt
@@ -101,4 +101,31 @@ class UserPreferencesRepositoryTest {
             tempDir.toFile().deleteRecursively()
         }
     }
+
+    @Test
+    fun `navidrome selected music folders persist and clear`() = runTest {
+        val tempDir = Files.createTempDirectory("user-preferences-repository-test")
+        try {
+            val repository = UserPreferencesRepository(
+                dataStore = PreferenceDataStoreFactory.create(
+                    scope = backgroundScope,
+                    produceFile = { tempDir.resolve("settings.preferences_pb").toFile() }
+                ),
+                json = Json
+            )
+
+            assertTrue(repository.navidromeSelectedMusicFolderIdsFlow.first().isEmpty())
+
+            repository.setNavidromeSelectedMusicFolderIds(setOf("flac", "mp3"))
+            assertEquals(
+                setOf("flac", "mp3"),
+                repository.navidromeSelectedMusicFolderIdsFlow.first()
+            )
+
+            repository.clearNavidromeSelectedMusicFolderIds()
+            assertTrue(repository.navidromeSelectedMusicFolderIdsFlow.first().isEmpty())
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a Navidrome/Subsonic music library selector on the dashboard
- persist selected server library ids and use them to filter library sync only
- keep playlists unchanged, default existing installs to all libraries, and improve the selector UI with expressive Material 3 surfaces

Fixes #23

## Validation
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk PATH=/usr/lib/jvm/java-21-openjdk/bin:$PATH ./gradlew :app:compileDebugKotlin`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk PATH=/usr/lib/jvm/java-21-openjdk/bin:$PATH ./gradlew :app:testDebugUnitTest --tests 'com.lostf1sh.pixelplayeross.data.navidrome.NavidromeRepositoryTest' --tests 'com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepositoryTest'`
