### PR TITLE
Move current song to front of queue when shuffle is enabled

### DIFF
--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaybackStateHolder.kt
@@ -709,6 +709,31 @@ class PlaybackStateHolder @Inject constructor(
         return masterPlayer.currentMediaItemIndex == currentIndex
     }
 
+    /**
+     * Moves the currently playing item to index 0 and replaces everything after it with the
+     * tail of [newQueue], without interrupting playback. Requires newQueue.first() to be the
+     * item that is currently playing. O(1) IPC calls regardless of queue size.
+     */
+    private suspend fun replacePlayerQueueWithCurrentFirst(newQueue: List<Song>): Boolean {
+        if (newQueue.isEmpty()) return false
+
+        val newTail = withContext(Dispatchers.Default) {
+            List(newQueue.size - 1) { index -> MediaItemBuilder.build(newQueue[index + 1]) }
+        }
+
+        val masterPlayer = dualPlayerEngine.masterPlayer
+        if (masterPlayer.mediaItemCount != newQueue.size) return false
+        val playerIndex = masterPlayer.currentMediaItemIndex
+        if (playerIndex !in 0 until masterPlayer.mediaItemCount) return false
+        if (masterPlayer.getMediaItemAt(playerIndex).mediaId != newQueue.first().id) return false
+
+        if (playerIndex > 0) {
+            masterPlayer.removeMediaItems(0, playerIndex)
+        }
+        masterPlayer.replaceMediaItems(1, masterPlayer.mediaItemCount, newTail)
+        return masterPlayer.currentMediaItemIndex == 0
+    }
+
     private fun replacePlayerQueue(
         player: Player,
         preparedQueue: PreparedQueueReplacement,
@@ -773,51 +798,25 @@ class PlaybackStateHolder @Inject constructor(
                         val currentMediaItem = player.currentMediaItem
 
                         // Run heavy shuffle work off main to keep UI and playback responsive.
+                        // The current song moves to the front of the shuffled queue: anchoring
+                        // it at its old index would strand the songs shuffled into the slots
+                        // before it, which forward playback never reaches (issue #32).
                         val shuffledQueue = withContext(Dispatchers.Default) {
-                            QueueUtils.buildAnchoredShuffleQueueSuspending(currentSongs, currentIndex)
+                            QueueUtils.buildAnchoredShuffleQueueSuspending(
+                                currentSongs,
+                                currentIndex,
+                                startAtZero = true
+                            )
                         }
 
-                        // For large queues, use bulk replace (1 IPC call) instead of
-                        // per-item moveMediaItem (n IPC calls) which freezes the UI.
-                        if (currentSongs.size > BULK_REPLACE_THRESHOLD) {
-                            val preservedReplacement = buildQueueSegments(
+                        val movedToFront = replacePlayerQueueWithCurrentFirst(shuffledQueue)
+                        if (!movedToFront) {
+                            val preparedQueue = buildQueueReplacement(
                                 newQueue = shuffledQueue,
-                                currentIndex = currentIndex,
+                                targetIndex = 0,
                                 currentMediaItem = currentMediaItem
                             )
-                            val replacedInPlace = preservedReplacement?.let { preparedSegments ->
-                                replacePlayerQueuePreservingCurrent(currentIndex, preparedSegments)
-                            } == true
-
-                            if (!replacedInPlace) {
-                                val preparedQueue = buildQueueReplacement(
-                                    newQueue = shuffledQueue,
-                                    targetIndex = currentIndex,
-                                    currentMediaItem = currentMediaItem
-                                )
-                                replacePlayerQueue(player, preparedQueue, currentPosition)
-                            }
-                        } else {
-                            val reordered = reorderQueueInPlace(player, shuffledQueue)
-                            if (!reordered) {
-                                val preservedReplacement = buildQueueSegments(
-                                    newQueue = shuffledQueue,
-                                    currentIndex = currentIndex,
-                                    currentMediaItem = currentMediaItem
-                                )
-                                val replacedInPlace = preservedReplacement?.let { preparedSegments ->
-                                    replacePlayerQueuePreservingCurrent(currentIndex, preparedSegments)
-                                } == true
-
-                                if (!replacedInPlace) {
-                                    val preparedQueue = buildQueueReplacement(
-                                        newQueue = shuffledQueue,
-                                        targetIndex = currentIndex,
-                                        currentMediaItem = currentMediaItem
-                                    )
-                                    replacePlayerQueue(player, preparedQueue, currentPosition)
-                                }
-                            }
+                            replacePlayerQueue(player, preparedQueue, currentPosition)
                         }
 
                         updateQueueCallback(shuffledQueue)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
@@ -2879,11 +2879,13 @@ class PlayerViewModel @Inject constructor(
 
             // If shuffle is persistent and currently ON, we shuffle the new songs immediately
             val finalSongsToPlay = if (isPersistent && isShuffleOn) {
-                // Shuffle the list but make sure the song you clicked stays at its current index or starts first
+                // Shuffle with the clicked song first so no songs land behind the playhead
+                // where forward playback would never reach them (issue #32)
                 withContext(Dispatchers.Default) {
                     QueueUtils.buildAnchoredShuffleQueueSuspending(
                         validSongs,
-                        validSongs.indexOfFirst { it.id == validStartSong.id }.coerceAtLeast(0)
+                        validSongs.indexOfFirst { it.id == validStartSong.id }.coerceAtLeast(0),
+                        startAtZero = true
                     )
                 }
             } else {

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaybackStateHolderTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaybackStateHolderTest.kt
@@ -1,22 +1,33 @@
 package com.lostf1sh.pixelplayeross.presentation.viewmodel
 
 import android.content.Context
+import android.net.Uri
 import android.os.PowerManager
+import android.os.SystemClock
 import com.lostf1sh.pixelplayeross.MainCoroutineExtension
 import com.lostf1sh.pixelplayeross.data.model.PlaybackQueueItemSnapshot
 import com.lostf1sh.pixelplayeross.data.model.PlaybackQueueSnapshot
+import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
 import com.lostf1sh.pixelplayeross.data.service.player.DualPlayerEngine
 import io.mockk.every
 import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -152,6 +163,101 @@ class PlaybackStateHolderTest {
 
         assertEquals(0L, holder.currentPosition.value)
     }
+
+    @Test
+    fun `enabling shuffle moves the playing song to the front of the player queue`() {
+        // Regression for issue #32: anchoring the current song at its old index left the
+        // songs shuffled into the slots before it unreachable by forward playback.
+        mockkStatic(SystemClock::class)
+        mockkStatic(Uri::class)
+        try {
+            every { SystemClock.elapsedRealtime() } returns 100_000L
+            every { Uri.parse(any()) } returns mockk(relaxed = true)
+            coEvery { userPreferencesRepository.persistentShuffleEnabledFlow } returns flowOf(false)
+            every { queueStateHolder.hasOriginalQueue() } returns false
+
+            val songs = List(6) { index -> song("song-$index") }
+            val startIndex = 3
+
+            val queueItems = songs
+                .map { MediaItem.Builder().setMediaId(it.id).build() }
+                .toMutableList()
+            var playerIndex = startIndex
+
+            val masterPlayer = mockk<Player>(relaxed = true)
+            every { masterPlayer.mediaItemCount } answers { queueItems.size }
+            every { masterPlayer.currentMediaItemIndex } answers { playerIndex }
+            every { masterPlayer.getMediaItemAt(any()) } answers { queueItems[firstArg()] }
+            every { masterPlayer.removeMediaItems(any(), any()) } answers {
+                val from = firstArg<Int>()
+                val to = secondArg<Int>()
+                repeat(to - from) { queueItems.removeAt(from) }
+                if (playerIndex >= to) playerIndex -= to - from
+            }
+            every { masterPlayer.replaceMediaItems(any(), any(), any()) } answers {
+                val from = firstArg<Int>()
+                val to = secondArg<Int>()
+                val replacement = thirdArg<List<MediaItem>>()
+                repeat(to - from) { queueItems.removeAt(from) }
+                queueItems.addAll(from, replacement)
+            }
+            every { dualPlayerEngine.masterPlayer } returns masterPlayer
+
+            val controller = mockk<MediaController>(relaxed = true)
+            every { controller.currentMediaItem } answers { queueItems.getOrNull(playerIndex) }
+            every { controller.currentMediaItemIndex } answers { playerIndex }
+
+            runBlocking {
+                val holder = createHolder()
+                holder.initialize(this)
+                holder.setMediaController(controller)
+
+                var uiQueue: List<Song>? = null
+                holder.toggleShuffle(
+                    currentSongs = songs,
+                    currentSong = songs[startIndex],
+                    currentQueueSourceName = "Test Queue",
+                    updateQueueCallback = { uiQueue = it }
+                )
+                withTimeout(5_000L) {
+                    holder.stablePlayerState.first { it.isShuffleEnabled }
+                }
+
+                assertEquals(
+                    songs[startIndex].id,
+                    queueItems.first().mediaId,
+                    "Playing song must move to index 0 so no songs are stranded behind the playhead"
+                )
+                assertEquals(0, playerIndex, "Player must keep playing the same item at its new index")
+                assertEquals(songs.size, queueItems.size, "Queue size must stay the same")
+                assertEquals(
+                    songs.map { it.id }.toSet(),
+                    queueItems.map { it.mediaId }.toSet(),
+                    "Shuffled queue must contain the same songs"
+                )
+                assertEquals(songs[startIndex].id, uiQueue?.firstOrNull()?.id)
+            }
+        } finally {
+            unmockkStatic(SystemClock::class)
+            unmockkStatic(Uri::class)
+        }
+    }
+
+    private fun song(id: String): Song = Song(
+        id = id,
+        title = "Title $id",
+        artist = "Artist",
+        artistId = 1L,
+        album = "Album",
+        albumId = 1L,
+        path = "/tmp/$id.mp3",
+        contentUriString = "content://pixelplayer/song/$id",
+        albumArtUriString = null,
+        duration = 180_000L,
+        mimeType = "audio/mpeg",
+        bitrate = 320_000,
+        sampleRate = 44_100
+    )
 
     @Test
     fun `late cold start snapshot is discarded after first occurrence already ended`() = runTest {


### PR DESCRIPTION
Fixes #32

## Root cause

Toggling shuffle mid-playback built the shuffled queue with the current song **anchored at its old index** (`buildAnchoredShuffleQueueSuspending` without `startAtZero`). Playing at index 3 meant three random songs were shuffled into slots 0–2 — behind the playhead. Forward playback never reached them, and pressing prev walked into songs that were never actually played, exactly as reported. Every other shuffle entry point (Home, playlist, artist, daily mix) already passes `startAtZero = true`; only two paths were outliers.

## Changes

- **`PlaybackStateHolder.toggleShuffle`** (enable path): builds the shuffled queue with `startAtZero = true` and applies it via a new `replacePlayerQueueWithCurrentFirst()` helper — removes the items before the playing item, then replaces the tail with the shuffled remainder. Two player calls regardless of queue size, no playback interruption. This also replaces the old `BULK_REPLACE_THRESHOLD` branching for this path (the small-queue variant issued one `moveMediaItem` IPC per song). The fallback full-replace and the unshuffle path (restore original order at original index) are unchanged.
- **`PlayerViewModel.playSongs`** (persistent-shuffle branch): had the same stranded-songs flaw when tapping a song mid-list with persistent shuffle on; now also starts the shuffled queue at zero.
- **`PlaybackStateHolderTest`**: regression test driving the real `toggleShuffle` against a stateful fake player, asserting the playing song moves to index 0, keeps playing, and no songs are lost.

## Testing

- `./gradlew :app:compileDebugKotlin` — passes
- `./gradlew :app:testDebugUnitTest` (full suite, incl. new regression test) — passes