### PR TITLE
Allow HTTP for local Navidrome servers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.PixelPlayer"
-        android:usesCleartextTraffic="false"
+        android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
         <activity

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentials.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentials.kt
@@ -1,5 +1,6 @@
 package com.lostf1sh.pixelplayeross.data.navidrome.model
 
+import com.lostf1sh.pixelplayeross.data.stream.CloudStreamSecurity
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
@@ -59,7 +60,7 @@ data class NavidromeCredentials(
     /**
      * Returns a validation error for connection setup, or null when the URL is acceptable.
      */
-    fun connectionValidationError(requireHttps: Boolean = true): String? {
+    fun connectionValidationError(requireHttps: Boolean = false): String? {
         val httpUrl = normalizedHttpUrlOrNull ?: return "Enter a valid server URL."
         if (httpUrl.username.isNotEmpty() || httpUrl.password.isNotEmpty()) {
             return "Server URL must not include embedded credentials."
@@ -67,6 +68,18 @@ data class NavidromeCredentials(
         if (requireHttps && !httpUrl.isHttps) {
             return "Use an https:// server URL for Navidrome/Subsonic."
         }
+        if (!httpUrl.isHttps && !isHttpAllowedHost(httpUrl.host.lowercase())) {
+            return "Use https:// for remote Navidrome/Subsonic servers. HTTP is only allowed for local network addresses."
+        }
         return null
+    }
+
+    private fun isHttpAllowedHost(host: String): Boolean {
+        return host == "localhost" ||
+            host == "127.0.0.1" ||
+            host.endsWith(".local") ||
+            host.endsWith(".ts.net") ||
+            !host.contains('.') ||
+            CloudStreamSecurity.isPrivateIpv4Literal(host)
     }
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/auth/NavidromeLoginActivity.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/auth/NavidromeLoginActivity.kt
@@ -287,7 +287,7 @@ fun NavidromeLoginScreen(
                         value = serverUrl,
                         onValueChange = { serverUrl = it },
                         label = stringResource(R.string.auth_server_url),
-                        placeholder = stringResource(R.string.auth_server_url_placeholder_https),
+                        placeholder = stringResource(R.string.auth_navidrome_server_placeholder),
                         supportingText = stringResource(R.string.auth_navidrome_server_url_hint),
                         leadingIcon = Icons.Rounded.CloudQueue,
                         enabled = !isLoading,
@@ -369,7 +369,7 @@ fun NavidromeLoginScreen(
                     FilledTonalButton(
                         onClick = {
                             if (serverUrl.isBlank()) {
-                                serverUrl = "https://"
+                                serverUrl = "http://"
                             }
                         },
                         enabled = !isLoading && serverUrl.isBlank(),
@@ -377,7 +377,7 @@ fun NavidromeLoginScreen(
                         contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)
                     ) {
                         Text(
-                            text = stringResource(R.string.auth_prefill_https),
+                            text = stringResource(R.string.auth_prefill_http),
                             fontFamily = RoundedSans,
                             fontWeight = FontWeight.Medium
                         )

--- a/app/src/main/res/values/strings_auth.xml
+++ b/app/src/main/res/values/strings_auth.xml
@@ -19,12 +19,12 @@
     <string name="auth_navidrome_title">Subsonic / Navidrome</string>
     <string name="auth_navidrome_subtitle">Connect to your self-hosted music server</string>
     <string name="auth_navidrome_info_card">Supports Navidrome, Airsonic, Gonic, Ampache and other servers compatible with the Subsonic API.</string>
-    <string name="auth_server_url_placeholder_https">https://music.example.com</string>
-    <string name="auth_navidrome_server_url_hint">Use the full https:// base address of your server.</string>
+    <string name="auth_navidrome_server_placeholder">http://192.168.1.100:4533</string>
+    <string name="auth_navidrome_server_url_hint">Use the full server URL, including http:// for local servers or https:// for remote servers.</string>
     <string name="auth_navidrome_username_hint">This is your Subsonic or Navidrome account name.</string>
     <string name="auth_navidrome_password_hint">App password also works if your server supports it.</string>
     <string name="auth_navidrome_пароль_hint">App password also works if your server supports it.</string>
-    <string name="auth_prefill_https">Prefill https://</string>
+    <string name="auth_prefill_http">Prefill http://</string>
     <string name="auth_navidrome_footer">Compatible with Navidrome, Gonic, Airsonic, and other Subsonic-compatible servers</string>
     <string name="cd_navidrome_logo">Navidrome</string>
     <string name="cd_subsonic_logo">Subsonic</string>
@@ -38,7 +38,6 @@
     <string name="auth_jellyfin_server_url_hint">Full URL of your Jellyfin server, including port.</string>
     <string name="auth_jellyfin_username_hint">Your Jellyfin account username.</string>
     <string name="auth_jellyfin_password_hint">Your Jellyfin account password.</string>
-    <string name="auth_prefill_http">Prefill http://</string>
     <string name="auth_jellyfin_footer">Connects to Jellyfin servers for streaming your music library</string>
     <string name="cd_jellyfin_logo">Jellyfin</string>
 

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentialsTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentialsTest.kt
@@ -19,15 +19,30 @@ class NavidromeCredentialsTest {
     }
 
     @Test
-    fun `connectionValidationError rejects insecure http urls`() {
+    fun `connectionValidationError accepts http urls for local network addresses`() {
         val credentials = NavidromeCredentials(
             serverUrl = "http://192.168.1.20:4533",
             username = "user",
             password = "pass"
         )
 
+        assertNull(credentials.connectionValidationError())
         assertEquals(
-            "Use an https:// server URL for Navidrome/Subsonic.",
+            "http://192.168.1.20:4533",
+            credentials.normalizedServerUrl
+        )
+    }
+
+    @Test
+    fun `connectionValidationError rejects http urls for public hosts`() {
+        val credentials = NavidromeCredentials(
+            serverUrl = "http://music.example.com",
+            username = "user",
+            password = "pass"
+        )
+
+        assertEquals(
+            "Use https:// for remote Navidrome/Subsonic servers. HTTP is only allowed for local network addresses.",
             credentials.connectionValidationError()
         )
     }


### PR DESCRIPTION
## Summary
- Permit plain HTTP connections for local Navidrome/Subsonic servers while keeping remote hosts on HTTPS.
- Update the login screen copy and default prefill to reflect local-network HTTP setups.
- Enable cleartext traffic at the app level so local server connections can succeed.
- Add unit coverage for accepted local HTTP URLs and rejected public HTTP URLs.

## Testing
- Added/updated unit tests for Navidrome URL validation.
- Not run (not requested).

Might fixes #27 