### PR TITLE
Fix local Jellyfin connections on Android 17

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Required at runtime for direct LAN connections when targeting Android 17+. -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/jellyfin/model/JellyfinCredentials.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/jellyfin/model/JellyfinCredentials.kt
@@ -47,6 +47,10 @@ data class JellyfinCredentials(
     val normalizedServerUrl: String
         get() = normalizedHttpUrlOrNull?.toString()?.trimEnd('/') ?: serverUrl.trim().trimEnd('/')
 
+    /** Whether Android 17's local-network runtime permission is needed for this server. */
+    val requiresLocalNetworkAccess: Boolean
+        get() = normalizedHttpUrlOrNull?.host?.let(CloudStreamSecurity::isLocalServerHost) == true
+
     fun connectionValidationError(): String? {
         val parsed = normalizedHttpUrlOrNull
             ?: return "Invalid server URL format"
@@ -66,12 +70,6 @@ data class JellyfinCredentials(
         return null
     }
 
-    private fun isHttpAllowedHost(host: String): Boolean {
-        return host == "localhost" ||
-                host == "127.0.0.1" ||
-                host.endsWith(".local") ||
-                host.endsWith(".ts.net") ||
-                !host.contains('.') ||
-                CloudStreamSecurity.isPrivateIpv4Literal(host)
-    }
+    private fun isHttpAllowedHost(host: String): Boolean =
+        CloudStreamSecurity.isLocalServerHost(host)
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentials.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentials.kt
@@ -57,6 +57,10 @@ data class NavidromeCredentials(
     val normalizedServerUrl: String
         get() = normalizedHttpUrlOrNull?.toString()?.trimEnd('/') ?: serverUrl.trim().trimEnd('/')
 
+    /** Whether Android 17's local-network runtime permission is needed for this server. */
+    val requiresLocalNetworkAccess: Boolean
+        get() = normalizedHttpUrlOrNull?.host?.let(CloudStreamSecurity::isLocalServerHost) == true
+
     /**
      * Returns a validation error for connection setup, or null when the URL is acceptable.
      */
@@ -74,12 +78,6 @@ data class NavidromeCredentials(
         return null
     }
 
-    private fun isHttpAllowedHost(host: String): Boolean {
-        return host == "localhost" ||
-            host == "127.0.0.1" ||
-            host.endsWith(".local") ||
-            host.endsWith(".ts.net") ||
-            !host.contains('.') ||
-            CloudStreamSecurity.isPrivateIpv4Literal(host)
-    }
+    private fun isHttpAllowedHost(host: String): Boolean =
+        CloudStreamSecurity.isLocalServerHost(host)
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/stream/CloudStreamSecurity.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/stream/CloudStreamSecurity.kt
@@ -160,6 +160,22 @@ object CloudStreamSecurity {
         }
     }
 
+    /**
+     * Hosts that can reasonably identify a self-hosted server reached over the local network or a VPN.
+     * `.lan` is commonly assigned by home routers; `.home.arpa` is the reserved home-network suffix.
+     */
+    internal fun isLocalServerHost(host: String): Boolean {
+        val normalized = host.lowercase()
+        return normalized == "localhost" ||
+            normalized == "127.0.0.1" ||
+            normalized.endsWith(".local") ||
+            normalized.endsWith(".lan") ||
+            normalized.endsWith(".home.arpa") ||
+            normalized.endsWith(".ts.net") ||
+            !normalized.contains('.') ||
+            isPrivateIpv4Literal(normalized)
+    }
+
     /** Used by login-time server-URL validation to decide whether cleartext HTTP is acceptable. */
     internal fun isPrivateIpv4Literal(host: String): Boolean {
         val parts = host.split('.')

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/jellyfin/auth/JellyfinLoginActivity.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/jellyfin/auth/JellyfinLoginActivity.kt
@@ -1,9 +1,14 @@
 package com.lostf1sh.pixelplayeross.presentation.jellyfin.auth
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -70,9 +75,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.data.jellyfin.model.JellyfinCredentials
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import com.lostf1sh.pixelplayeross.ui.theme.PixelPlayerTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -107,6 +114,31 @@ fun JellyfinLoginScreen(
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var passwordVisible by remember { mutableStateOf(false) }
+    var pendingLocalNetworkLogin by remember {
+        mutableStateOf<Triple<String, String, String>?>(null)
+    }
+    var localNetworkPermissionDenied by remember { mutableStateOf(false) }
+
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        val pendingLogin = pendingLocalNetworkLogin
+        pendingLocalNetworkLogin = null
+        if (granted && pendingLogin != null) {
+            viewModel.login(pendingLogin.first, pendingLogin.second, pendingLogin.third)
+        } else if (!granted) {
+            localNetworkPermissionDenied = true
+        }
+    }
+
+    LaunchedEffect(localNetworkPermissionDenied) {
+        if (localNetworkPermissionDenied) {
+            snackbarHostState.showSnackbar(
+                context.getString(R.string.auth_local_network_permission_denied)
+            )
+            localNetworkPermissionDenied = false
+        }
+    }
 
     LaunchedEffect(loginState) {
         when (val state = loginState) {
@@ -128,6 +160,23 @@ fun JellyfinLoginScreen(
 
     val isLoading = loginState is JellyfinLoginState.Loading
     val inputShape = AbsoluteSmoothCornerShape(18.dp, 60)
+    val connect = {
+        focusManager.clearFocus()
+        val credentials = JellyfinCredentials(serverUrl, username, password)
+        val permissionMissing = Build.VERSION.SDK_INT >= 37 &&
+            credentials.requiresLocalNetworkAccess &&
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_LOCAL_NETWORK
+            ) != PackageManager.PERMISSION_GRANTED
+
+        if (permissionMissing) {
+            pendingLocalNetworkLogin = Triple(serverUrl, username, password)
+            localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+        } else {
+            viewModel.login(serverUrl, username, password)
+        }
+    }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -321,9 +370,8 @@ fun JellyfinLoginScreen(
                         ),
                         keyboardActions = KeyboardActions(
                             onDone = {
-                                focusManager.clearFocus()
                                 if (serverUrl.isNotBlank() && username.isNotBlank() && password.isNotBlank()) {
-                                    viewModel.login(serverUrl, username, password)
+                                    connect()
                                 }
                             }
                         ),
@@ -372,10 +420,7 @@ fun JellyfinLoginScreen(
 
             // Login Button
             Button(
-                onClick = {
-                    focusManager.clearFocus()
-                    viewModel.login(serverUrl, username, password)
-                },
+                onClick = connect,
                 enabled = !isLoading && serverUrl.isNotBlank() && username.isNotBlank() && password.isNotBlank(),
                 shape = AbsoluteSmoothCornerShape(18.dp, 60),
                 modifier = Modifier

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/auth/NavidromeLoginActivity.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navidrome/auth/NavidromeLoginActivity.kt
@@ -1,9 +1,14 @@
 package com.lostf1sh.pixelplayeross.presentation.navidrome.auth
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -67,12 +72,14 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeCredentials
 import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
 import com.lostf1sh.pixelplayeross.ui.theme.PixelPlayerTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -107,6 +114,31 @@ fun NavidromeLoginScreen(
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var passwordVisible by remember { mutableStateOf(false) }
+    var pendingLocalNetworkLogin by remember {
+        mutableStateOf<Triple<String, String, String>?>(null)
+    }
+    var localNetworkPermissionDenied by remember { mutableStateOf(false) }
+
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        val pendingLogin = pendingLocalNetworkLogin
+        pendingLocalNetworkLogin = null
+        if (granted && pendingLogin != null) {
+            viewModel.login(pendingLogin.first, pendingLogin.second, pendingLogin.third)
+        } else if (!granted) {
+            localNetworkPermissionDenied = true
+        }
+    }
+
+    LaunchedEffect(localNetworkPermissionDenied) {
+        if (localNetworkPermissionDenied) {
+            snackbarHostState.showSnackbar(
+                context.getString(R.string.auth_local_network_permission_denied)
+            )
+            localNetworkPermissionDenied = false
+        }
+    }
 
     LaunchedEffect(loginState) {
         when (val state = loginState) {
@@ -128,6 +160,23 @@ fun NavidromeLoginScreen(
 
     val isLoading = loginState is NavidromeLoginState.Loading
     val inputShape = AbsoluteSmoothCornerShape(18.dp, 60)
+    val connect = {
+        focusManager.clearFocus()
+        val credentials = NavidromeCredentials(serverUrl, username, password)
+        val permissionMissing = Build.VERSION.SDK_INT >= 37 &&
+            credentials.requiresLocalNetworkAccess &&
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_LOCAL_NETWORK
+            ) != PackageManager.PERMISSION_GRANTED
+
+        if (permissionMissing) {
+            pendingLocalNetworkLogin = Triple(serverUrl, username, password)
+            localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+        } else {
+            viewModel.login(serverUrl, username, password)
+        }
+    }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -342,9 +391,8 @@ fun NavidromeLoginScreen(
                         ),
                         keyboardActions = KeyboardActions(
                             onDone = {
-                                focusManager.clearFocus()
                                 if (serverUrl.isNotBlank() && username.isNotBlank() && password.isNotBlank()) {
-                                    viewModel.login(serverUrl, username, password)
+                                    connect()
                                 }
                             }
                         ),
@@ -389,10 +437,7 @@ fun NavidromeLoginScreen(
 
             // Login Button
             Button(
-                onClick = {
-                    focusManager.clearFocus()
-                    viewModel.login(serverUrl, username, password)
-                },
+                onClick = connect,
                 enabled = !isLoading && serverUrl.isNotBlank() && username.isNotBlank() && password.isNotBlank(),
                 shape = AbsoluteSmoothCornerShape(18.dp, 60),
                 modifier = Modifier

--- a/app/src/main/res/values/strings_auth.xml
+++ b/app/src/main/res/values/strings_auth.xml
@@ -14,6 +14,7 @@
     <string name="auth_password_placeholder">Enter password</string>
     <string name="auth_username_placeholder_admin">admin</string>
     <string name="toast_welcome_user">Welcome, %1$s!</string>
+    <string name="auth_local_network_permission_denied">Allow nearby devices access to connect to a server on your local network.</string>
 
     <!-- Navidrome / Subsonic -->
     <string name="auth_navidrome_title">Subsonic / Navidrome</string>
@@ -35,7 +36,7 @@
     <string name="auth_jellyfin_subtitle">Connect to your Jellyfin media server</string>
     <string name="auth_jellyfin_connection_subtitle">Enter your Jellyfin server URL and account credentials.</string>
     <string name="auth_jellyfin_server_placeholder">http://192.168.1.100:8096</string>
-    <string name="auth_jellyfin_server_url_hint">Full URL including port. Local, Tailscale, and .local addresses can use HTTP.</string>
+    <string name="auth_jellyfin_server_url_hint">Full URL including port. Local, Tailscale, .local, and .lan addresses can use HTTP.</string>
     <string name="auth_jellyfin_username_hint">Your Jellyfin account username.</string>
     <string name="auth_jellyfin_password_hint">Your Jellyfin account password.</string>
     <string name="auth_jellyfin_footer">Connects to Jellyfin servers for streaming your music library</string>

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/jellyfin/model/JellyfinCredentialsTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/jellyfin/model/JellyfinCredentialsTest.kt
@@ -35,10 +35,24 @@ class JellyfinCredentialsTest {
             "http://100.64.12.34:8096",
             "http://musicbox:8096",
             "http://media.local",
+            "http://jellyfin.lan:8096",
+            "http://media.home.arpa:8096",
             "http://jellyfin.tailnet.ts.net:8096",
         ).forEach { url ->
             assertNull(creds(url).connectionValidationError(), "expected $url to be allowed over http")
         }
+    }
+
+    @Test
+    fun `local addresses require local network access`() {
+        listOf(
+            "http://192.168.1.50:8096",
+            "http://jellyfin.lan:8096",
+            "https://media.home.arpa:8096"
+        ).forEach { url ->
+            assertTrue(creds(url).requiresLocalNetworkAccess, "$url should require LAN access")
+        }
+        assertFalse(creds("https://jellyfin.example.com").requiresLocalNetworkAccess)
     }
 
     @Test
@@ -79,6 +93,7 @@ class JellyfinCredentialsTest {
             "192.168.1.50:8096/" to "http://192.168.1.50:8096",
             "100.64.12.34:8096/" to "http://100.64.12.34:8096",
             "jellyfin.tailnet.ts.net:8096/" to "http://jellyfin.tailnet.ts.net:8096",
+            "jellyfin.lan:8096/" to "http://jellyfin.lan:8096",
             "musicbox:8096/" to "http://musicbox:8096"
         ).forEach { (input, expected) ->
             assertEquals(expected, creds(input).normalizedServerUrl)

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentialsTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentialsTest.kt
@@ -1,7 +1,9 @@
 package com.lostf1sh.pixelplayeross.data.navidrome.model
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class NavidromeCredentialsTest {
@@ -30,6 +32,20 @@ class NavidromeCredentialsTest {
         assertEquals(
             "http://192.168.1.20:4533",
             credentials.normalizedServerUrl
+        )
+    }
+
+    @Test
+    fun `connectionValidationError accepts local dns suffixes`() {
+        listOf("jellyfin.lan", "media.local", "music.home.arpa").forEach { host ->
+            val credentials = NavidromeCredentials("http://$host:4533", "user", "pass")
+
+            assertNull(credentials.connectionValidationError())
+            assertTrue(credentials.requiresLocalNetworkAccess)
+        }
+        assertFalse(
+            NavidromeCredentials("https://music.example.com", "user", "pass")
+                .requiresLocalNetworkAccess
         )
     }
 


### PR DESCRIPTION
This should stop local Jellyfin connections from timing out on Android 17. It also makes addresses like jellyfin.lan work the way people expect.

Fixes #43