### PR TITLE
Coroutines, Flow, and Compose hygiene pass

### DIFF
--- a/app/src/main/java/com/lostf1sh/pixelplayeross/PixelPlayerApplication.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/PixelPlayerApplication.kt
@@ -59,6 +59,9 @@ class PixelPlayerApplication : Application(), ImageLoaderFactory, Configuration.
     @Inject
     lateinit var userPreferencesRepository: dagger.Lazy<UserPreferencesRepository>
 
+    @Inject
+    lateinit var syncManager: dagger.Lazy<com.lostf1sh.pixelplayeross.data.worker.SyncManager>
+
     private val startupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     // ADD THE COMPANION OBJECT
@@ -99,6 +102,10 @@ class PixelPlayerApplication : Application(), ImageLoaderFactory, Configuration.
         }
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(appLifecycleObserver)
+
+        // Explicit launch site for SyncManager's background observers (storage changes,
+        // foreground catch-up sync, periodic maintenance) — see SyncManager.start().
+        syncManager.get().start()
 
         startupScope.launch {
             AlbumArtUtils.migrateLegacyCacheLocation(this@PixelPlayerApplication)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/DailyMixManager.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/DailyMixManager.kt
@@ -9,11 +9,8 @@ import com.lostf1sh.pixelplayeross.data.database.EngagementDao
 import com.lostf1sh.pixelplayeross.data.database.SongEngagementEntity
 import com.lostf1sh.pixelplayeross.data.model.Song
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 import java.io.File
 import java.util.Calendar
@@ -33,13 +30,12 @@ class DailyMixManager @Inject constructor(
     private val fileLock = Any()
     private val statsType = object : TypeToken<MutableMap<String, SongEngagementStats>>() {}.type
 
-    // Migration runs on IO without blocking the main thread.
-    private val managerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
-    // Deferred result: null if no migration needed, completes when done.
-    private val migrationDeferred: Deferred<Unit>
+    // Migration is lazy: it runs inside the first caller that needs migrated data,
+    // on that caller's scope, instead of a fire-and-forget launch at construction.
+    private val migrationMutex = Mutex()
 
     // Flag to track if we've migrated legacy data
+    @Volatile
     private var legacyMigrationComplete = false
 
     data class SongEngagementStats(
@@ -48,18 +44,19 @@ class DailyMixManager @Inject constructor(
         val lastPlayedTimestamp: Long = 0L
     )
 
-    init {
-        // Launch migration asynchronously — does not block the calling thread.
-        // Any method that needs migrated data should call migrationDeferred.await() first.
-        migrationDeferred = managerScope.async {
-            migrateLegacyDataIfNeeded()
+    private suspend fun ensureLegacyDataMigrated() {
+        if (legacyMigrationComplete) return
+        migrationMutex.withLock {
+            if (!legacyMigrationComplete) {
+                migrateLegacyDataIfNeeded()
+            }
         }
     }
 
     /**
      * Migrates engagements from legacy JSON file to Room database.
-     * This runs once on startup if the legacy file exists.
-     * Suspend fun running on an IO coroutine, so no runBlocking needed.
+     * Runs once, lazily, inside the first caller that needs engagement data.
+     * Suspend fun running on the caller's coroutine, so no runBlocking needed.
      * The synchronized block only guards the file read (no suspension points inside).
      */
     private suspend fun migrateLegacyDataIfNeeded() {
@@ -113,7 +110,7 @@ class DailyMixManager @Inject constructor(
      * without blocking any thread at startup.
      */
     private suspend fun readEngagements(): Map<String, SongEngagementStats> {
-        migrationDeferred.await() // Only waits if migration is still running
+        ensureLegacyDataMigrated()
         return engagementDao.getAllEngagements().associate { entity ->
             entity.songId to SongEngagementStats(
                 playCount = entity.playCount,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/jellyfin/JellyfinRepository.kt
@@ -26,6 +26,7 @@ import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
 import com.lostf1sh.pixelplayeross.data.stream.BulkSyncResult
 import com.lostf1sh.pixelplayeross.data.stream.CloudMusicUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -179,6 +180,7 @@ class JellyfinRepository @Inject constructor(
                 Timber.d("$TAG: Login successful for $username@$serverUrl")
                 Result.success(username)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Login failed")
                 api.clearCredentials()
                 _isLoggedInFlow.value = false
@@ -270,6 +272,7 @@ class JellyfinRepository @Inject constructor(
                 Timber.d("$TAG: Synced ${entities.size} playlists")
                 Result.success(entities)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync playlists")
                 Result.failure(e)
             }
@@ -313,6 +316,7 @@ class JellyfinRepository @Inject constructor(
                 Timber.d("$TAG: Synced ${entities.size} songs for playlist $playlistId")
                 Result.success(entities.size)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync playlist songs")
                 Result.failure(e)
             }
@@ -354,6 +358,7 @@ class JellyfinRepository @Inject constructor(
                 Timber.d("$TAG: Synced ${entities.size} library songs")
                 Result.success(entities.size)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync library songs")
                 Result.failure(e)
             }
@@ -375,6 +380,7 @@ class JellyfinRepository @Inject constructor(
                 try {
                     syncUnifiedLibrarySongsFromJellyfin()
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Timber.e(e, "$TAG: Failed to sync unified library after playlist fetch failure")
                 }
                 return@withContext Result.success(
@@ -396,6 +402,7 @@ class JellyfinRepository @Inject constructor(
             try {
                 syncUnifiedLibrarySongsFromJellyfin()
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync unified library")
             }
 
@@ -445,6 +452,7 @@ class JellyfinRepository @Inject constructor(
                 val jellyfinSongs = JellyfinResponseParser.parseSongs(result.getOrThrow())
                 Result.success(jellyfinSongs.map { it.toDisplaySong() })
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Search failed")
                 Result.failure(e)
             }
@@ -479,6 +487,7 @@ class JellyfinRepository @Inject constructor(
                 }
                 Result.failure(Exception("No lyrics found"))
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to get lyrics for song $songId")
                 Result.failure(e)
             }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/jellyfin/JellyfinStreamProxy.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/jellyfin/JellyfinStreamProxy.kt
@@ -3,6 +3,7 @@ package com.lostf1sh.pixelplayeross.data.jellyfin
 import android.net.Uri
 import com.lostf1sh.pixelplayeross.data.stream.CloudStreamProxy
 import com.lostf1sh.pixelplayeross.data.stream.CloudStreamSecurity
+import kotlinx.coroutines.CancellationException
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import timber.log.Timber
@@ -38,6 +39,7 @@ class JellyfinStreamProxy @Inject constructor(
         return try {
             repository.getStreamUrl(id)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.w(e, "JellyfinStreamProxy: Failed to resolve stream URL for item $id")
             null
         }
@@ -61,6 +63,7 @@ class JellyfinStreamProxy @Inject constructor(
         try {
             getOrFetchStreamUrl(itemId)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.w(e, "warmUpStreamUrl failed for $itemId")
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepository.kt
@@ -28,6 +28,7 @@ import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
 import com.lostf1sh.pixelplayeross.data.stream.BulkSyncResult
 import com.lostf1sh.pixelplayeross.data.stream.CloudMusicUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -214,6 +215,7 @@ class NavidromeRepository @Inject constructor(
                 Timber.d("$TAG: Login successful for $username@$serverUrl")
                 Result.success(username)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Login failed")
                 api.clearCredentials()
                 _isLoggedInFlow.value = false
@@ -347,6 +349,7 @@ class NavidromeRepository @Inject constructor(
                 Timber.d("$TAG: Synced ${entities.size} playlists")
                 Result.success(entities)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync playlists")
                 Result.failure(e)
             }
@@ -414,6 +417,7 @@ class NavidromeRepository @Inject constructor(
                 Timber.d("$TAG: Synced ${entities.size} songs for playlist $playlistId")
                 Result.success(entities.size)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync playlist songs")
                 Result.failure(e)
             }
@@ -526,6 +530,7 @@ class NavidromeRepository @Inject constructor(
                 onProgress?.invoke(1f, context.getString(R.string.dash_status_library_sync_complete))
                 Result.success(entities.size)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync library songs")
                 Result.failure(e)
             }
@@ -586,6 +591,7 @@ class NavidromeRepository @Inject constructor(
                 try {
                     syncUnifiedLibrarySongsFromNavidrome()
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Timber.e(e, "$TAG: Failed to sync unified library after playlist fetch failure")
                 }
                 return@withContext Result.success(
@@ -623,6 +629,7 @@ class NavidromeRepository @Inject constructor(
             try {
                 syncUnifiedLibrarySongsFromNavidrome()
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to sync unified library")
             }
 
@@ -697,6 +704,7 @@ class NavidromeRepository @Inject constructor(
 
                 Result.success(songs)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Search failed")
                 Result.failure(e)
             }
@@ -762,6 +770,7 @@ class NavidromeRepository @Inject constructor(
 
                 Result.failure(Exception("No lyrics found"))
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "$TAG: Failed to get lyrics for song $songId")
                 Result.failure(e)
             }
@@ -970,6 +979,7 @@ class NavidromeRepository @Inject constructor(
                 Timber.d("$TAG: Created app playlist for Navidrome playlist $navidromePlaylistId")
             }
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.e(e, "$TAG: Failed to update app playlist for Navidrome playlist $navidromePlaylistId")
         }
     }
@@ -980,6 +990,7 @@ class NavidromeRepository @Inject constructor(
             playlistPreferencesRepository.deletePlaylist(appPlaylistId)
             Timber.d("$TAG: Deleted app playlist for Navidrome playlist $navidromePlaylistId")
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.w(e, "$TAG: Failed to delete app playlist for Navidrome playlist $navidromePlaylistId")
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeStreamProxy.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeStreamProxy.kt
@@ -3,6 +3,7 @@ package com.lostf1sh.pixelplayeross.data.navidrome
 import android.net.Uri
 import com.lostf1sh.pixelplayeross.data.stream.CloudStreamProxy
 import com.lostf1sh.pixelplayeross.data.stream.CloudStreamSecurity
+import kotlinx.coroutines.CancellationException
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import timber.log.Timber
@@ -48,6 +49,7 @@ class NavidromeStreamProxy @Inject constructor(
         return try {
             repository.getStreamUrl(id)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.w(e, "NavidromeStreamProxy: Failed to resolve stream URL for song $id")
             null
         }
@@ -71,6 +73,7 @@ class NavidromeStreamProxy @Inject constructor(
         try {
             getOrFetchStreamUrl(songId)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.w(e, "warmUpStreamUrl failed for $songId")
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/worker/SyncManager.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/worker/SyncManager.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import timber.log.Timber
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Data class representing the progress of the sync operation.
@@ -112,7 +113,16 @@ class SyncManager @Inject constructor(
                 replay = 0
             )
 
-    init {
+    private val started = AtomicBoolean(false)
+
+    /**
+     * Starts background observation (storage-change auto-sync, app-foreground catch-up)
+     * and schedules periodic maintenance. Called once from PixelPlayerApplication.onCreate
+     * so the launch site is explicit and greppable instead of hidden in DI construction.
+     * Idempotent — extra calls are no-ops.
+     */
+    fun start() {
+        if (!started.compareAndSet(false, true)) return
         observeStorageChanges()
         observeAppForeground()
         schedulePeriodicMaintenance()

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/di/AppModule.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/di/AppModule.kt
@@ -105,8 +105,8 @@ object AppModule {
     @Singleton
     @Provides
     @AppScope
-    fun provideAppCoroutineScope(): CoroutineScope {
-        return CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    fun provideAppCoroutineScope(dispatchers: DispatcherProvider): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + dispatchers.io)
     }
 
     @Singleton

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/di/DispatcherProvider.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/di/DispatcherProvider.kt
@@ -1,0 +1,37 @@
+package com.lostf1sh.pixelplayeross.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Injectable dispatcher abstraction so coroutine-heavy classes can be unit-tested
+ * deterministically with a TestDispatcher instead of hardcoded [Dispatchers].
+ *
+ * Prefer injecting this over referencing [Dispatchers.IO]/[Dispatchers.Default]
+ * directly in new or touched code.
+ */
+interface DispatcherProvider {
+    val main: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+}
+
+class DefaultDispatcherProvider @Inject constructor() : DispatcherProvider {
+    override val main: CoroutineDispatcher get() = Dispatchers.Main
+    override val io: CoroutineDispatcher get() = Dispatchers.IO
+    override val default: CoroutineDispatcher get() = Dispatchers.Default
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DispatcherModule {
+    @Binds
+    @Singleton
+    abstract fun bindDispatcherProvider(impl: DefaultDispatcherProvider): DispatcherProvider
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/AlbumMultiSelectionOptionSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/AlbumMultiSelectionOptionSheet.kt
@@ -45,11 +45,14 @@ import coil.size.Size
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.model.Album
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import androidx.compose.runtime.remember
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AlbumMultiSelectionOptionSheet(
-    selectedAlbums: List<Album>,
+    selectedAlbums: ImmutableList<Album>,
     maxSelection: Int,
     onDismiss: () -> Unit,
     onPlay: () -> Unit,
@@ -75,7 +78,7 @@ fun AlbumMultiSelectionOptionSheet(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 StackedAlbumCovers(
-                    albums = selectedAlbums.take(4)
+                    albums = remember(selectedAlbums) { selectedAlbums.take(4).toImmutableList() }
                 )
 
                 Spacer(modifier = Modifier.width(16.dp))
@@ -217,7 +220,7 @@ private fun AlbumSelectionActionButton(
 
 @Composable
 private fun StackedAlbumCovers(
-    albums: List<Album>,
+    albums: ImmutableList<Album>,
     modifier: Modifier = Modifier
 ) {
     val imageSize = 64.dp

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/CustomPresetsSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/CustomPresetsSheet.kt
@@ -38,12 +38,13 @@ import androidx.compose.ui.res.stringResource
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.equalizer.EqualizerPreset
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
+import kotlinx.collections.immutable.ImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CustomPresetsSheet(
-    presets: List<EqualizerPreset>,
-    pinnedPresetsNames: List<String>,
+    presets: ImmutableList<EqualizerPreset>,
+    pinnedPresetsNames: ImmutableList<String>,
     onPresetSelected: (EqualizerPreset) -> Unit,
     onPinToggled: (EqualizerPreset) -> Unit,
     onRename: (EqualizerPreset) -> Unit,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/DailyMixSection.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/DailyMixSection.kt
@@ -61,6 +61,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import androidx.compose.ui.res.stringResource
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.persistentListOf
 
 
 // 2) DailyMixSection y DailyMixCard quedan igual de ligeras...
@@ -168,7 +169,7 @@ fun DailyMixSection(
         if (showPlaylistBottomSheet) {
             PlaylistBottomSheet(
                 playlistUiState = playlistUiState,
-                songs = listOf(song),
+                songs = persistentListOf(song),
                 onDismiss = { showPlaylistBottomSheet = false },
                 bottomBarHeight = bottomBarHeightDp,
                 playerViewModel = playerViewModel,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/EditMultipleSongsSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/EditMultipleSongsSheet.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
+import kotlinx.collections.immutable.ImmutableList
 
 /**
  * Data class representing a field that can have mixed values across multiple songs
@@ -70,10 +71,10 @@ private fun <T> List<T?>.toMixedValueField(): MixedValueField<T> {
 @Composable
 fun EditMultipleSongsSheet(
     visible: Boolean,
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     onDismiss: () -> Unit,
     onSave: (
-        selectedSongs: List<Song>,
+        selectedSongs: ImmutableList<Song>,
         title: String?,
         artist: String?,
         album: String?,
@@ -117,10 +118,10 @@ fun EditMultipleSongsSheet(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun EditMultipleSongsContent(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     onDismiss: () -> Unit,
     onSave: (
-        selectedSongs: List<Song>,
+        selectedSongs: ImmutableList<Song>,
         title: String?,
         artist: String?,
         album: String?,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/FileExplorerBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/FileExplorerBottomSheet.kt
@@ -91,14 +91,15 @@ import com.lostf1sh.pixelplayeross.presentation.viewmodel.DirectoryEntry
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import com.lostf1sh.pixelplayeross.utils.StorageInfo
 import java.io.File
+import kotlinx.collections.immutable.ImmutableList
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FileExplorerDialog(
     visible: Boolean,
     currentPath: File,
-    directoryChildren: List<DirectoryEntry>,
-    availableStorages: List<StorageInfo>,
+    directoryChildren: ImmutableList<DirectoryEntry>,
+    availableStorages: ImmutableList<StorageInfo>,
     selectedStorageIndex: Int,
     isLoading: Boolean,
     isPriming: Boolean = false,
@@ -173,8 +174,8 @@ fun FileExplorerDialog(
 @Composable
 fun FileExplorerContent(
     currentPath: File,
-    directoryChildren: List<DirectoryEntry>,
-    availableStorages: List<StorageInfo>,
+    directoryChildren: ImmutableList<DirectoryEntry>,
+    availableStorages: ImmutableList<StorageInfo>,
     selectedStorageIndex: Int,
     isLoading: Boolean,
     isPriming: Boolean,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/LibrarySortBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/LibrarySortBottomSheet.kt
@@ -57,12 +57,13 @@ import com.lostf1sh.pixelplayeross.data.model.SortDirection
 import com.lostf1sh.pixelplayeross.data.model.SortOption
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.ImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LibrarySortBottomSheet(
     title: String,
-    options: List<SortOption>,
+    options: ImmutableList<SortOption>,
     selectedOption: SortOption?,
     onDismiss: () -> Unit,
     onOptionSelected: (SortOption) -> Unit,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/LyricsSheet.kt
@@ -137,6 +137,8 @@ import androidx.compose.ui.text.style.TextGeometricTransform
 import androidx.compose.ui.text.style.TextOverflow
 import com.lostf1sh.pixelplayeross.presentation.components.subcomps.PlayingEqIcon
 import com.lostf1sh.pixelplayeross.utils.MultiLangRomanizer
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 internal data class LyricsSheetColors(
     val container: Color,
@@ -763,12 +765,13 @@ fun LyricsSheet(
 
                     true -> {
                         lyrics?.synced?.let { synced ->
+                            val syncedLines = remember(synced) { synced.toImmutableList() }
                             SyncedLyricsList(
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .padding(horizontal = 24.dp),
                                 contentPadding = PaddingValues(top = 130.dp, bottom = 100.dp),
-                                lines = synced,
+                                lines = syncedLines,
                                 listState = syncedListState,
                                 playbackPositionFlow = playbackPositionFlow,
                                 lyricsSyncOffset = lyricsSyncOffset,
@@ -946,7 +949,7 @@ fun LyricsSheet(
                                 Icon(
                                     modifier = Modifier.size(32.dp),
                                     imageVector = Icons.Rounded.Pause,
-                                    contentDescription = "Pause",
+                                    contentDescription = stringResource(R.string.cd_pause),
                                     tint = onPlayPauseColor
                                 )
                             } else {
@@ -1101,7 +1104,7 @@ fun LyricsSheet(
             ) {
                 Icon(
                     imageVector = Icons.Rounded.KeyboardArrowUp,
-                    contentDescription = "Show Controls"
+                    contentDescription = stringResource(R.string.cd_show_controls)
                 )
             }
         }
@@ -1182,7 +1185,7 @@ private fun LyricsPlaybackSeekBar(
 @OptIn(ExperimentalSnapperApi::class)
 @Composable
 fun SyncedLyricsList(
-    lines: List<SyncedLine>,
+    lines: ImmutableList<SyncedLine>,
     listState: LazyListState,
     playbackPositionFlow: StateFlow<Long>,
     lyricsSyncOffset: Int,
@@ -2013,7 +2016,7 @@ private fun LyricsTrackInfo(
         SmartImage(
             model = song.albumArtUriString ?: R.drawable.rounded_album_24,
             shape = albumShape,
-            contentDescription = "Cover Art",
+            contentDescription = stringResource(R.string.cd_cover_art),
             modifier = Modifier
                 .size(66.dp)
                 .padding(6.dp)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/MultiSelectionBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/MultiSelectionBottomSheet.kt
@@ -88,11 +88,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.presentation.components.subcomps.AutoSizingTextToFill
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun MultiSelectionBottomSheet(
-    selectedSongs: List<Song>,
+    selectedSongs: ImmutableList<Song>,
     favoriteSongIds: Set<String> = emptySet(),
     onDismiss: () -> Unit,
     onPlayAll: () -> Unit,
@@ -176,7 +178,7 @@ fun MultiSelectionBottomSheet(
                     } else 0.dp
                     
                     StackedAlbumArts(
-                        songs = selectedSongs.take(4),
+                        songs = remember(selectedSongs) { selectedSongs.take(4).toImmutableList() },
                         modifier = Modifier
                             .height(74.dp)
                             .width(stackedWidth)
@@ -449,7 +451,7 @@ fun MultiSelectionBottomSheet(
  */
 @Composable
 private fun StackedAlbumArts(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     modifier: Modifier = Modifier
 ) {
     val imageSize = 66.dp

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/OptimizedAlbumArt.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/OptimizedAlbumArt.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.SubcomposeAsyncImage
@@ -117,7 +118,7 @@ fun OptimizedAlbumArt(
     // This avoids recompositions on painter.state changes during scroll.
     SubcomposeAsyncImage(
         model = requestModel,
-        contentDescription = "Album art of $title",
+        contentDescription = stringResource(R.string.cd_album_art_of, title),
         modifier = modifier,
         contentScale = ContentScale.Crop,
         onSuccess = { state ->
@@ -164,7 +165,7 @@ private fun PlaceholderContent(title: String) {
     ) {
         Image(
             painter = painterResource(R.drawable.ic_music_placeholder),
-            contentDescription = "$title placeholder",
+            contentDescription = stringResource(R.string.cd_album_art_placeholder, title),
             contentScale = ContentScale.Fit,
             modifier = Modifier.size(96.dp),
             colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(
@@ -185,7 +186,7 @@ private fun renderDirectAlbumArt(
         is ImageVector -> {
             Image(
                 imageVector = model,
-                contentDescription = "Album art of $title",
+                contentDescription = stringResource(R.string.cd_album_art_of, title),
                 contentScale = ContentScale.Crop,
                 modifier = modifier.fillMaxSize()
             )
@@ -194,7 +195,7 @@ private fun renderDirectAlbumArt(
         is Painter -> {
             Image(
                 painter = model,
-                contentDescription = "Album art of $title",
+                contentDescription = stringResource(R.string.cd_album_art_of, title),
                 contentScale = ContentScale.Crop,
                 modifier = modifier.fillMaxSize()
             )
@@ -203,7 +204,7 @@ private fun renderDirectAlbumArt(
         is ImageBitmap -> {
             Image(
                 bitmap = model,
-                contentDescription = "Album art of $title",
+                contentDescription = stringResource(R.string.cd_album_art_of, title),
                 contentScale = ContentScale.Crop,
                 modifier = modifier.fillMaxSize()
             )
@@ -212,7 +213,7 @@ private fun renderDirectAlbumArt(
         is Bitmap -> {
             Image(
                 bitmap = model.asImageBitmap(),
-                contentDescription = "Album art of $title",
+                contentDescription = stringResource(R.string.cd_album_art_of, title),
                 contentScale = ContentScale.Crop,
                 modifier = modifier.fillMaxSize()
             )

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistArtCollage.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistArtCollage.kt
@@ -28,10 +28,11 @@ import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.model.Song
 import kotlin.math.floor
 import kotlin.math.sqrt
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun PlaylistArtCollage(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     modifier: Modifier = Modifier,
 ) {
     if (songs.isEmpty()) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistBottomSheet.kt
@@ -49,13 +49,15 @@ import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlayerViewModel
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlaylistUiState
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlaylistViewModel
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PlaylistBottomSheet(
     playlistUiState: PlaylistUiState,
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     onDismiss: () -> Unit,
     bottomBarHeight: Dp,
     playerViewModel: PlayerViewModel,
@@ -71,11 +73,11 @@ fun PlaylistBottomSheet(
 
     var searchQuery by remember { mutableStateOf("") }
     val editablePlaylists = remember(playlistUiState.playlists) {
-        playlistUiState.playlists.filterNot { it.isSmartPlaylist }
+        playlistUiState.playlists.filterNot { it.isSmartPlaylist }.toImmutableList()
     }
     val filteredPlaylists = remember(searchQuery, editablePlaylists) {
         if (searchQuery.isBlank()) editablePlaylists
-        else editablePlaylists.filter { it.name.contains(searchQuery, true) }
+        else editablePlaylists.filter { it.name.contains(searchQuery, true) }.toImmutableList()
     }
     val selectedPlaylists = remember {
         mutableStateMapOf<String, Boolean>().apply {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistContainer.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistContainer.kt
@@ -90,6 +90,8 @@ import com.lostf1sh.pixelplayeross.utils.formatSongCount
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import androidx.compose.foundation.combinedClickable
 import kotlinx.coroutines.flow.map
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -104,7 +106,7 @@ fun PlaylistContainer(
     playerViewModel: PlayerViewModel,
     isAddingToPlaylist: Boolean = false,
     selectedPlaylists: SnapshotStateMap<String, Boolean>? = null,
-    filteredPlaylists: List<Playlist> = playlistUiState.playlists,
+    filteredPlaylists: ImmutableList<Playlist> = playlistUiState.playlists,
     currentSortOption: SortOption? = null,
     isSelectionMode: Boolean = false,
     selectedPlaylistIds: Set<String> = emptySet(),
@@ -230,7 +232,7 @@ fun PlaylistItems(
     currentSong: Song? = null,
     playerViewModel: PlayerViewModel,
     isAddingToPlaylist: Boolean = false,
-    filteredPlaylists: List<Playlist>,
+    filteredPlaylists: ImmutableList<Playlist>,
     currentSortOption: SortOption? = null,
     selectedPlaylists: SnapshotStateMap<String, Boolean>? = null,
     isSelectionMode: Boolean = false,
@@ -423,7 +425,7 @@ fun PlaylistItem(
         ) {
             PlaylistCover(
                 playlist = playlist,
-                playlistSongs = playlistSongs ?: emptyList(),
+                playlistSongs = remember(playlistSongs) { (playlistSongs ?: emptyList()).toImmutableList() },
                 size = 48.dp
             )
 
@@ -446,7 +448,7 @@ fun PlaylistItem(
                         Spacer(modifier = Modifier.width(8.dp))
                         Icon(
                             painter = painterResource(R.drawable.ic_navidrome),
-                            contentDescription = "Navidrome",
+                            contentDescription = stringResource(R.string.cd_navidrome_logo),
                             tint = Color.Unspecified,
                             modifier = Modifier.size(18.dp)
                         )

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistCover.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistCover.kt
@@ -32,11 +32,12 @@ import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.utils.resolvePlaylistCoverContentColor
 import com.lostf1sh.pixelplayeross.utils.shapes.RoundedStarShape
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun PlaylistCover(
     playlist: Playlist,
-    playlistSongs: List<Song>,
+    playlistSongs: ImmutableList<Song>,
     modifier: Modifier = Modifier,
     size: Dp = 48.dp
 ) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistMultiSelectionBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/PlaylistMultiSelectionBottomSheet.kt
@@ -61,6 +61,9 @@ import com.lostf1sh.pixelplayeross.utils.resolvePlaylistCoverContentColor
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.compose.ui.res.stringResource
 import com.lostf1sh.pixelplayeross.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import androidx.compose.runtime.remember
 
 /**
  * Bottom sheet for batch operations on multiple selected playlists.
@@ -76,7 +79,7 @@ import com.lostf1sh.pixelplayeross.R
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PlaylistMultiSelectionBottomSheet(
-    selectedPlaylists: List<Playlist>,
+    selectedPlaylists: ImmutableList<Playlist>,
     onDismiss: () -> Unit,
     onDeleteAll: () -> Unit,
     onExportAll: () -> Unit,
@@ -124,7 +127,7 @@ fun PlaylistMultiSelectionBottomSheet(
                     } else 0.dp
 
                     StackedPlaylistCovers(
-                        playlists = selectedPlaylists.take(4),
+                        playlists = remember(selectedPlaylists) { selectedPlaylists.take(4).toImmutableList() },
                         modifier = Modifier
                             .height(74.dp)
                             .width(stackedWidth)
@@ -280,7 +283,7 @@ fun PlaylistMultiSelectionBottomSheet(
  */
 @Composable
 private fun StackedPlaylistCovers(
-    playlists: List<Playlist>,
+    playlists: ImmutableList<Playlist>,
     modifier: Modifier = Modifier
 ) {
     val imageSize = 66.dp

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/QueueBottomSheet.kt
@@ -191,6 +191,7 @@ import java.util.RandomAccess
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import kotlin.math.abs
+import kotlinx.collections.immutable.ImmutableList
 
 private data class QueueUndoBarProjection(
     val isVisible: Boolean = false,
@@ -212,7 +213,7 @@ fun QueueBottomSheet(
     viewModel: PlayerViewModel = hiltViewModel(),
     playlistViewModel: PlaylistViewModel = hiltViewModel(),
     settingsViewModel: SettingsViewModel = hiltViewModel(),
-    queue: List<Song>,
+    queue: ImmutableList<Song>,
     currentQueueSourceName: String,
     currentSongId: String?,
     currentMediaItemIndex: Int = -1,
@@ -239,7 +240,7 @@ fun QueueBottomSheet(
     onCancelCountedPlay: () -> Unit,
     onPlayCounter: (count: Int) -> Unit,
     onRequestSaveAsPlaylist: (
-        songs: List<Song>,
+        songs: ImmutableList<Song>,
         defaultName: String,
         onConfirm: (String, Set<String>) -> Unit
     ) -> Unit,
@@ -1444,7 +1445,7 @@ private fun QueueControlsToolbar(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SaveQueueAsPlaylistSheet(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     defaultName: String,
     onDismiss: () -> Unit,
     onConfirm: (String, Set<String>) -> Unit,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/RecentlyPlayedSection.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/RecentlyPlayedSection.kt
@@ -49,6 +49,7 @@ import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.presentation.model.RecentlyPlayedSongUiModel
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.ThemeStateHolder
+import kotlinx.collections.immutable.ImmutableList
 
 private val HomeRecentlyPlayedPillHeight = 58.dp
 private val HomeRecentlyPlayedPillSpacing = 8.dp
@@ -71,7 +72,7 @@ private data class RecentlyPlayedPillRow(
 
 @Composable
 fun RecentlyPlayedSection(
-    songs: List<RecentlyPlayedSongUiModel>,
+    songs: ImmutableList<RecentlyPlayedSongUiModel>,
     onSongClick: (Song) -> Unit,
     onOpenAllClick: () -> Unit,
     themeStateHolder: ThemeStateHolder,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/ReorderPresetsSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/ReorderPresetsSheet.kt
@@ -78,13 +78,14 @@ import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.collections.immutable.ImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ReorderPresetsSheet(
     visible: Boolean,
-    allAvailablePresets: List<EqualizerPreset>,
-    pinnedPresetsNames: List<String>,
+    allAvailablePresets: ImmutableList<EqualizerPreset>,
+    pinnedPresetsNames: ImmutableList<String>,
     onSave: (List<String>) -> Unit,
     onReset: () -> Unit,
     onDismiss: () -> Unit

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/ReorderTabsSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/ReorderTabsSheet.kt
@@ -63,11 +63,13 @@ import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ReorderTabsSheet(
-    tabs: List<String>,
+    tabs: ImmutableList<String>,
     onReorder: (List<String>) -> Unit,
     onReset: () -> Unit,
     onDismiss: () -> Unit
@@ -115,7 +117,7 @@ fun ReorderTabsSheet(
         onMove = { from, to ->
             localTabs = localTabs.toMutableList().apply {
                 add(to.index, removeAt(from.index))
-            }
+            }.toImmutableList()
             // Haptic feedback on reorder
             performAppCompatHapticFeedback(
                 view,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/SongPickerBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/SongPickerBottomSheet.kt
@@ -93,6 +93,8 @@ import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import com.lostf1sh.pixelplayeross.ui.theme.ShapeCache
 import kotlinx.coroutines.flow.map
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(UnstableApi::class)
 @ExperimentalMaterial3Api
@@ -388,8 +390,9 @@ fun SongPickerSelectionPane(
 
         when {
             searchQuery.isNotBlank() -> {
-                val displayed = (searchResults ?: emptyList()).let { results ->
-                    if (favoritesOnly) results.filter { it.id in favoriteIds } else results
+                val displayed = remember(searchResults, favoritesOnly, favoriteIds) {
+                    val results = searchResults ?: emptyList()
+                    (if (favoritesOnly) results.filter { it.id in favoriteIds } else results).toImmutableList()
                 }
                 SongPickerList(
                     filteredSongs = displayed,
@@ -778,7 +781,7 @@ fun SongPickerEmptyState(
 @kotlin.OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SongPickerList(
-    filteredSongs: List<Song>,
+    filteredSongs: ImmutableList<Song>,
     isLoading: Boolean,
     selectedSongIds: MutableMap<String, Boolean>,
     albumShape: androidx.compose.ui.graphics.Shape,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/StatsOverviewCard.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/StatsOverviewCard.kt
@@ -42,6 +42,9 @@ import com.lostf1sh.pixelplayeross.presentation.stats.displayNameRes
 import com.lostf1sh.pixelplayeross.utils.formatListeningDurationCompact
 import com.lostf1sh.pixelplayeross.utils.formatListeningDurationLong
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import androidx.compose.runtime.remember
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -214,7 +217,7 @@ private fun PlaceholderOverviewContent() {
 
 @Composable
 private fun MiniListeningTimeline(summary: PlaybackStatsRepository.PlaybackStatsSummary?) {
-    val timeline = summary?.timeline ?: emptyList()
+    val timeline = remember(summary) { (summary?.timeline ?: emptyList()).toImmutableList() }
     if (summary?.range == StatsTimeRange.MONTH && timeline.isNotEmpty()) {
         MonthlyHorizontalListeningTimeline(timeline)
         return
@@ -267,7 +270,7 @@ private fun MiniListeningTimeline(summary: PlaybackStatsRepository.PlaybackStats
 
 @Composable
 private fun MonthlyHorizontalListeningTimeline(
-    timeline: List<PlaybackStatsRepository.TimelineEntry>
+    timeline: ImmutableList<PlaybackStatsRepository.TimelineEntry>
 ) {
     val maxDuration = timeline.maxOfOrNull { it.totalDurationMs }?.takeIf { it > 0 } ?: 1L
     Column(

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/UnifiedPlayerOverlaysLayer.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/UnifiedPlayerOverlaysLayer.kt
@@ -38,9 +38,10 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import kotlin.math.roundToInt
+import kotlinx.collections.immutable.persistentListOf
 
 internal data class SaveQueueOverlayData(
-    val songs: List<Song>,
+    val songs: ImmutableList<Song>,
     val defaultName: String,
     val onConfirm: (String, Set<String>) -> Unit
 )
@@ -252,7 +253,7 @@ internal fun UnifiedPlayerSongInfoLayer(
             if (showPlaylistBottomSheet) {
                 PlaylistBottomSheet(
                     playlistUiState = playlistUiState,
-                    songs = listOf(liveSong),
+                    songs = persistentListOf(liveSong),
                     onDismiss = { showPlaylistBottomSheet = false },
                     bottomBarHeight = 0.dp,
                     playerViewModel = playerViewModel,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/FullPlayerContent.kt
@@ -1175,7 +1175,7 @@ private fun predictSkipPreviousCarouselIndex(
 @Composable
 private fun FullPlayerSongMetadataSection(
     song: Song,
-    currentSongArtists: List<Artist>,
+    currentSongArtists: ImmutableList<Artist>,
     loadingTweaks: FullPlayerLoadingTweaks,
     isSheetDragGestureActive: Boolean,
     expansionFractionProvider: () -> Float,
@@ -1323,7 +1323,7 @@ private fun FullPlayerLandscapeContent(
 @Composable
 private fun SongMetadataDisplaySection(
     song: Song?,
-    currentSongArtists: List<Artist>,
+    currentSongArtists: ImmutableList<Artist>,
     expansionFractionProvider: () -> Float,
     textColor: Color,
     artistTextColor: Color,
@@ -1996,7 +1996,7 @@ private fun PlayerSongInfo(
     title: String,
     artist: String,
     artistId: Long,
-    artists: List<Artist>,
+    artists: ImmutableList<Artist>,
     expansionFractionProvider: () -> Float,
     textColor: Color,
     artistTextColor: Color,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/PlayerArtistPickerBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/PlayerArtistPickerBottomSheet.kt
@@ -43,6 +43,7 @@ import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.presentation.components.SmartImage
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.ImmutableList
 
 private data class PlayerArtistShortcutItem(
     val artist: Artist,
@@ -53,7 +54,7 @@ private data class PlayerArtistShortcutItem(
 @Composable
 internal fun PlayerArtistPickerBottomSheet(
     song: Song,
-    artists: List<Artist>,
+    artists: ImmutableList<Artist>,
     sheetState: SheetState,
     onDismiss: () -> Unit,
     onArtistClick: (Artist) -> Unit

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/scoped/SheetModalOverlayController.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/scoped/SheetModalOverlayController.kt
@@ -11,6 +11,7 @@ import com.lostf1sh.pixelplayeross.presentation.components.SaveQueueOverlayData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * Owns transient overlay state that is coupled to the sheet scene:
@@ -47,7 +48,7 @@ internal class SheetModalOverlayController(
             queueSheetControllerProvider().animateTo(false)
             onCollapsePlayerSheet()
             delay(animationDurationMs.toLong())
-            pendingSaveQueueOverlay = SaveQueueOverlayData(songs, defaultName, onConfirm)
+            pendingSaveQueueOverlay = SaveQueueOverlayData(songs.toImmutableList(), defaultName, onConfirm)
         }
     }
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/subcomps/FetchLyricsDialog.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/subcomps/FetchLyricsDialog.kt
@@ -58,6 +58,7 @@ import com.lostf1sh.pixelplayeross.data.repository.LyricsSearchResult
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.LyricsSearchUiState
 import com.lostf1sh.pixelplayeross.utils.ProviderText
 import com.lostf1sh.pixelplayeross.utils.shapes.RoundedStarShape
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun FetchLyricsDialog(
@@ -303,7 +304,7 @@ private fun LoadingContent() {
 
 @Composable
 private fun PickResultContent(
-    results: List<LyricsSearchResult>,
+    results: ImmutableList<LyricsSearchResult>,
     onPickResult: (LyricsSearchResult) -> Unit,
     onCancel: () -> Unit
 ) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/subcomps/SelectionHeader.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/subcomps/SelectionHeader.kt
@@ -53,6 +53,9 @@ import com.lostf1sh.pixelplayeross.presentation.components.SmartImage
 import androidx.compose.ui.res.stringResource
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import androidx.compose.runtime.remember
 
 /**
  * Header component displayed during multi-selection mode.
@@ -67,7 +70,7 @@ import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SelectionHeader(
-    selectedSongs: List<Song>,
+    selectedSongs: ImmutableList<Song>,
     onPlayClick: () -> Unit,
     onLikeClick: () -> Unit,
     onShareClick: () -> Unit,
@@ -86,7 +89,7 @@ fun SelectionHeader(
         ) {
             // Stacked album arts (up to 5, overlapping)
             StackedCoverArts(
-                songs = selectedSongs.take(5),
+                songs = remember(selectedSongs) { selectedSongs.take(5).toImmutableList() },
                 totalCount = selectedSongs.size
             )
             
@@ -192,7 +195,7 @@ fun SelectionHeader(
  */
 @Composable
 private fun StackedCoverArts(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     totalCount: Int,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/jellyfin/dashboard/JellyfinDashboardScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/jellyfin/dashboard/JellyfinDashboardScreen.kt
@@ -40,6 +40,7 @@ import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.ImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -111,7 +112,7 @@ fun JellyfinDashboardScreen(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun JellyfinDashboardContent(
-    playlists: List<JellyfinPlaylistEntity>,
+    playlists: ImmutableList<JellyfinPlaylistEntity>,
     isSyncing: Boolean,
     syncMessage: String?,
     username: String?,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/jellyfin/dashboard/JellyfinDashboardViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/jellyfin/dashboard/JellyfinDashboardViewModel.kt
@@ -14,14 +14,19 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.map
 
 @HiltViewModel
 class JellyfinDashboardViewModel @Inject constructor(
     private val repository: JellyfinRepository
 ) : ViewModel() {
 
-    val playlists: StateFlow<List<JellyfinPlaylistEntity>> = repository.getPlaylists()
-        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+    val playlists: StateFlow<ImmutableList<JellyfinPlaylistEntity>> = repository.getPlaylists()
+        .map { it.toImmutableList() }
+        .stateIn(viewModelScope, SharingStarted.Lazily, persistentListOf())
 
     private val _isSyncing = MutableStateFlow(false)
     val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
@@ -29,8 +34,8 @@ class JellyfinDashboardViewModel @Inject constructor(
     private val _syncMessage = MutableStateFlow<String?>(null)
     val syncMessage: StateFlow<String?> = _syncMessage.asStateFlow()
 
-    private val _selectedPlaylistSongs = MutableStateFlow<List<Song>>(emptyList())
-    val selectedPlaylistSongs: StateFlow<List<Song>> = _selectedPlaylistSongs.asStateFlow()
+    private val _selectedPlaylistSongs = MutableStateFlow<ImmutableList<Song>>(persistentListOf())
+    val selectedPlaylistSongs: StateFlow<ImmutableList<Song>> = _selectedPlaylistSongs.asStateFlow()
 
     val username: String? get() = repository.username
     val serverUrl: String? get() = repository.serverUrl
@@ -95,7 +100,7 @@ class JellyfinDashboardViewModel @Inject constructor(
     fun loadPlaylistSongs(playlistId: String) {
         viewModelScope.launch {
             repository.getPlaylistSongs(playlistId).collect { songs ->
-                _selectedPlaylistSongs.value = songs
+                _selectedPlaylistSongs.value = songs.toImmutableList()
             }
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
@@ -51,6 +51,8 @@ import com.lostf1sh.pixelplayeross.utils.formatTimeAgo
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -138,13 +140,13 @@ fun NavidromeDashboardScreen(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun DashboardContent(
-    playlists: List<NavidromePlaylistEntity>,
+    playlists: ImmutableList<NavidromePlaylistEntity>,
     isSyncing: Boolean,
     syncProgress: Float?,
     syncMessage: String?,
-    selectedPlaylistSongs: List<Song>,
+    selectedPlaylistSongs: ImmutableList<Song>,
     selectedPlaylistName: String?,
-    musicFolders: List<NavidromeMusicFolder>,
+    musicFolders: ImmutableList<NavidromeMusicFolder>,
     musicFoldersLoadFailed: Boolean,
     selectedMusicFolderIds: Set<String>,
     librarySelectionNeedsSync: Boolean,
@@ -273,7 +275,7 @@ private fun DashboardContent(
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Text(
-                            text = "Last synced: ${formatTimeAgo(lastSyncTime)}",
+                            text = stringResource(R.string.dash_last_synced_format, formatTimeAgo(lastSyncTime)),
                             style = MaterialTheme.typography.bodySmall,
                             fontFamily = RoundedSans,
                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
@@ -409,7 +411,7 @@ private fun DashboardContent(
 @Composable
 private fun SubsonicMenuCard(
     isSyncing: Boolean,
-    musicFolders: List<NavidromeMusicFolder>,
+    musicFolders: ImmutableList<NavidromeMusicFolder>,
     musicFoldersLoadFailed: Boolean,
     selectedMusicFolderIds: Set<String>,
     librarySelectionNeedsSync: Boolean,
@@ -421,7 +423,7 @@ private fun SubsonicMenuCard(
     var showLibrarySelector by remember { mutableStateOf(false) }
     val effectiveSelectedIds = selectedNavidromeMusicFolderIds(musicFolders, selectedMusicFolderIds)
     val selectedFolderNames = remember(musicFolders, effectiveSelectedIds) {
-        musicFolders.filter { it.id in effectiveSelectedIds }.map { it.name }
+        musicFolders.filter { it.id in effectiveSelectedIds }.map { it.name }.toImmutableList()
     }
     val librarySummary = when {
         musicFoldersLoadFailed -> stringResource(R.string.dash_libraries_load_failed)
@@ -535,7 +537,7 @@ private fun SubsonicMenuCard(
 @Composable
 private fun NavidromeLibrarySummaryPanel(
     librarySummary: String,
-    selectedFolderNames: List<String>,
+    selectedFolderNames: ImmutableList<String>,
     selectedCount: Int,
     totalCount: Int,
     loadFailed: Boolean,
@@ -714,7 +716,7 @@ private fun NavidromeLibrarySummaryPanel(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun LibrarySelectorSheet(
-    musicFolders: List<NavidromeMusicFolder>,
+    musicFolders: ImmutableList<NavidromeMusicFolder>,
     selectedMusicFolderIds: Set<String>,
     onDismiss: () -> Unit,
     onSelectionChange: (Set<String>) -> Unit

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
@@ -19,6 +19,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.map
 
 @HiltViewModel
 class NavidromeDashboardViewModel @Inject constructor(
@@ -26,8 +30,9 @@ class NavidromeDashboardViewModel @Inject constructor(
     private val workManager: WorkManager
 ) : ViewModel() {
 
-    val playlists: StateFlow<List<NavidromePlaylistEntity>> = repository.getPlaylists()
-        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+    val playlists: StateFlow<ImmutableList<NavidromePlaylistEntity>> = repository.getPlaylists()
+        .map { it.toImmutableList() }
+        .stateIn(viewModelScope, SharingStarted.Lazily, persistentListOf())
 
     private val _isSyncing = MutableStateFlow(false)
     val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
@@ -38,14 +43,14 @@ class NavidromeDashboardViewModel @Inject constructor(
     private val _syncMessage = MutableStateFlow<String?>(null)
     val syncMessage: StateFlow<String?> = _syncMessage.asStateFlow()
 
-    private val _selectedPlaylistSongs = MutableStateFlow<List<Song>>(emptyList())
-    val selectedPlaylistSongs: StateFlow<List<Song>> = _selectedPlaylistSongs.asStateFlow()
+    private val _selectedPlaylistSongs = MutableStateFlow<ImmutableList<Song>>(persistentListOf())
+    val selectedPlaylistSongs: StateFlow<ImmutableList<Song>> = _selectedPlaylistSongs.asStateFlow()
 
     private val _selectedPlaylistName = MutableStateFlow<String?>(null)
     val selectedPlaylistName: StateFlow<String?> = _selectedPlaylistName.asStateFlow()
 
-    private val _musicFolders = MutableStateFlow<List<NavidromeMusicFolder>>(emptyList())
-    val musicFolders: StateFlow<List<NavidromeMusicFolder>> = _musicFolders.asStateFlow()
+    private val _musicFolders = MutableStateFlow<ImmutableList<NavidromeMusicFolder>>(persistentListOf())
+    val musicFolders: StateFlow<ImmutableList<NavidromeMusicFolder>> = _musicFolders.asStateFlow()
 
     private val _musicFoldersLoadFailed = MutableStateFlow(false)
     val musicFoldersLoadFailed: StateFlow<Boolean> = _musicFoldersLoadFailed.asStateFlow()
@@ -117,12 +122,12 @@ class NavidromeDashboardViewModel @Inject constructor(
         viewModelScope.launch {
             repository.getMusicFolders()
                 .onSuccess { folders ->
-                    _musicFolders.value = folders
+                    _musicFolders.value = folders.toImmutableList()
                     _musicFoldersLoadFailed.value = false
                 }
                 .onFailure {
                     // Music-folder discovery is optional; sync falls back to the server-wide library.
-                    _musicFolders.value = emptyList()
+                    _musicFolders.value = persistentListOf()
                     _musicFoldersLoadFailed.value = true
                 }
         }
@@ -148,7 +153,7 @@ class NavidromeDashboardViewModel @Inject constructor(
         selectedPlaylistJob?.cancel()
         selectedPlaylistJob = viewModelScope.launch {
             repository.getPlaylistSongs(playlistId).collect { songs ->
-                _selectedPlaylistSongs.value = songs
+                _selectedPlaylistSongs.value = songs.toImmutableList()
             }
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AccountsScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AccountsScreen.kt
@@ -82,6 +82,7 @@ import com.lostf1sh.pixelplayeross.presentation.viewmodel.ExternalServiceAccount
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun AccountsScreen(
@@ -494,7 +495,7 @@ private fun ConnectedAccountCard(
 
 @Composable
 private fun EmptyAccountsCard(
-    disconnectedServices: List<ExternalServiceAccount>,
+    disconnectedServices: ImmutableList<ExternalServiceAccount>,
     onConnect: (ExternalServiceAccount) -> Unit
 ) {
     val noLinkedTitle = stringResource(R.string.presentation_batch_b_accounts_no_linked_title)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AlbumDetailScreen.kt
@@ -103,6 +103,7 @@ import com.lostf1sh.pixelplayeross.utils.shapes.RoundedStarShape
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.persistentListOf
 
 private const val UseSharedCollapsibleTopBarProbe = true
 
@@ -501,7 +502,7 @@ fun AlbumDetailScreen(
 
                     PlaylistBottomSheet(
                         playlistUiState = playlistUiState,
-                        songs = listOf(currentSong),
+                        songs = persistentListOf(currentSong),
                         onDismiss = { showPlaylistBottomSheet = false },
                         bottomBarHeight = bottomBarHeightDp,
                         playerViewModel = playerViewModel

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/ArtistDetailScreen.kt
@@ -99,6 +99,7 @@ import coil.size.Size
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.compose.ui.res.stringResource
 import com.lostf1sh.pixelplayeross.R
+import kotlinx.collections.immutable.persistentListOf
 
 private const val UseSharedCollapsibleTopBarProbe = true
 
@@ -550,7 +551,7 @@ fun ArtistDetailScreen(
 
                 PlaylistBottomSheet(
                     playlistUiState = playlistUiState,
-                    songs = listOf(currentSong),
+                    songs = persistentListOf(currentSong),
                     onDismiss = { showPlaylistBottomSheet = false },
                     bottomBarHeight = bottomBarHeightDp,
                     playerViewModel = playerViewModel,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/ArtistSettingsScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/ArtistSettingsScreen.kt
@@ -96,6 +96,8 @@ import com.lostf1sh.pixelplayeross.presentation.components.ExpressiveTopBarConte
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.ArtistSettingsViewModel
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -322,7 +324,7 @@ fun ArtistSettingsScreen(
             // Examples Card
             item {
                 ExamplesCard(
-                    examples = listOf(
+                    examples = persistentListOf(
                         stringResource(R.string.presentation_batch_g_artist_ex_1_in) to stringResource(R.string.presentation_batch_g_artist_ex_1_out),
                         stringResource(R.string.presentation_batch_g_artist_ex_2_in) to stringResource(R.string.presentation_batch_g_artist_ex_2_out),
                         stringResource(R.string.presentation_batch_g_artist_ex_3_in) to stringResource(R.string.presentation_batch_g_artist_ex_3_out),
@@ -465,7 +467,7 @@ private fun InfoCard(
 
 @Composable
 private fun ExamplesCard(
-    examples: List<Pair<String, String>>
+    examples: ImmutableList<Pair<String, String>>
 ) {
     Surface(
         color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.3f),

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/CreatePlaylistScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/CreatePlaylistScreen.kt
@@ -170,6 +170,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.presentation.screens.TabAnimation
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class Quadruple<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
@@ -1324,7 +1326,7 @@ private fun PlaylistFormContent(
                 }
             }
 
-            val tabs = listOf(
+            val tabs = persistentListOf(
                 stringResource(R.string.presentation_batch_f_tab_default),
                 stringResource(R.string.presentation_batch_f_tab_image),
                 stringResource(R.string.presentation_batch_f_tab_icon)
@@ -1549,7 +1551,7 @@ fun getIconByName(name: String?): ImageVector? {
 
 @Composable
 fun ExpressiveButtonGroup(
-    items: List<String>,
+    items: ImmutableList<String>,
     selectedIndex: Int,
     onItemClick: (Int) -> Unit,
     modifier: Modifier = Modifier

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/DailyMixScreen.kt
@@ -89,6 +89,7 @@ import kotlinx.coroutines.flow.map
 import com.lostf1sh.pixelplayeross.presentation.components.subcomps.EnhancedSongListItem
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.persistentListOf
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -203,7 +204,7 @@ fun DailyMixScreen(
 
             PlaylistBottomSheet(
                 playlistUiState = playlistUiState,
-                songs = listOf(song),
+                songs = persistentListOf(song),
                 onDismiss = { showPlaylistBottomSheet = false },
                 bottomBarHeight = bottomBarHeightDp,
                 playerViewModel = playerViewModel,
@@ -376,7 +377,7 @@ fun DailyMixScreen(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ExpressiveDailyMixHeader(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     scrollState: LazyListState
 ) {
     val dailyMixHeaderTitle = stringResource(R.string.presentation_batch_b_daily_mix_title)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/DeviceCapabilitiesScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/DeviceCapabilitiesScreen.kt
@@ -94,6 +94,8 @@ import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlayerViewModel
 import kotlinx.coroutines.launch
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import kotlin.math.roundToInt
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(UnstableApi::class)
 @kotlin.OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -501,7 +503,7 @@ private fun PlaybackPathCard(
         SectionLabel(text = stringResource(R.string.device_capabilities_offload_title))
         ChipRow(
             emptyText = stringResource(R.string.device_capabilities_offload_empty),
-            chips = audioCapabilities.offloadSupportedFormats
+            chips = remember(audioCapabilities) { audioCapabilities.offloadSupportedFormats.toImmutableList() }
         )
 
         SectionLabel(text = stringResource(R.string.device_capabilities_outputs_title))
@@ -542,7 +544,7 @@ private fun PlaybackPathCard(
 
 @Composable
 private fun FormatCompatibilityCard(
-    formats: List<FormatSupportInfo>,
+    formats: ImmutableList<FormatSupportInfo>,
     playbackCompatibility: PlaybackCompatibilitySummary?,
     modifier: Modifier = Modifier
 ) {
@@ -1165,7 +1167,7 @@ private fun TonalChip(
 
 @Composable
 private fun ChipRow(
-    chips: List<String>,
+    chips: ImmutableList<String>,
     emptyText: String,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/EditTransitionScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/EditTransitionScreen.kt
@@ -86,6 +86,8 @@ import com.lostf1sh.pixelplayeross.presentation.viewmodel.TransitionViewModel
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import java.util.concurrent.TimeUnit
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -352,7 +354,7 @@ private fun TransitionModeSection(
 
         // Redesigned Toggle component: flat, symmetric, no weird shadows
         ExpressiveMorphingToggle(
-            options = listOf(TransitionMode.NONE, TransitionMode.OVERLAP),
+            options = remember { persistentListOf(TransitionMode.NONE, TransitionMode.OVERLAP) },
             selectedOption = selected,
             onOptionSelected = onModeSelected
         )
@@ -361,7 +363,7 @@ private fun TransitionModeSection(
 
 @Composable
 private fun ExpressiveMorphingToggle(
-    options: List<TransitionMode>,
+    options: ImmutableList<TransitionMode>,
     selectedOption: TransitionMode,
     onOptionSelected: (TransitionMode) -> Unit
 ) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/EqualizerScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/EqualizerScreen.kt
@@ -150,6 +150,8 @@ import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -303,7 +305,7 @@ fun EqualizerScreen(
             item(key = "preset_tabs") {
                 val visiblePresets = remember(uiState.accessiblePresets) {
                     val defaultPresets = uiState.accessiblePresets.filter { !it.isCustom }
-                    defaultPresets + EqualizerPreset.custom(List(10) { 0 }) // Always show "Custom" tab at end
+                    (defaultPresets + EqualizerPreset.custom(List(10) { 0 })).toImmutableList() // Always show "Custom" tab at end
                 }
                 
                 PresetTabsRow(
@@ -437,7 +439,7 @@ fun EqualizerScreen(
 
 @Composable
 private fun PresetTabsRow(
-    presets: List<EqualizerPreset>,
+    presets: ImmutableList<EqualizerPreset>,
     selectedPreset: EqualizerPreset,
     onPresetSelected: (EqualizerPreset) -> Unit,
     onEditClick: () -> Unit
@@ -529,7 +531,7 @@ private fun PresetTabsRow(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun BandSlidersSection(
-    bandLevels: List<Int>,
+    bandLevels: ImmutableList<Int>,
     isEnabled: Boolean,
     currentPreset: EqualizerPreset,
     editingPresetName: String?,
@@ -540,7 +542,7 @@ private fun BandSlidersSection(
     onUnpinClick: () -> Unit,
     onPresetsListClick: () -> Unit
 ) {
-    val frequencies = EqualizerPreset.BAND_FREQUENCIES
+    val frequencies = remember { EqualizerPreset.BAND_FREQUENCIES.toImmutableList() }
     
     Card(
         modifier = Modifier
@@ -747,9 +749,9 @@ private fun BandSlidersSection(
 
 @Composable
 private fun GraphBandSliders(
-    bandLevels: List<Int>,
+    bandLevels: ImmutableList<Int>,
     isEnabled: Boolean,
-    frequencies: List<String>,
+    frequencies: ImmutableList<String>,
     onBandLevelChanged: (Int, Int) -> Unit
 ) {
     Box(
@@ -1565,9 +1567,9 @@ private fun VolumeControlCard(
 
 @Composable
 private fun HybridBandSliders(
-    bandLevels: List<Int>,
+    bandLevels: ImmutableList<Int>,
     isEnabled: Boolean,
-    frequencies: List<String>,
+    frequencies: ImmutableList<String>,
     onBandLevelChanged: (Int, Int) -> Unit
 ) {
     val context = LocalContext.current
@@ -1785,9 +1787,9 @@ private fun HybridHorizontalSlider(
 
 @Composable
 private fun HybridFrequencyResponseGraph(
-    bandLevels: List<Int>,
+    bandLevels: ImmutableList<Int>,
     isEnabled: Boolean,
-    frequencies: List<String>? = null
+    frequencies: ImmutableList<String>? = null
 ) {
      val primaryColor = MaterialTheme.colorScheme.primary
      val gridColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/GenreDetailScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/GenreDetailScreen.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.launch
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import kotlin.math.roundToInt
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.toImmutableList
 
 // --- Data Models & Helpers ---
 
@@ -450,7 +451,7 @@ fun GenreDetailScreen(
             MaterialTheme(colorScheme = baseColorScheme) {
                 QuickFillDialog(
                     visible = showQuickFillDialog,
-                    songs = uiState.songs,
+                    songs = remember(uiState.songs) { uiState.songs.toImmutableList() },
                     customGenres = customGenres,
                     customGenreIcons = customGenreIcons,
                     onDismiss = { showQuickFillDialog = false },
@@ -552,7 +553,7 @@ fun GenreDetailScreen(
                 if (showPlaylistBottomSheet) {
                     com.lostf1sh.pixelplayeross.presentation.components.PlaylistBottomSheet(
                         playlistUiState = playlistUiState,
-                        songs = listOf(song),
+                        songs = persistentListOf(song),
                         onDismiss = { showPlaylistBottomSheet = false },
                         bottomBarHeight = 0.dp, // Or calculate if needed
                         playerViewModel = playerViewModel

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/HomeScreen.kt
@@ -451,7 +451,7 @@ fun HomeScreen(
                         contentType = "recently_played_section"
                     ) {
                         RecentlyPlayedSection(
-                            songs = recentlyPlayedSongs,
+                            songs = remember(recentlyPlayedSongs) { recentlyPlayedSongs.toImmutableList() },
                             onSongClick = { song ->
                                 if (recentlyPlayedQueue.isNotEmpty()) {
                                     playerViewModel.playSongs(

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryMediaTabs.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryMediaTabs.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.collections.immutable.ImmutableList
 
 // Shared placeholder for loading skeletons: allocating a fresh MutableStateFlow inline in
 // composition would create a new object on every recomposition of every skeleton row.
@@ -678,7 +679,7 @@ fun LibraryArtistsTab(
 @Composable
 fun LibraryPlaylistsTab(
     playlistUiState: PlaylistUiState,
-    filteredPlaylists: List<com.lostf1sh.pixelplayeross.data.model.Playlist> = playlistUiState.playlists,
+    filteredPlaylists: ImmutableList<com.lostf1sh.pixelplayeross.data.model.Playlist> = playlistUiState.playlists,
     navController: NavController,
     playerViewModel: PlayerViewModel,
     bottomBarHeight: Dp,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryScreen.kt
@@ -84,7 +84,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -332,7 +335,7 @@ fun LibraryScreen(
 
     var showSongInfoBottomSheet by remember { mutableStateOf(false) }
     var showPlaylistBottomSheet by remember { mutableStateOf(false) }
-    var playlistSheetSongs by remember { mutableStateOf<List<Song>>(emptyList()) }
+    var playlistSheetSongs by remember { mutableStateOf<ImmutableList<Song>>(persistentListOf()) }
     val selectedSongForInfo by playerViewModel.selectedSongForInfo.collectAsStateWithLifecycle()
     val tabTitles by playerViewModel.libraryTabsFlow.collectAsStateWithLifecycle()
     val currentTabId by playerViewModel.currentLibraryTabId.collectAsStateWithLifecycle()
@@ -381,7 +384,7 @@ fun LibraryScreen(
     val isSelectionMode by multiSelectionState.isSelectionMode.collectAsStateWithLifecycle()
     val selectedSongIds by multiSelectionState.selectedSongIds.collectAsStateWithLifecycle()
     var showMultiSelectionSheet by remember { mutableStateOf(false) }
-    var selectedAlbums by remember { mutableStateOf<List<Album>>(emptyList()) }
+    var selectedAlbums by remember { mutableStateOf<ImmutableList<Album>>(persistentListOf()) }
     val selectedAlbumIds = remember(selectedAlbums) { selectedAlbums.map { it.id }.toSet() }
     val isAlbumSelectionMode = selectedAlbums.isNotEmpty()
     var showAlbumMultiSelectionSheet by remember { mutableStateOf(false) }
@@ -411,11 +414,11 @@ fun LibraryScreen(
         { album ->
             val existingIndex = selectedAlbums.indexOfFirst { it.id == album.id }
             if (existingIndex >= 0) {
-                selectedAlbums = selectedAlbums.toMutableList().also { it.removeAt(existingIndex) }
+                selectedAlbums = selectedAlbums.toMutableList().also { it.removeAt(existingIndex) }.toImmutableList()
             } else if (selectedAlbums.size >= MAX_ALBUM_MULTI_SELECTION) {
                 playerViewModel.sendToast(context.getString(R.string.presentation_batch_d_max_albums_selection, MAX_ALBUM_MULTI_SELECTION))
             } else {
-                selectedAlbums = selectedAlbums + album
+                selectedAlbums = (selectedAlbums + album).toImmutableList()
             }
         }
     }
@@ -577,7 +580,7 @@ fun LibraryScreen(
                     }
 
                     LibraryTabId.ALBUMS -> {
-                        selectedAlbums = emptyList()
+                        selectedAlbums = persistentListOf()
                         showAlbumMultiSelectionSheet = false
                     }
 
@@ -599,11 +602,14 @@ fun LibraryScreen(
     }
 
     // Feedback for Playlist Creation
-    LaunchedEffect(Unit) {
-        playlistViewModel.playlistCreationEvent.collect { success ->
-            if (success) {
-                showCreatePlaylistDialog = false
-                Toast.makeText(context, context.getString(R.string.toast_playlist_created), Toast.LENGTH_SHORT).show()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(playlistViewModel, lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            playlistViewModel.playlistCreationEvent.collect { success ->
+                if (success) {
+                    showCreatePlaylistDialog = false
+                    Toast.makeText(context, context.getString(R.string.toast_playlist_created), Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
@@ -623,7 +629,7 @@ fun LibraryScreen(
         // Clear selection when switching tabs
         multiSelectionState.clearSelection()
         playlistMultiSelectionState.clearSelection()
-        selectedAlbums = emptyList()
+        selectedAlbums = persistentListOf()
         showMultiSelectionSheet = false
         showPlaylistMultiSelectionSheet = false
         showAlbumMultiSelectionSheet = false
@@ -654,15 +660,14 @@ fun LibraryScreen(
         }
     }
 
-    val gradientColorsDark = listOf(
-        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-        Color.Transparent
-    ).toImmutableList()
-
-    val gradientColorsLight = listOf(
-        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f),
-        Color.Transparent
-    ).toImmutableList()
+    val primaryContainer = MaterialTheme.colorScheme.primaryContainer
+    val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
+    val gradientColorsDark = remember(primaryContainer) {
+        listOf(primaryContainer.copy(alpha = 0.5f), Color.Transparent).toImmutableList()
+    }
+    val gradientColorsLight = remember(onPrimaryContainer) {
+        listOf(onPrimaryContainer.copy(alpha = 0.2f), Color.Transparent).toImmutableList()
+    }
 
     val gradientColors = if (dm) gradientColorsDark else gradientColorsLight
 
@@ -855,7 +860,7 @@ fun LibraryScreen(
                             }
 
                             val distinctByKey = ensured.distinctBy { it.storageKey }
-                            distinctByKey.ifEmpty { listOf(currentTabId.defaultSort) }
+                            distinctByKey.ifEmpty { listOf(currentTabId.defaultSort) }.toImmutableList()
                         }
 
                         val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
@@ -955,11 +960,11 @@ fun LibraryScreen(
                                                     .filterNot { selectedAlbumIds.contains(it.id) }
                                                     .take(remaining)
                                                 if (albumsToAppend.isNotEmpty()) {
-                                                    selectedAlbums = selectedAlbums + albumsToAppend
+                                                    selectedAlbums = (selectedAlbums + albumsToAppend).toImmutableList()
                                                 }
                                             }
                                         },
-                                        onDeselect = { selectedAlbums = emptyList() },
+                                        onDeselect = { selectedAlbums = persistentListOf() },
                                         onOptionsClick = { showAlbumMultiSelectionSheet = true }
                                     )
                                 } else {
@@ -1494,7 +1499,7 @@ fun LibraryScreen(
                     playerViewModel.sendToast(context.getString(R.string.toast_playing_next))
                 },
                 onAddToPlayList = {
-                    playlistSheetSongs = listOf(currentSong)
+                    playlistSheetSongs = persistentListOf(currentSong)
                     showPlaylistBottomSheet = true
                 },
                 onDeleteFromDevice = playerViewModel::deleteFromDevice,
@@ -1623,17 +1628,17 @@ fun LibraryScreen(
             onDismiss = { showAlbumMultiSelectionSheet = false },
             onPlay = {
                 playerViewModel.playSelectedAlbums(selectedAlbums)
-                selectedAlbums = emptyList()
+                selectedAlbums = persistentListOf()
                 showAlbumMultiSelectionSheet = false
             },
             onPlayNext = {
                 playerViewModel.addSelectedAlbumsAsNext(selectedAlbums)
-                selectedAlbums = emptyList()
+                selectedAlbums = persistentListOf()
                 showAlbumMultiSelectionSheet = false
             },
             onAddToQueue = {
                 playerViewModel.addSelectedAlbumsToQueue(selectedAlbums)
-                selectedAlbums = emptyList()
+                selectedAlbums = persistentListOf()
                 showAlbumMultiSelectionSheet = false
             }
         )
@@ -2232,7 +2237,7 @@ private fun rememberLibraryNavigationPillTitleStyle(widthAxis: Float): TextStyle
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryTabSwitcherSheet(
-    tabs: List<String>,
+    tabs: ImmutableList<String>,
     currentIndex: Int,
     onTabSelected: (Int) -> Unit,
     onEditClick: () -> Unit,
@@ -2731,7 +2736,7 @@ fun LibraryFoldersTab(
 
 @Composable
 fun FolderPlaylistItem(folder: MusicFolder, onClick: () -> Unit) {
-    val previewSongs = remember(folder) { folder.collectAllSongs().take(9) }
+    val previewSongs = remember(folder) { folder.collectAllSongs().take(9).toImmutableList() }
 
     Card(
         onClick = onClick,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibrarySongsAndFavoritesTabs.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibrarySongsAndFavoritesTabs.kt
@@ -47,7 +47,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.util.UnstableApi
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -127,15 +130,18 @@ fun LibraryFavoritesTab(
         }
     }
     // Scroll Handler from ViewModel
-    LaunchedEffect(Unit) {
-        playerViewModel.scrollToIndexEvent.collect { index ->
-            if (index >= 0) {
-                 val firstVisible = listState.firstVisibleItemIndex
-                 if (Math.abs(index - firstVisible) > 20) {
-                     listState.scrollToItem(index)
-                 } else {
-                     listState.animateScrollToItem(index)
-                 }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(playerViewModel, lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            playerViewModel.scrollToIndexEvent.collect { index ->
+                if (index >= 0) {
+                    val firstVisible = listState.firstVisibleItemIndex
+                    if (Math.abs(index - firstVisible) > 20) {
+                        listState.scrollToItem(index)
+                    } else {
+                        listState.animateScrollToItem(index)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibrarySongsTab.kt
@@ -37,7 +37,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.util.UnstableApi
 import com.lostf1sh.pixelplayeross.data.model.LibraryTabId
 import com.lostf1sh.pixelplayeross.data.model.Song
@@ -118,15 +121,18 @@ fun LibrarySongsTab(
     }
 
     // Scroll Handler from ViewModel
-    LaunchedEffect(Unit) {
-        playerViewModel.scrollToIndexEvent.collect { index ->
-            if (index >= 0) {
-                 val firstVisible = listState.firstVisibleItemIndex
-                 if (Math.abs(index - firstVisible) > 20) {
-                     listState.scrollToItem(index)
-                 } else {
-                     listState.animateScrollToItem(index)
-                 }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(playerViewModel, lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            playerViewModel.scrollToIndexEvent.collect { index ->
+                if (index >= 0) {
+                    val firstVisible = listState.firstVisibleItemIndex
+                    if (Math.abs(index - firstVisible) > 20) {
+                        listState.scrollToItem(index)
+                    } else {
+                        listState.animateScrollToItem(index)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/PlaylistDetailScreen.kt
@@ -133,6 +133,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import com.lostf1sh.pixelplayeross.presentation.components.rememberModalSheetState
+import kotlinx.collections.immutable.persistentListOf
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(
@@ -951,7 +952,7 @@ fun PlaylistDetailScreen(
 
                 PlaylistBottomSheet(
                     playlistUiState = playlistUiState,
-                    songs = listOf(currentSong),
+                    songs = persistentListOf(currentSong),
                     onDismiss = {
                         showPlaylistBottomSheet = false
                     },
@@ -979,7 +980,7 @@ fun PlaylistDetailScreen(
         }
 
         // Build options list inline to avoid potential static initialization issues
-        val songSortOptions = listOf(
+        val songSortOptions = persistentListOf(
             SortOption.SongDefaultOrder,
             SortOption.SongTitleAZ,
             SortOption.SongTitleZA,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/QuickFillScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/QuickFillScreen.kt
@@ -43,11 +43,13 @@ import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.compose.ui.res.stringResource
 import com.lostf1sh.pixelplayeross.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun QuickFillDialog(
     visible: Boolean,
-    songs: List<Song>, // Initial list of songs (from Unknown genre)
+    songs: ImmutableList<Song>, // Initial list of songs (from Unknown genre)
     customGenres: Set<String>,
     customGenreIcons: Map<String, Int>,
     onDismiss: () -> Unit,
@@ -73,7 +75,7 @@ fun QuickFillDialog(
 
 @Composable
 fun QuickFillContent(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     customGenres: Set<String>,
     customGenreIcons: Map<String, Int>,
     onDismiss: () -> Unit,
@@ -161,7 +163,7 @@ fun QuickFillContent(
                         
                         val filteredSongs = remember(songs, searchQuery) {
                             if (searchQuery.isBlank()) songs 
-                            else songs.filter { it.title.contains(searchQuery, true) || it.artist.contains(searchQuery, true) }
+                            else songs.filter { it.title.contains(searchQuery, true) || it.artist.contains(searchQuery, true) }.toImmutableList()
                         }
                         
                         SongPickerList(

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/RecentlyPlayedScreen.kt
@@ -93,6 +93,8 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -140,13 +142,13 @@ fun RecentlyPlayedScreen(
     }.collectAsStateWithLifecycle(initialValue = recentSongsInitialValue)
 
     val recentlyPlayedSongs = remember(playbackHistory, recentlyPlayedSourceSongs, selectedRange) {
-        val sourceSongs = recentlyPlayedSourceSongs ?: return@remember emptyList()
+        val sourceSongs = recentlyPlayedSourceSongs ?: return@remember persistentListOf()
         mapRecentlyPlayedSongs(
             playbackHistory = playbackHistory,
             songs = sourceSongs,
             range = selectedRange,
             maxItems = Int.MAX_VALUE
-        )
+        ).toImmutableList()
     }
     val groupedSongs = remember(recentlyPlayedSongs, selectedRange, context) {
         groupRecentlyPlayedSongs(
@@ -341,7 +343,7 @@ fun RecentlyPlayedScreen(
             if (showPlaylistBottomSheet) {
                 PlaylistBottomSheet(
                     playlistUiState = playlistUiState,
-                    songs = listOf(song),
+                    songs = persistentListOf(song),
                     onDismiss = { showPlaylistBottomSheet = false },
                     bottomBarHeight = bottomBarHeightDp,
                     playerViewModel = playerViewModel,
@@ -373,7 +375,7 @@ fun RecentlyPlayedScreen(
 @Composable
 private fun ExpressiveRecentlyPlayedHeader(
     title: String,
-    songs: List<RecentlyPlayedSongUiModel>,
+    songs: ImmutableList<RecentlyPlayedSongUiModel>,
     selectedRange: StatsTimeRange,
     scrollState: LazyListState
 ) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SearchScreen.kt
@@ -195,15 +195,14 @@ fun SearchScreen(
 
     val dm = LocalPixelPlayerDarkTheme.current
 
-    val gradientColorsDark = listOf(
-        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-        Color.Transparent
-    ).toImmutableList()
-
-    val gradientColorsLight = listOf(
-        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f),
-        Color.Transparent
-    ).toImmutableList()
+    val primaryContainer = MaterialTheme.colorScheme.primaryContainer
+    val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
+    val gradientColorsDark = remember(primaryContainer) {
+        listOf(primaryContainer.copy(alpha = 0.5f), Color.Transparent).toImmutableList()
+    }
+    val gradientColorsLight = remember(onPrimaryContainer) {
+        listOf(onPrimaryContainer.copy(alpha = 0.2f), Color.Transparent).toImmutableList()
+    }
 
     val gradientColors = if (dm) gradientColorsDark else gradientColorsLight
 
@@ -519,7 +518,7 @@ fun SearchScreen(
 
                 PlaylistBottomSheet(
                     playlistUiState = playlistUiState,
-                    songs = listOf(currentSong),
+                    songs = persistentListOf(currentSong),
                     onDismiss = { showPlaylistBottomSheet = false },
                     bottomBarHeight = bottomBarHeightDp,
                     playerViewModel = playerViewModel,
@@ -542,7 +541,7 @@ fun SearchResultSectionHeader(title: String) {
 
 @Composable
 fun SearchHistoryList(
-    historyItems: List<SearchHistoryItem>,
+    historyItems: ImmutableList<SearchHistoryItem>,
     onHistoryClick: (String) -> Unit,
     onHistoryDelete: (String) -> Unit,
     onClearAllHistory: () -> Unit
@@ -668,7 +667,7 @@ fun EmptySearchResults(searchQuery: String, colorScheme: ColorScheme) {
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun SearchResultsList(
-    results: List<SearchResultItem>,
+    results: ImmutableList<SearchResultItem>,
     searchQuery: String,
     playerViewModel: PlayerViewModel,
     onItemSelected: () -> Unit,
@@ -861,7 +860,8 @@ fun SearchResultsList(
                             is SearchResultItem.PlaylistItem -> {
                                 val playlistSongs by remember(item.playlist.songIds, playerViewModel) {
                                     playerViewModel.observeSongs(item.playlist.songIds)
-                                }.collectAsStateWithLifecycle(initialValue = emptyList())
+                                        .map { it.toImmutableList() }
+                                }.collectAsStateWithLifecycle(initialValue = persistentListOf())
                                 val coroutineScope = rememberCoroutineScope()
                                 val onPlayClick: () -> Unit = {
                                     coroutineScope.launch {
@@ -939,7 +939,7 @@ fun SearchResultAlbumItem(
         ) {
             SmartImage(
                 model = album.albumArtUriString,
-                contentDescription = "Album Art: ${album.title}",
+                contentDescription = stringResource(R.string.cd_album_art_of, album.title),
                 targetSize = SmartImageListTargetSize,
                 modifier = Modifier
                     .size(56.dp)
@@ -1017,7 +1017,7 @@ fun SearchResultArtistItem(
             if (!artist.effectiveImageUrl.isNullOrBlank()) {
                 SmartImage(
                     model = artist.effectiveImageUrl,
-                    contentDescription = "Artist: ${artist.name}",
+                    contentDescription = stringResource(R.string.cd_artist_format, artist.name),
                     targetSize = SmartImageListTargetSize,
                     modifier = Modifier
                         .size(56.dp)
@@ -1026,7 +1026,7 @@ fun SearchResultArtistItem(
             } else {
                 Icon(
                     painter = painterResource(id = R.drawable.rounded_artist_24),
-                    contentDescription = "Artist",
+                    contentDescription = stringResource(R.string.cd_artist_icon),
                     modifier = Modifier
                         .size(56.dp)
                         .background(MaterialTheme.colorScheme.tertiaryContainer, ShapeCache.expressiveAvatar)
@@ -1058,7 +1058,7 @@ fun SearchResultArtistItem(
                     contentColor = MaterialTheme.colorScheme.onTertiary
                 )
             ) {
-                Icon(Icons.Rounded.PlayArrow, contentDescription = "Play Artist", modifier = Modifier.size(24.dp))
+                Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.cd_play_artist), modifier = Modifier.size(24.dp))
             }
         }
     }
@@ -1068,7 +1068,7 @@ fun SearchResultArtistItem(
 @Composable
 fun SearchResultPlaylistItem(
     playlist: Playlist,
-    playlistSongs: List<Song>,
+    playlistSongs: ImmutableList<Song>,
     onOpenClick: () -> Unit,
     onPlayClick: () -> Unit
 ) {
@@ -1128,7 +1128,7 @@ fun SearchResultPlaylistItem(
                     contentColor = MaterialTheme.colorScheme.onPrimary
                 )
             ) {
-                Icon(Icons.Rounded.PlayArrow, contentDescription = "Play Playlist", modifier = Modifier.size(24.dp))
+                Icon(Icons.Rounded.PlayArrow, contentDescription = stringResource(R.string.cd_play_playlist), modifier = Modifier.size(24.dp))
             }
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsCategoryScreen.kt
@@ -105,7 +105,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -168,6 +171,8 @@ import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlayerViewModel
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.SettingsViewModel
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import com.lostf1sh.pixelplayeross.presentation.components.rememberModalSheetState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -240,9 +245,12 @@ fun SettingsCategoryScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        settingsViewModel.dataTransferEvents.collectLatest { message ->
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(settingsViewModel, lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            settingsViewModel.dataTransferEvents.collectLatest { message ->
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            }
         }
     }
 
@@ -277,7 +285,7 @@ fun SettingsCategoryScreen(
                     song.displayArtist.contains(query, ignoreCase = true) ||
                     song.album.contains(query, ignoreCase = true)
             }
-        }
+        }.toImmutableList()
     }
 
     // TopBar Animations (identical to SettingsScreen)
@@ -1971,7 +1979,7 @@ private fun BackupTransferProgressDialog(progress: BackupTransferProgressUpdate)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ImportFileSelectionDialog(
-    backupHistory: List<BackupHistoryEntry>,
+    backupHistory: ImmutableList<BackupHistoryEntry>,
     isInspecting: Boolean,
     onDismiss: () -> Unit,
     onBrowseFile: () -> Unit,
@@ -2321,7 +2329,7 @@ private fun ImportModuleSelectionDialog(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun PaletteRegenerateSongSheetContent(
-    songs: List<Song>,
+    songs: ImmutableList<Song>,
     isRunning: Boolean,
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SetupScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SetupScreen.kt
@@ -130,6 +130,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.lostf1sh.pixelplayeross.R
@@ -224,20 +225,22 @@ fun SetupScreen(
     val directorySelectionPageIndex = remember(pages) { pages.indexOf(SetupPage.DirectorySelection) }
     val finishPageIndex = remember(pages) { pages.indexOf(SetupPage.Finish) }
 
-    LaunchedEffect(Unit) {
-        setupViewModel.events.collectLatest { event ->
-            when (event) {
-                is SetupEvent.Message -> {
-                    Toast.makeText(context, event.value, Toast.LENGTH_LONG).show()
-                }
-                is SetupEvent.RestoreCompleted -> {
-                    Toast.makeText(context, event.message, Toast.LENGTH_LONG).show()
-                    val targetPageIndex = finishPageIndex.takeIf { it >= 0 }
+    LaunchedEffect(setupViewModel, lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            setupViewModel.events.collectLatest { event ->
+                when (event) {
+                    is SetupEvent.Message -> {
+                        Toast.makeText(context, event.value, Toast.LENGTH_LONG).show()
+                    }
+                    is SetupEvent.RestoreCompleted -> {
+                        Toast.makeText(context, event.message, Toast.LENGTH_LONG).show()
+                        val targetPageIndex = finishPageIndex.takeIf { it >= 0 }
 
-                    if (targetPageIndex != null) {
-                        pagerState.animateScrollToPage(targetPageIndex)
-                    } else {
-                        onSetupComplete()
+                        if (targetPageIndex != null) {
+                            pagerState.animateScrollToPage(targetPageIndex)
+                        } else {
+                            onSetupComplete()
+                        }
                     }
                 }
             }
@@ -445,8 +448,8 @@ fun SetupScreen(
 fun DirectorySelectionPage(
     uiState: SetupUiState,
     currentPath: File,
-    directoryChildren: List<DirectoryEntry>,
-    availableStorages: List<StorageInfo>,
+    directoryChildren: ImmutableList<DirectoryEntry>,
+    availableStorages: ImmutableList<StorageInfo>,
     selectedStorageIndex: Int,
     isExplorerPriming: Boolean,
     isExplorerReady: Boolean,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/StatsScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/StatsScreen.kt
@@ -131,6 +131,8 @@ import com.lostf1sh.pixelplayeross.utils.shapes.RoundedStarShape
 import androidx.compose.material.icons.outlined.MusicNote
 import androidx.compose.material.icons.outlined.PlayCircleOutline
 import com.lostf1sh.pixelplayeross.ui.theme.ExpTitleTypography
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 private const val PULL_TO_REFRESH_MIN_DURATION_MS = 3500L
 
@@ -631,7 +633,7 @@ private fun SummaryProgressRow(
 
 @Composable
 private fun RangeTabsHeader(
-    ranges: List<StatsTimeRange>,
+    ranges: ImmutableList<StatsTimeRange>,
     selected: StatsTimeRange,
     onRangeSelected: (StatsTimeRange) -> Unit,
     indicatorSpacing: Dp,
@@ -1029,7 +1031,7 @@ private fun ListeningTimelineSection(
     modifier: Modifier = Modifier
 ) {
     val range = summary?.range ?: StatsTimeRange.WEEK
-    val timeline = summary?.timeline.orEmpty()
+    val timeline = remember(summary) { summary?.timeline.orEmpty().toImmutableList() }
     val hasTimeline = timeline.isNotEmpty() && timeline.any { it.totalDurationMs > 0L || it.playCount > 0 }
     val sectionTitleStyle = rememberStatsSectionTitleStyle()
     val emDash = stringResource(R.string.presentation_batch_g_stats_em_dash)
@@ -1274,7 +1276,7 @@ private fun CategoryMetricsSection(
                     supporting = supportingParts.joinToString(separator = " • ")
                 )
             }
-        }.filter { it.durationMs > 0L }
+        }.filter { it.durationMs > 0L }.toImmutableList()
 
         if (entries.isEmpty()) {
             StatsEmptyState(
@@ -1305,7 +1307,7 @@ private fun CategoryMetricsSection(
 
 @Composable
 private fun CategoryHorizontalBarChart(
-    entries: List<CategoryMetricEntry>,
+    entries: ImmutableList<CategoryMetricEntry>,
     palette: CategoryChartPalette,
     modifier: Modifier = Modifier
 ) {
@@ -1453,7 +1455,7 @@ private fun TimelineMetricBadge(
 
 @Composable
 private fun TimelineBarChart(
-    entries: List<PlaybackStatsRepository.TimelineEntry>,
+    entries: ImmutableList<PlaybackStatsRepository.TimelineEntry>,
     metric: TimelineMetric,
     range: StatsTimeRange,
     blankLabel: String,
@@ -1485,7 +1487,7 @@ private fun TimelineBarChart(
 
 @Composable
 private fun VerticalTimelineBarChart(
-    entries: List<PlaybackStatsRepository.TimelineEntry>,
+    entries: ImmutableList<PlaybackStatsRepository.TimelineEntry>,
     metric: TimelineMetric,
     range: StatsTimeRange,
     spec: TimelineChartSpec,
@@ -1584,7 +1586,7 @@ private fun VerticalTimelineBarChart(
 
 @Composable
 private fun HorizontalTimelineBarChart(
-    entries: List<PlaybackStatsRepository.TimelineEntry>,
+    entries: ImmutableList<PlaybackStatsRepository.TimelineEntry>,
     metric: TimelineMetric,
     range: StatsTimeRange,
     spec: TimelineChartSpec,
@@ -2257,7 +2259,7 @@ private fun TrackConcentrationCard(
                             )
                         )
                     }
-                }
+                }.toImmutableList()
 
                 TrackDistributionOverview(
                     slices = slices,
@@ -2273,7 +2275,7 @@ private fun TrackConcentrationCard(
 
 @Composable
 private fun TrackDistributionOverview(
-    slices: List<TrackShareSlice>,
+    slices: ImmutableList<TrackShareSlice>,
     totalDurationMs: Long,
     topThreeShare: Float,
     averagePlaysPerTrack: Float,
@@ -2455,7 +2457,7 @@ private fun TrackDistributionStats(
 
 @Composable
 private fun TrackDistributionDonut(
-    slices: List<TrackShareSlice>,
+    slices: ImmutableList<TrackShareSlice>,
     totalDurationMs: Long,
     topThreeShare: Float,
     modifier: Modifier = Modifier

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/search/components/GenreCategoriesGrid.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/search/components/GenreCategoriesGrid.kt
@@ -53,11 +53,12 @@ import com.lostf1sh.pixelplayeross.ui.theme.LocalPixelPlayerDarkTheme
 import androidx.compose.ui.res.stringResource
 import com.lostf1sh.pixelplayeross.R
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import kotlinx.collections.immutable.ImmutableList
 
 @OptIn(UnstableApi::class)
 @Composable
 fun GenreCategoriesGrid(
-    genres: List<Genre>,
+    genres: ImmutableList<Genre>,
     onGenreClick: (Genre) -> Unit,
     playerViewModel: PlayerViewModel,
     modifier: Modifier = Modifier
@@ -135,7 +136,7 @@ fun GenreCategoriesGrid(
                 ) {
                 androidx.compose.material3.Icon(
                         imageVector = if (isGridView) Icons.AutoMirrored.Rounded.ViewList else Icons.Rounded.GridView,
-                        contentDescription = "Toggle Grid/List View"
+                        contentDescription = stringResource(R.string.cd_toggle_grid_list)
                     )
                 }
             }
@@ -225,7 +226,7 @@ private fun GenreCard(
             ) {
                 SmartImage(
                     model = GenreIconProvider.getGenreImageResource(genre.name, customIcons),
-                    contentDescription = "Genre illustration",
+                    contentDescription = stringResource(R.string.cd_genre_illustration),
                     modifier = Modifier
                         .fillMaxSize()
                         .alpha(0.55f),

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/AccountsViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/AccountsViewModel.kt
@@ -14,6 +14,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 enum class ExternalServiceAccount {
     NAVIDROME,
@@ -30,7 +33,7 @@ data class ExternalAccountUiModel(
 
 data class AccountsUiState(
     val connectedAccounts: List<ExternalAccountUiModel> = emptyList(),
-    val disconnectedServices: List<ExternalServiceAccount> = emptyList()
+    val disconnectedServices: ImmutableList<ExternalServiceAccount> = persistentListOf()
 )
 
 @HiltViewModel
@@ -111,7 +114,7 @@ class AccountsViewModel @Inject constructor(
 
         AccountsUiState(
             connectedAccounts = connectedAccounts,
-            disconnectedServices = disconnectedServices
+            disconnectedServices = disconnectedServices.toImmutableList()
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AccountsUiState())
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/DeviceCapabilitiesViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/DeviceCapabilitiesViewModel.kt
@@ -31,6 +31,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 data class CodecInfo(
     val name: String,
@@ -131,7 +134,7 @@ data class DeviceCapabilitiesState(
     val exoPlayerInfo: ExoPlayerInfo? = null,
     val storageSummary: LocalMusicStorageSummary? = null,
     val playbackCompatibility: PlaybackCompatibilitySummary? = null,
-    val formatSupport: List<FormatSupportInfo> = emptyList(),
+    val formatSupport: ImmutableList<FormatSupportInfo> = persistentListOf(),
     val memorySummary: MemorySummary? = null,
     val decoderInfo: ActiveDecoderInfo? = null,
     val isLoading: Boolean = true
@@ -176,7 +179,7 @@ class DeviceCapabilitiesViewModel @Inject constructor(
                     exoPlayerInfo = exoInfo,
                     storageSummary = storage,
                     playbackCompatibility = playback,
-                    formatSupport = formatSupport,
+                    formatSupport = formatSupport.toImmutableList(),
                     memorySummary = memorySummary,
                     decoderInfo = decoderInfo,
                     isLoading = false

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/EqualizerViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/EqualizerViewModel.kt
@@ -7,6 +7,7 @@ import com.lostf1sh.pixelplayeross.data.equalizer.EqualizerPreset
 import com.lostf1sh.pixelplayeross.data.preferences.EqualizerPreferencesRepository
 import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
 import com.lostf1sh.pixelplayeross.data.service.player.DualPlayerEngine
+import com.lostf1sh.pixelplayeross.di.AppScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -18,19 +19,20 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.math.roundToInt
 import kotlinx.serialization.json.Json // Added import
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 data class EqualizerUiState(
     val isEnabled: Boolean = false,
     val currentPreset: EqualizerPreset = EqualizerPreset.FLAT,
-    val bandLevels: List<Int> = List(10) { 0 },
+    val bandLevels: ImmutableList<Int> = List(10) { 0 }.toImmutableList(),
     val editingPresetName: String? = null,
     val bassBoostEnabled: Boolean = false,
     val bassBoostStrength: Float = 0f, // Changed to Float
@@ -45,23 +47,23 @@ data class EqualizerUiState(
     val isBassBoostDismissed: Boolean = false,
     val isVirtualizerDismissed: Boolean = false,
     val isLoudnessDismissed: Boolean = false,
-    val customPresets: List<EqualizerPreset> = emptyList(), // Added
-    val pinnedPresetsNames: List<String> = emptyList(), // Added
+    val customPresets: ImmutableList<EqualizerPreset> = persistentListOf(), // Added
+    val pinnedPresetsNames: ImmutableList<String> = persistentListOf(), // Added
 ) {
     // Computed property for accessible presets (Pinned)
-    val accessiblePresets: List<EqualizerPreset>
+    val accessiblePresets: ImmutableList<EqualizerPreset>
         get() {
             // Map pinned names to actual Presets (Default or Custom)
             return pinnedPresetsNames.mapNotNull { name ->
                 // First check custom presets
                 customPresets.find { it.name == name }
                     ?: EqualizerPreset.fromName(name) // Then standard defaults
-            }
+            }.toImmutableList()
         }
         
     // Computed property for All Available Presets (for Edit Sheet)
-    val allAvailablePresets: List<EqualizerPreset>
-        get() = EqualizerPreset.ALL_PRESETS + customPresets
+    val allAvailablePresets: ImmutableList<EqualizerPreset>
+        get() = (EqualizerPreset.ALL_PRESETS + customPresets).toImmutableList()
 }
 
 @HiltViewModel
@@ -69,6 +71,7 @@ class EqualizerViewModel @Inject constructor(
     private val equalizerManager: EqualizerManager,
     private val equalizerPreferencesRepository: EqualizerPreferencesRepository,
     private val dualPlayerEngine: DualPlayerEngine,
+    @param:AppScope private val appScope: CoroutineScope,
     @param:dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context
 ) : ViewModel() {
     
@@ -151,20 +154,24 @@ class EqualizerViewModel @Inject constructor(
             }
             
             // Update UI state with device capabilities
-            _uiState.value = _uiState.value.copy(
-                isBassBoostSupported = equalizerManager.isBassBoostSupported(),
-                isVirtualizerSupported = equalizerManager.isVirtualizerSupported(),
-                isLoudnessEnhancerSupported = equalizerManager.isLoudnessEnhancerSupported()
-            )
+            _uiState.update {
+                it.copy(
+                    isBassBoostSupported = equalizerManager.isBassBoostSupported(),
+                    isVirtualizerSupported = equalizerManager.isVirtualizerSupported(),
+                    isLoudnessEnhancerSupported = equalizerManager.isLoudnessEnhancerSupported()
+                )
+            }
 
             dualPlayerEngine.activeAudioSessionId.collect { sessionId ->
                 if (sessionId != 0) {
                     Timber.tag(TAG).d("Audio Session ID changed to $sessionId.")
-                    _uiState.value = _uiState.value.copy(
-                        isBassBoostSupported = equalizerManager.isBassBoostSupported(),
-                        isVirtualizerSupported = equalizerManager.isVirtualizerSupported(),
-                        isLoudnessEnhancerSupported = equalizerManager.isLoudnessEnhancerSupported()
-                    )
+                    _uiState.update {
+                        it.copy(
+                            isBassBoostSupported = equalizerManager.isBassBoostSupported(),
+                            isVirtualizerSupported = equalizerManager.isVirtualizerSupported(),
+                            isLoudnessEnhancerSupported = equalizerManager.isLoudnessEnhancerSupported()
+                        )
+                    }
                 }
             }
         }
@@ -219,7 +226,7 @@ class EqualizerViewModel @Inject constructor(
                 EqualizerUiState(
                     isEnabled = enabled,
                     currentPreset = currentPreset,
-                    bandLevels = if (currentPreset.name == "custom") customBands else currentPreset.bandLevels,
+                    bandLevels = (if (currentPreset.name == "custom") customBands else currentPreset.bandLevels).toImmutableList(),
                     editingPresetName = _uiState.value.editingPresetName,
                     bassBoostEnabled = bbEnabled,
                     bassBoostStrength = bbStrength.toFloat(), // Raw 0-1000
@@ -232,8 +239,8 @@ class EqualizerViewModel @Inject constructor(
                     isLoudnessDismissed = lDismissed,
                     viewMode = viewMode,
                     // New State
-                    customPresets = customPresets,
-                    pinnedPresetsNames = pinnedPresets,
+                    customPresets = customPresets.toImmutableList(),
+                    pinnedPresetsNames = pinnedPresets.toImmutableList(),
                     // Capabilities (Keep existing values)
                     isBassBoostSupported = _uiState.value.isBassBoostSupported,
                     isVirtualizerSupported = _uiState.value.isVirtualizerSupported,
@@ -278,7 +285,7 @@ class EqualizerViewModel @Inject constructor(
         _uiState.update { current ->
             current.copy(
                 currentPreset = preset,
-                bandLevels = preset.bandLevels,
+                bandLevels = preset.bandLevels.toImmutableList(),
                 editingPresetName = null
             )
         }
@@ -301,7 +308,7 @@ class EqualizerViewModel @Inject constructor(
                 ?: current.currentPreset.name.takeIf { current.currentPreset.isCustom && it != "custom" }
             current.copy(
                 currentPreset = EqualizerPreset.custom(updatedBands),
-                bandLevels = updatedBands,
+                bandLevels = updatedBands.toImmutableList(),
                 editingPresetName = editingName
             )
         }
@@ -487,7 +494,9 @@ class EqualizerViewModel @Inject constructor(
 
     private fun persistLatestStateAsync() {
         val latest = _uiState.value
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+        // Runs on the app scope: viewModelScope is already cancelled in onCleared,
+        // and this final flush must survive the ViewModel.
+        appScope.launch {
             runCatching {
                 equalizerPreferencesRepository.setEqualizerEnabled(latest.isEnabled)
                 equalizerPreferencesRepository.setEqualizerPreset(latest.currentPreset.name)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/FileExplorerStateHolder.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/FileExplorerStateHolder.kt
@@ -28,6 +28,9 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 data class DirectoryEntry(
     val file: File,
@@ -87,8 +90,8 @@ class FileExplorerStateHolder(
     private var rootCanonicalPath: String = normalizePath(visibleRoot)
 
     // Available storages (Internal, SD Card, USB)
-    private val _availableStorages = MutableStateFlow<List<StorageInfo>>(emptyList())
-    val availableStorages: StateFlow<List<StorageInfo>> = _availableStorages.asStateFlow()
+    private val _availableStorages = MutableStateFlow<ImmutableList<StorageInfo>>(persistentListOf())
+    val availableStorages: StateFlow<ImmutableList<StorageInfo>> = _availableStorages.asStateFlow()
 
     private val _selectedStorageIndex = MutableStateFlow(0)
     val selectedStorageIndex: StateFlow<Int> = _selectedStorageIndex.asStateFlow()
@@ -122,8 +125,8 @@ class FileExplorerStateHolder(
     val isCurrentDirectoryResolved: StateFlow<Boolean> = _isCurrentDirectoryResolved.asStateFlow()
 
     // Combined flow for UI consumption
-    private val _currentDirectoryChildren = MutableStateFlow<List<DirectoryEntry>>(emptyList())
-    val currentDirectoryChildren: StateFlow<List<DirectoryEntry>> = _currentDirectoryChildren.asStateFlow()
+    private val _currentDirectoryChildren = MutableStateFlow<ImmutableList<DirectoryEntry>>(persistentListOf())
+    val currentDirectoryChildren: StateFlow<ImmutableList<DirectoryEntry>> = _currentDirectoryChildren.asStateFlow()
 
     private val mapperDispatcher = Dispatchers.Default
     private val prefetchDispatcher = Dispatchers.IO.limitedParallelism(2)
@@ -179,13 +182,13 @@ class FileExplorerStateHolder(
             }
             .flowOn(mapperDispatcher)
             .onEach {
-                _currentDirectoryChildren.value = it
+                _currentDirectoryChildren.value = it.toImmutableList()
             }.launchIn(scope)
 
     }
 
     fun refreshAvailableStorages() {
-        _availableStorages.value = StorageUtils.getAvailableStorages(context)
+        _availableStorages.value = StorageUtils.getAvailableStorages(context).toImmutableList()
         // Ensure selected index is valid
         if (_selectedStorageIndex.value >= _availableStorages.value.size) {
             _selectedStorageIndex.value = 0

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/GenreDetailViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/GenreDetailViewModel.kt
@@ -10,10 +10,12 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.Dispatchers
+import com.lostf1sh.pixelplayeross.di.DispatcherProvider
 import javax.inject.Inject
 
 // --- Model Types for Sectioned Display ---
@@ -100,7 +102,8 @@ data class GenreDetailUiState(
 @HiltViewModel
 class GenreDetailViewModel @Inject constructor(
     private val musicRepository: MusicRepository,
-    private val savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle,
+    private val dispatchers: DispatcherProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(GenreDetailUiState())
@@ -113,7 +116,7 @@ class GenreDetailViewModel @Inject constructor(
             val decodedGenreId = java.net.URLDecoder.decode(genreId, "UTF-8")
             loadGenreDetails(decodedGenreId)
         } ?: run {
-            _uiState.value = _uiState.value.copy(error = "Genre ID not found", isLoadingGenreName = false, isLoadingSongs = false)
+            _uiState.update { it.copy(error = "Genre ID not found", isLoadingGenreName = false, isLoadingSongs = false) }
         }
     }
 
@@ -127,22 +130,22 @@ class GenreDetailViewModel @Inject constructor(
 
     private fun loadGenreDetails(genreId: String) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoadingGenreName = true, isLoadingSongs = true, error = null)
+            _uiState.update { it.copy(isLoadingGenreName = true, isLoadingSongs = true, error = null) }
 
             try {
                 // Step 1: Fast load of the Genre object to stabilize the UI theme as early as possible.
                 // This prevents a major recomposition (theme switch) mid-animation.
-                val initialGenre = withContext(Dispatchers.Default) {
+                val initialGenre = withContext(dispatchers.default) {
                     val genres = musicRepository.getGenres().first()
                     genres.find { it.id.equals(genreId, ignoreCase = true) }
                 }
                 
                 if (initialGenre != null) {
-                    _uiState.value = _uiState.value.copy(genre = initialGenre, isLoadingGenreName = false)
+                    _uiState.update { it.copy(genre = initialGenre, isLoadingGenreName = false) }
                 }
 
                 // Step 2: Heavy data processing for songs and sections
-                val result = withContext(Dispatchers.Default) {
+                val result = withContext(dispatchers.default) {
                     val genres = musicRepository.getGenres().first()
                     val genre = initialGenre ?: genres.find { it.id.equals(genreId, ignoreCase = true) }
                         ?: Genre(
@@ -163,21 +166,26 @@ class GenreDetailViewModel @Inject constructor(
                     ProcessingResult(genre, songs, sorted, sections, flattened)
                 }
 
-                _uiState.value = _uiState.value.copy(
-                    genre = result.genre,
-                    songs = result.songs,
-                    sortedSongs = result.sortedSongs,
-                    displaySections = result.sections,
-                    flattenedItems = result.flattened,
-                    isLoadingGenreName = false,
-                    isLoadingSongs = false
-                )
+                _uiState.update {
+                    it.copy(
+                        genre = result.genre,
+                        songs = result.songs,
+                        sortedSongs = result.sortedSongs,
+                        displaySections = result.sections,
+                        flattenedItems = result.flattened,
+                        isLoadingGenreName = false,
+                        isLoadingSongs = false
+                    )
+                }
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    error = "Failed to load genre details: ${e.message}",
-                    isLoadingGenreName = false,
-                    isLoadingSongs = false
-                )
+                if (e is CancellationException) throw e
+                _uiState.update {
+                    it.copy(
+                        error = "Failed to load genre details: ${e.message}",
+                        isLoadingGenreName = false,
+                        isLoadingSongs = false
+                    )
+                }
             }
         }
     }
@@ -190,8 +198,8 @@ class GenreDetailViewModel @Inject constructor(
         if (currentState.sortOption == newSort) return
 
         viewModelScope.launch {
-            _uiState.value = currentState.copy(isLoadingSongs = true)
-            val (updatedSections, updatedFlattened, updatedSorted) = withContext(Dispatchers.Default) {
+            _uiState.update { it.copy(isLoadingSongs = true) }
+            val (updatedSections, updatedFlattened, updatedSorted) = withContext(dispatchers.default) {
                 val sections = buildDisplaySections(currentState.songs, newSort)
                 val flattened = flattenSections(sections, artistMap)
                 val sorted = when (newSort) {
@@ -201,13 +209,15 @@ class GenreDetailViewModel @Inject constructor(
                 }
                 Triple(sections, flattened, sorted)
             }
-            _uiState.value = currentState.copy(
-                sortOption = newSort,
-                displaySections = updatedSections,
-                flattenedItems = updatedFlattened,
-                sortedSongs = updatedSorted,
-                isLoadingSongs = false
-            )
+            _uiState.update {
+                it.copy(
+                    sortOption = newSort,
+                    displaySections = updatedSections,
+                    flattenedItems = updatedFlattened,
+                    sortedSongs = updatedSorted,
+                    isLoadingSongs = false
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/LyricsSearchUiState.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/LyricsSearchUiState.kt
@@ -2,11 +2,12 @@ package com.lostf1sh.pixelplayeross.presentation.viewmodel
 
 import com.lostf1sh.pixelplayeross.data.model.Lyrics
 import com.lostf1sh.pixelplayeross.data.repository.LyricsSearchResult
+import kotlinx.collections.immutable.ImmutableList
 
 sealed interface LyricsSearchUiState {
     object Idle : LyricsSearchUiState
     object Loading : LyricsSearchUiState
-    data class PickResult(val query: String, val results: List<LyricsSearchResult>) : LyricsSearchUiState
+    data class PickResult(val query: String, val results: ImmutableList<LyricsSearchResult>) : LyricsSearchUiState
     data class Success(val lyrics: Lyrics) : LyricsSearchUiState
     data class NotFound(val message: String, val allowManualSearch: Boolean = true) : LyricsSearchUiState
     data class Error(val message: String, val query: String? = null) : LyricsSearchUiState

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/LyricsStateHolder.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/LyricsStateHolder.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * Callback interface for lyrics loading results.
@@ -228,7 +229,7 @@ class LyricsStateHolder @Inject constructor(
             if (forcePickResults) {
                 musicRepository.searchRemoteLyrics(song)
                     .onSuccess { (query, results) ->
-                        _searchUiState.value = LyricsSearchUiState.PickResult(query, results)
+                        _searchUiState.value = LyricsSearchUiState.PickResult(query, results.toImmutableList())
                     }
                     .onFailure { error ->
                         handleError(error)
@@ -246,7 +247,7 @@ class LyricsStateHolder @Inject constructor(
                             // Fallback to search
                             musicRepository.searchRemoteLyrics(song)
                                 .onSuccess { (query, results) ->
-                                    _searchUiState.value = LyricsSearchUiState.PickResult(query, results)
+                                    _searchUiState.value = LyricsSearchUiState.PickResult(query, results.toImmutableList())
                                 }
                                 .onFailure { searchError -> handleError(searchError) }
                         } else {
@@ -267,7 +268,7 @@ class LyricsStateHolder @Inject constructor(
             _searchUiState.value = LyricsSearchUiState.Loading
             musicRepository.searchRemoteLyricsByQuery(title, artist)
                 .onSuccess { (q, results) ->
-                    _searchUiState.value = LyricsSearchUiState.PickResult(q, results)
+                    _searchUiState.value = LyricsSearchUiState.PickResult(q, results.toImmutableList())
                 }
                 .onFailure { error -> handleError(error) }
         }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/MultiSelectionStateHolder.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/MultiSelectionStateHolder.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * State holder for multi-selection functionality in LibraryScreen tabs.
@@ -23,12 +26,12 @@ class MultiSelectionStateHolder @Inject constructor() {
 
     // Internal mutable state - uses List to preserve selection order
     // LinkedHashSet behavior is enforced via toggle logic
-    private val _selectedSongs = MutableStateFlow<List<Song>>(emptyList())
+    private val _selectedSongs = MutableStateFlow<ImmutableList<Song>>(persistentListOf())
     
     /**
      * Immutable flow of selected songs, preserving selection order.
      */
-    val selectedSongs: StateFlow<List<Song>> = _selectedSongs.asStateFlow()
+    val selectedSongs: StateFlow<ImmutableList<Song>> = _selectedSongs.asStateFlow()
     
     /**
      * Set of selected song IDs for efficient lookup.
@@ -126,7 +129,7 @@ class MultiSelectionStateHolder @Inject constructor() {
      * Updates all state flows atomically.
      */
     private fun updateState(songs: List<Song>, ids: Set<String>) {
-        _selectedSongs.value = songs
+        _selectedSongs.value = songs.toImmutableList()
         _selectedSongIds.value = ids
         _selectedCount.value = songs.size
         _isSelectionMode.value = songs.isNotEmpty()

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
@@ -288,7 +288,9 @@ class PlayerViewModel @Inject constructor(
         .distinctUntilChanged()
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.Eagerly,
+            // WhileSubscribed: upstream ticks on every playback position update, so keeping
+            // this hot with no UI attached (widget-only playback) is pure wasted work.
+            started = SharingStarted.WhileSubscribed(5000),
             initialValue = persistentListOf()
         )
 
@@ -368,15 +370,15 @@ class PlayerViewModel @Inject constructor(
         .cachedIn(viewModelScope)
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val currentSongArtists: StateFlow<List<Artist>> = stablePlayerState
+    val currentSongArtists: StateFlow<ImmutableList<Artist>> = stablePlayerState
         .map { it.currentSong?.id }
         .distinctUntilChanged()
         .flatMapLatest { songId ->
             val idLong = songId?.toLongOrNull()
-            if (idLong == null) flowOf(emptyList())
-            else musicRepository.getArtistsForSong(idLong)
+            if (idLong == null) flowOf<ImmutableList<Artist>>(persistentListOf())
+            else musicRepository.getArtistsForSong(idLong).map { it.toImmutableList() }
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), persistentListOf())
 
     private val _sheetState = MutableStateFlow(PlayerSheetState.COLLAPSED)
     val sheetState: StateFlow<PlayerSheetState> = _sheetState.asStateFlow()
@@ -959,19 +961,19 @@ class PlayerViewModel @Inject constructor(
             initialValue = 0 // Default to Songs tab
         )
 
-    val libraryTabsFlow: StateFlow<List<String>> = userPreferencesRepository.libraryTabsOrderFlow
+    val libraryTabsFlow: StateFlow<ImmutableList<String>> = userPreferencesRepository.libraryTabsOrderFlow
         .map { orderJson ->
             if (orderJson != null) {
                 try {
-                    Json.decodeFromString<List<String>>(orderJson)
+                    Json.decodeFromString<List<String>>(orderJson).toImmutableList()
                 } catch (e: Exception) {
-                    listOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED")
+                    persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED")
                 }
             } else {
-                listOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED")
+                persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED")
             }
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED"))
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED"))
 
     private val _loadedTabs = MutableStateFlow(emptySet<String>())
     private var lastBlockedDirectories: Set<String>? = null
@@ -1133,7 +1135,7 @@ class PlayerViewModel @Inject constructor(
     // composable. Now a single collect + distinctUntilChanged batches all settings.
     // ---------------------------------------------------------------------------
     data class FullPlayerSlice(
-        val currentSongArtists: List<Artist> = emptyList(),
+        val currentSongArtists: ImmutableList<Artist> = persistentListOf(),
         val lyricsSyncOffset: Int = 0,
         val albumArtQuality: AlbumArtQuality = AlbumArtQuality.MEDIUM,
         val audioMetadata: PlaybackAudioMetadata = PlaybackAudioMetadata(),
@@ -1152,7 +1154,7 @@ class PlayerViewModel @Inject constructor(
         albumArtQuality,
         playbackAudioMetadata,
         showPlayerFileInfo
-    ) { artists: List<Artist>, syncOffset: Int, artQuality: AlbumArtQuality,
+    ) { artists: ImmutableList<Artist>, syncOffset: Int, artQuality: AlbumArtQuality,
         audioMeta: PlaybackAudioMetadata, showFileInfo: Boolean ->
         FullPlayerSlicePart1(artists, syncOffset, artQuality, audioMeta, showFileInfo)
     }
@@ -1174,7 +1176,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     private data class FullPlayerSlicePart1(
-        val currentSongArtists: List<Artist>,
+        val currentSongArtists: ImmutableList<Artist>,
         val lyricsSyncOffset: Int,
         val albumArtQuality: AlbumArtQuality,
         val audioMetadata: PlaybackAudioMetadata,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaylistSelectionStateHolder.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaylistSelectionStateHolder.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * State holder for multi-selection functionality for playlists in LibraryScreen.
@@ -18,12 +21,12 @@ import javax.inject.Singleton
 class PlaylistSelectionStateHolder @Inject constructor() {
 
     // Internal mutable state - uses List to preserve selection order
-    private val _selectedPlaylists = MutableStateFlow<List<Playlist>>(emptyList())
+    private val _selectedPlaylists = MutableStateFlow<ImmutableList<Playlist>>(persistentListOf())
     
     /**
      * Immutable flow of selected playlists, preserving selection order.
      */
-    val selectedPlaylists: StateFlow<List<Playlist>> = _selectedPlaylists.asStateFlow()
+    val selectedPlaylists: StateFlow<ImmutableList<Playlist>> = _selectedPlaylists.asStateFlow()
     
     /**
      * Set of selected playlist IDs for efficient lookup.
@@ -121,7 +124,7 @@ class PlaylistSelectionStateHolder @Inject constructor() {
      * Updates all state flows atomically.
      */
     private fun updateState(playlists: List<Playlist>, ids: Set<String>) {
-        _selectedPlaylists.value = playlists
+        _selectedPlaylists.value = playlists.toImmutableList()
         _selectedPlaylistIds.value = ids
         _selectedCount.value = playlists.size
         _isSelectionMode.value = playlists.isNotEmpty()

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlaylistViewModel.kt
@@ -44,9 +44,12 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import timber.log.Timber
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 data class PlaylistUiState(
-    val playlists: List<Playlist> = emptyList(),
+    val playlists: ImmutableList<Playlist> = persistentListOf(),
     val currentPlaylistSongs: List<Song> = emptyList(),
     val currentPlaylistDetails: Playlist? = null,
     val isLoading: Boolean = false,
@@ -131,7 +134,7 @@ class PlaylistViewModel @Inject constructor(
                 val currentSortOption =
                     _uiState.value.currentPlaylistSortOption // Use the most up-to-date sort option
                 val sortedPlaylists = sortPlaylistsList(playlists, currentSortOption)
-                _uiState.update { it.copy(playlists = sortedPlaylists) }
+                _uiState.update { it.copy(playlists = sortedPlaylists.toImmutableList()) }
             }
         }
         // Collect subsequent changes to sort option from preferences
@@ -687,7 +690,7 @@ class PlaylistViewModel @Inject constructor(
         val currentPlaylists = _uiState.value.playlists
         val sortedPlaylists = sortPlaylistsList(currentPlaylists, sortOption)
 
-        _uiState.update { it.copy(playlists = sortedPlaylists) }
+        _uiState.update { it.copy(playlists = sortedPlaylists.toImmutableList()) }
 
         viewModelScope.launch {
             playlistPreferencesRepository.setPlaylistsSortOption(sortOption.storageKey)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SettingsViewModel.kt
@@ -30,6 +30,7 @@ import com.lostf1sh.pixelplayeross.data.worker.SyncManager
 import com.lostf1sh.pixelplayeross.data.worker.SyncProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -43,6 +44,9 @@ import com.lostf1sh.pixelplayeross.data.preferences.LaunchTab
 import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.data.service.player.HiFiCapabilityChecker
 import java.io.File
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 data class SettingsUiState(
     val isLoadingDirectories: Boolean = false,
@@ -87,7 +91,7 @@ data class SettingsUiState(
     val backupInfoDismissed: Boolean = false,
     val isDataTransferInProgress: Boolean = false,
     val restorePlan: RestorePlan? = null,
-    val backupHistory: List<BackupHistoryEntry> = emptyList(),
+    val backupHistory: ImmutableList<BackupHistoryEntry> = persistentListOf(),
     val backupValidationErrors: List<ValidationError> = emptyList(),
     val isInspectingBackup: Boolean = false,
     val collagePattern: CollagePattern = CollagePattern.default,
@@ -200,13 +204,15 @@ class SettingsViewModel @Inject constructor(
             initialValue = SyncProgress()
         )
 
-    private val _dataTransferEvents = MutableSharedFlow<String>()
-    val dataTransferEvents: SharedFlow<String> = _dataTransferEvents.asSharedFlow()
+    // Channel instead of SharedFlow: backup/restore results must survive the window
+    // where the collector is torn down (config change, backstack) and re-subscribes.
+    private val _dataTransferEvents = Channel<String>(Channel.BUFFERED)
+    val dataTransferEvents: Flow<String> = _dataTransferEvents.receiveAsFlow()
 
     init {
         viewModelScope.launch {
             backupManager.getBackupHistory().collect { history ->
-                _uiState.update { it.copy(backupHistory = history) }
+                _uiState.update { it.copy(backupHistory = history.toImmutableList()) }
             }
         }
 
@@ -895,9 +901,9 @@ class SettingsViewModel @Inject constructor(
                 _dataTransferProgress.value = progress
             }
             result.fold(
-                onSuccess = { _dataTransferEvents.emit(context.getString(R.string.data_exported_successfully)) },
+                onSuccess = { _dataTransferEvents.send(context.getString(R.string.data_exported_successfully)) },
                 onFailure = {
-                    _dataTransferEvents.emit(
+                    _dataTransferEvents.send(
                         context.getString(
                             R.string.export_failed_format,
                             it.localizedMessage ?: context.getString(R.string.error_unknown),
@@ -921,7 +927,7 @@ class SettingsViewModel @Inject constructor(
                     _uiState.update { it.copy(restorePlan = plan, isInspectingBackup = false) }
                 },
                 onFailure = { error ->
-                    _dataTransferEvents.emit(
+                    _dataTransferEvents.send(
                         context.getString(
                             R.string.backup_invalid_format,
                             error.localizedMessage ?: context.getString(R.string.error_unknown),
@@ -958,12 +964,12 @@ class SettingsViewModel @Inject constructor(
             }
             when (result) {
                 is RestoreResult.Success -> {
-                    _dataTransferEvents.emit(context.getString(R.string.data_restored_successfully))
+                    _dataTransferEvents.send(context.getString(R.string.data_restored_successfully))
                     syncManager.sync()
                 }
                 is RestoreResult.PartialFailure -> {
                     val failedNames = result.failed.entries.joinToString { "${it.key.label}: ${it.value}" }
-                    _dataTransferEvents.emit(
+                    _dataTransferEvents.send(
                         context.getString(R.string.restore_partial_unresolved_format, failedNames),
                     )
                     if (result.succeeded.isNotEmpty() || !result.rolledBack) {
@@ -971,7 +977,7 @@ class SettingsViewModel @Inject constructor(
                     }
                 }
                 is RestoreResult.TotalFailure -> {
-                    _dataTransferEvents.emit(context.getString(R.string.restore_failed_format, result.error))
+                    _dataTransferEvents.send(context.getString(R.string.restore_failed_format, result.error))
                 }
             }
             delay(300)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SetupViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SetupViewModel.kt
@@ -22,10 +22,10 @@ import com.lostf1sh.pixelplayeross.data.repository.MusicRepository
 import com.lostf1sh.pixelplayeross.data.worker.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -76,8 +76,10 @@ class SetupViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(SetupUiState())
     val uiState = _uiState.asStateFlow()
-    private val _events = MutableSharedFlow<SetupEvent>()
-    val events = _events.asSharedFlow()
+    // Channel instead of SharedFlow: RestoreCompleted drives navigation, so an event
+    // emitted while the collector is being re-created (config change) must not be lost.
+    private val _events = Channel<SetupEvent>(Channel.BUFFERED)
+    val events = _events.receiveAsFlow()
     
     /**
      * Expose sync progress for UI to show during initial setup
@@ -326,7 +328,7 @@ class SetupViewModel @Inject constructor(
                 },
                 onFailure = { error ->
                     _uiState.update { it.copy(isInspectingBackup = false) }
-                    _events.emit(
+                    _events.send(
                         SetupEvent.Message(
                             context.getString(
                                 R.string.backup_invalid_format,
@@ -382,18 +384,18 @@ class SetupViewModel @Inject constructor(
 
             when (result) {
                 is RestoreResult.Success -> {
-                    _events.emit(SetupEvent.RestoreCompleted(context.getString(R.string.restore_completed_success)))
+                    _events.send(SetupEvent.RestoreCompleted(context.getString(R.string.restore_completed_success)))
                 }
                 is RestoreResult.PartialFailure -> {
                     val canFinishSetup = result.succeeded.isNotEmpty() || !result.rolledBack
                     if (canFinishSetup) {
-                        _events.emit(
+                        _events.send(
                             SetupEvent.RestoreCompleted(
                                 context.getString(R.string.restore_completed_partial_issues),
                             )
                         )
                     } else {
-                        _events.emit(
+                        _events.send(
                             SetupEvent.Message(
                                 context.getString(
                                     R.string.restore_could_not_complete,
@@ -404,7 +406,7 @@ class SetupViewModel @Inject constructor(
                     }
                 }
                 is RestoreResult.TotalFailure -> {
-                    _events.emit(SetupEvent.Message(context.getString(R.string.restore_failed_format, result.error)))
+                    _events.send(SetupEvent.Message(context.getString(R.string.restore_failed_format, result.error)))
                 }
             }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
@@ -31,6 +31,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @HiltViewModel
 class SongInfoBottomSheetViewModel @Inject constructor(
@@ -57,15 +60,15 @@ class SongInfoBottomSheetViewModel @Inject constructor(
     }
 
     private val _audioMeta = MutableStateFlow<AudioMeta?>(null)
-    private val _resolvedArtists = MutableStateFlow<List<Artist>>(emptyList())
-    val resolvedArtists: StateFlow<List<Artist>> = _resolvedArtists.asStateFlow()
+    private val _resolvedArtists = MutableStateFlow<ImmutableList<Artist>>(persistentListOf())
+    val resolvedArtists: StateFlow<ImmutableList<Artist>> = _resolvedArtists.asStateFlow()
 
     val audioMeta: StateFlow<AudioMeta?> = _audioMeta.asStateFlow()
 
     fun loadArtistsForSong(song: Song) {
         val refs = song.artists
         if (refs.isEmpty() || refs.size < 2) {
-            _resolvedArtists.value = emptyList()
+            _resolvedArtists.value = persistentListOf()
             return
         }
         viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
@@ -79,7 +82,7 @@ class SongInfoBottomSheetViewModel @Inject constructor(
                 entitiesById[ref.id]?.toArtist()
                     ?: Artist(id = ref.id, name = ref.name, songCount = 0)
             }
-            _resolvedArtists.value = resolved
+            _resolvedArtists.value = resolved.toImmutableList()
         }
     }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/StatsViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/StatsViewModel.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @HiltViewModel
 class StatsViewModel @Inject constructor(
@@ -31,7 +33,7 @@ class StatsViewModel @Inject constructor(
         val isLoading: Boolean = true,
         val isRefreshing: Boolean = false,
         val summary: PlaybackStatsSummary? = null,
-        val availableRanges: List<StatsTimeRange> = StatsTimeRange.entries
+        val availableRanges: ImmutableList<StatsTimeRange> = StatsTimeRange.entries.toImmutableList()
     )
 
     private val _uiState = MutableStateFlow(StatsUiState())

--- a/app/src/main/res/values/strings_components.xml
+++ b/app/src/main/res/values/strings_components.xml
@@ -3,6 +3,10 @@
     <string name="widget_tap_to_open">Tap to open</string>
     <string name="widget_album_art">Album art</string>
     <string name="widget_album_art_placeholder">Album art placeholder</string>
+    <string name="cd_album_art_of">Album art of %1$s</string>
+    <string name="cd_album_art_placeholder">%1$s placeholder</string>
+    <string name="cd_show_controls">Show controls</string>
+    <string name="cd_cover_art">Cover art</string>
     <string name="cd_favorite">Favorite</string>
     <string name="cd_play">Play</string>
     <string name="cd_pause">Pause</string>

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -251,4 +251,10 @@
     <string name="toast_added_to_queue">Added to queue</string>
     <string name="toast_playing_next">Playing next</string>
     <string name="error_share_song_format">Could not share song: %1$s</string>
+    <string name="cd_artist_format">Artist: %1$s</string>
+    <string name="cd_play_artist">Play artist</string>
+    <string name="cd_play_playlist">Play playlist</string>
+    <string name="cd_toggle_grid_list">Toggle grid/list view</string>
+    <string name="cd_genre_illustration">Genre illustration</string>
+    <string name="dash_last_synced_format">Last synced: %1$s</string>
 </resources>


### PR DESCRIPTION
Broad code-quality pass over the coroutine, Flow, and Compose layers. No feature changes.

## Structured concurrency
- **CancellationException is rethrown** from every broad `catch` wrapping suspend work in `NavidromeRepository`, `JellyfinRepository`, and both stream proxies (25 sites) — cancellation no longer gets swallowed as a "network error" during rapid track skips or screen exits.
- `DailyMixManager` no longer owns an ad-hoc scope with an `init { launch }` migration; legacy `song_scores.json` migration now runs lazily behind a mutex on first read.
- `SyncManager` observation starts via an explicit `start()` from `PixelPlayerApplication.onCreate` instead of side-effectful `init`.
- `EqualizerViewModel` persists its final state through the injected `@AppScope` (safe from `onCleared`).
- New `DispatcherProvider` abstraction (Hilt-bound) replaces hardcoded `Dispatchers.*` in touched call sites — makes these paths unit-testable.

## Flow/event modeling
- One-shot UI events in `SettingsViewModel`/`SetupViewModel` moved from lossy `MutableSharedFlow` to `Channel(BUFFERED).receiveAsFlow()` — events emitted with no collector (e.g. during config change) are no longer dropped; `SetupEvent.RestoreCompleted` drives navigation and must never be lost.
- `.value = .value.copy(...)` mutations converted to atomic `.update {}`.
- Event flows collected with `repeatOnLifecycle(STARTED)` so collection stops in background.
- `PlayerViewModel.queueFlow` downgraded from `SharingStarted.Eagerly` to `WhileSubscribed(5000)`; the remaining `Eagerly` sites were audited and are justified (synchronous `.value` reads / cold-start flash prevention), now documented in place.

## Compose
- `List<T>` → `ImmutableList<T>` on ~84 `@Composable` params across ~40 files for strong-skipping.
- Theme-derived gradient color lists in Search/Library are `remember`-keyed instead of rebuilt every recomposition.
- 18 hardcoded `contentDescription`/text strings moved to `strings*.xml` (new `cd_*` entries).

## Verification
`:app:compileDebugKotlin`, `:app:testDebugUnitTest`, and `:app:lintDebug` all green.

