### PR TITLE
Keep external audio effects attached across player rebuilds

### DIFF
--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/equalizer/ExternalAudioEffectSession.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/equalizer/ExternalAudioEffectSession.kt
@@ -1,0 +1,77 @@
+package com.lostf1sh.pixelplayeross.data.equalizer
+
+import android.content.Context
+import android.content.Intent
+import android.media.audiofx.AudioEffect
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Announces the player's audio session to external audio effect apps
+ * (ViPER4Android, JamesDSP, Wavelet, the OEM "audio effects" panel, ...).
+ *
+ * Those apps do not process an app's output unless they are told which audio session to attach
+ * to: they listen for [AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION] and create their own
+ * effect on the session id carried by the broadcast. Without it our output is either untouched or
+ * only incidentally processed, which is exactly the "V4A does nothing until I enable the built-in
+ * equalizer" symptom — attaching *any* effect to the session is what pulled the track off the
+ * offloaded output where system effects are bypassed.
+ *
+ * Both actions are on Android's implicit-broadcast exemption list, so manifest-declared receivers
+ * in those apps still receive them on O+.
+ */
+@Singleton
+class ExternalAudioEffectSession @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+
+    private companion object {
+        private const val TAG = "ExternalAudioEffect"
+    }
+
+    /** Session id we last announced as open, or `null` when nothing is open. */
+    private var openedSessionId: Int? = null
+
+    /**
+     * Announces [audioSessionId] as available for external effects, closing any previously
+     * announced session first. Safe to call repeatedly with the same id.
+     */
+    @Synchronized
+    fun open(audioSessionId: Int) {
+        if (audioSessionId <= 0) return
+        if (openedSessionId == audioSessionId) return
+
+        openedSessionId?.let { previous ->
+            broadcast(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION, previous)
+        }
+        openedSessionId = audioSessionId
+        broadcast(AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION, audioSessionId)
+    }
+
+    /**
+     * Tells external effect apps to detach from the session, so they release their effect engines
+     * once we stop owning the session. No-op when nothing is open.
+     */
+    @Synchronized
+    fun close() {
+        val sessionId = openedSessionId ?: return
+        openedSessionId = null
+        broadcast(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION, sessionId)
+    }
+
+    private fun broadcast(action: String, audioSessionId: Int) {
+        val intent = Intent(action).apply {
+            putExtra(AudioEffect.EXTRA_AUDIO_SESSION, audioSessionId)
+            putExtra(AudioEffect.EXTRA_PACKAGE_NAME, context.packageName)
+            putExtra(AudioEffect.EXTRA_CONTENT_TYPE, AudioEffect.CONTENT_TYPE_MUSIC)
+        }
+        try {
+            context.sendBroadcast(intent)
+            Timber.tag(TAG).d("Broadcast %s for session %d", action, audioSessionId)
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Failed to broadcast %s for session %d", action, audioSessionId)
+        }
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/NavidromeRepository.kt
@@ -18,6 +18,7 @@ import com.lostf1sh.pixelplayeross.data.database.SongEntity
 import com.lostf1sh.pixelplayeross.data.database.SourceType
 import com.lostf1sh.pixelplayeross.data.database.toSong
 import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeAuthMethod
 import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeCredentials
 import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeMusicFolder
 import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeSong
@@ -73,6 +74,7 @@ class NavidromeRepository @Inject constructor(
         private const val KEY_SERVER_URL = "server_url"
         private const val KEY_USERNAME = "username"
         private const val KEY_PASSWORD = "password"
+        private const val KEY_AUTH_METHOD = "auth_method"
         private const val KEY_LAST_FULL_SYNC = "last_full_sync"
 
         // Negative offsets prevent collisions with MediaStore IDs.
@@ -121,6 +123,15 @@ class NavidromeRepository @Inject constructor(
     val isLoggedInFlow: StateFlow<Boolean> = _isLoggedInFlow.asStateFlow()
 
     init {
+        // Remember a server-driven switch to password auth so later launches start with
+        // the method that works instead of spending a rejected request rediscovering it.
+        // Only for the saved server: a fallback during a login attempt to some other
+        // server must not rewrite the stored account's method (login() saves its own).
+        api.onAuthMethodChanged = { method ->
+            if (api.getServerUrl() == prefs.getString(KEY_SERVER_URL, null)) {
+                prefs.edit { putString(KEY_AUTH_METHOD, method.name) }
+            }
+        }
         initFromSavedCredentials()
     }
 
@@ -143,7 +154,10 @@ class NavidromeRepository @Inject constructor(
                 _isLoggedInFlow.value = false
                 return
             }
-            api.setCredentials(credentials)
+            api.setCredentials(
+                credentials,
+                NavidromeAuthMethod.fromStorageKey(prefs.getString(KEY_AUTH_METHOD, null))
+            )
             _isLoggedInFlow.value = true
             Timber.d("$TAG: Restored credentials for $username@${credentials.normalizedServerUrl}")
         }
@@ -193,7 +207,9 @@ class NavidromeRepository @Inject constructor(
                     api.clearCredentials()
                     return@withContext Result.failure(IllegalArgumentException(validationError))
                 }
-                api.setCredentials(credentials)
+                // Start from token auth on every login: the server may have changed, and
+                // ping() downgrades to password auth by itself if tokens are rejected.
+                api.setCredentials(credentials, NavidromeAuthMethod.TOKEN)
 
                 // Test connection
                 val pingResult = api.ping()
@@ -209,6 +225,7 @@ class NavidromeRepository @Inject constructor(
                     putString(KEY_SERVER_URL, credentials.normalizedServerUrl)
                         .putString(KEY_USERNAME, username)
                         .putString(KEY_PASSWORD, password)
+                        .putString(KEY_AUTH_METHOD, api.activeAuthMethod.name)
                 }
 
                 _isLoggedInFlow.value = true

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeAuthMethod.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeAuthMethod.kt
@@ -1,0 +1,24 @@
+package com.lostf1sh.pixelplayeross.data.navidrome.model
+
+/**
+ * How credentials are sent to a Subsonic-compatible server.
+ *
+ * Token auth is the modern default, but some servers cannot support it because they
+ * never store a recoverable copy of the password (Nextcloud/ownCloud Music rejects
+ * `t`/`s` outright with Subsonic error 41). Those servers accept only the older
+ * password parameter, so we fall back to it when the server says token auth is
+ * unsupported.
+ */
+enum class NavidromeAuthMethod {
+    /** Salted MD5 token: `t=md5(password + salt)&s=salt`. */
+    TOKEN,
+
+    /** Hex-encoded password: `p=enc:<hex>`. */
+    PASSWORD;
+
+    companion object {
+        /** Reads a persisted value, defaulting to [TOKEN] for unknown or missing input. */
+        fun fromStorageKey(value: String?): NavidromeAuthMethod =
+            entries.firstOrNull { it.name == value } ?: TOKEN
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentials.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/navidrome/model/NavidromeCredentials.kt
@@ -7,9 +7,12 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 /**
  * Represents authentication credentials for a Navidrome/Subsonic server.
  *
- * Navidrome supports two authentication methods:
- * 1. Password in URL (p=xxx) - not recommended for security
- * 2. Token-based authentication (t=xxx&s=xxx) - recommended
+ * Subsonic servers accept two authentication methods:
+ * 1. Token-based authentication (t=xxx&s=xxx) - preferred, and what we try first
+ * 2. Password in URL (p=enc:xxx) - used only when the server rejects tokens
+ *
+ * Which one is in play is tracked by the API client, not here; see
+ * [com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeAuthMethod].
  *
  * @property serverUrl The base URL of the Navidrome server (e.g., "https://music.example.com")
  * @property username The username for authentication

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/network/navidrome/NavidromeApiService.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/network/navidrome/NavidromeApiService.kt
@@ -1,5 +1,6 @@
 package com.lostf1sh.pixelplayeross.data.network.navidrome
 
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeAuthMethod
 import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeCredentials
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -17,8 +18,10 @@ import javax.inject.Singleton
 /**
  * Navidrome/Subsonic API client.
  *
- * Implements the Subsonic API protocol with token-based authentication.
- * Compatible with Navidrome, Gonic, Airsonic, and other Subsonic-compatible servers.
+ * Implements the Subsonic API protocol with token-based authentication, falling back
+ * to password authentication for servers that reject tokens (see [NavidromeAuthMethod]).
+ * Compatible with Navidrome, Gonic, Airsonic, Nextcloud Music, and other
+ * Subsonic-compatible servers.
  *
  * API Reference: http://www.subsonic.org/pages/api.jsp
  */
@@ -41,6 +44,16 @@ class NavidromeApiService @Inject constructor(
     @Volatile
     private var credentials: NavidromeCredentials? = null
 
+    @Volatile
+    private var authMethod: NavidromeAuthMethod = NavidromeAuthMethod.TOKEN
+
+    /**
+     * Notified when the client switches auth method after a server rejection, so the
+     * choice can be persisted and reused on the next launch instead of re-discovered.
+     */
+    @Volatile
+    var onAuthMethodChanged: ((NavidromeAuthMethod) -> Unit)? = null
+
     private val okHttpClient: OkHttpClient = baseOkHttpClient.newBuilder()
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS) // Longer timeout for streaming
@@ -51,10 +64,18 @@ class NavidromeApiService @Inject constructor(
 
     /**
      * Set the server credentials for API calls.
+     *
+     * @param authMethod The auth method to start with. Pass the previously discovered
+     *   method for a known server; [NavidromeAuthMethod.TOKEN] servers that reject
+     *   tokens are detected on the first request.
      */
-    fun setCredentials(credentials: NavidromeCredentials) {
+    fun setCredentials(
+        credentials: NavidromeCredentials,
+        authMethod: NavidromeAuthMethod = NavidromeAuthMethod.TOKEN
+    ) {
         this.credentials = credentials
-        Timber.d("$TAG: Credentials set for server: ${credentials.normalizedServerUrl}, user: ${credentials.username}")
+        this.authMethod = authMethod
+        Timber.d("$TAG: Credentials set for server: ${credentials.normalizedServerUrl}, user: ${credentials.username}, auth: $authMethod")
     }
 
     /**
@@ -62,8 +83,15 @@ class NavidromeApiService @Inject constructor(
      */
     fun clearCredentials() {
         this.credentials = null
+        this.authMethod = NavidromeAuthMethod.TOKEN
         Timber.d("$TAG: Credentials cleared")
     }
+
+    /**
+     * The auth method currently in use, after any server-driven fallback.
+     */
+    val activeAuthMethod: NavidromeAuthMethod
+        get() = authMethod
 
     /**
      * Check if credentials are configured.
@@ -78,39 +106,25 @@ class NavidromeApiService @Inject constructor(
     // ─── Authentication ─────────────────────────────────────────────────
 
     /**
-     * Generate authentication parameters using the token/salt method.
-     * Token = md5(password + salt)
-     *
-     * @return Pair of (token, salt)
-     */
-    private fun generateAuthParams(password: String): Pair<String, String> {
-        val salt = UUID.randomUUID().toString().take(6)
-        val token = md5(password + salt)
-        return Pair(token, salt)
-    }
-
-    /**
-     * Compute MD5 hash of a string.
-     */
-    private fun md5(input: String): String {
-        val md = MessageDigest.getInstance("MD5")
-        val digest = md.digest(input.toByteArray(Charsets.UTF_8))
-        return digest.joinToString("") { "%02x".format(it) }
-    }
-
-    /**
      * Build a URL with authentication parameters for a Subsonic API endpoint.
      */
-    private fun buildApiUrl(endpoint: String, extraParams: Map<String, String> = emptyMap()): String {
+    private fun buildApiUrl(
+        endpoint: String,
+        extraParams: Map<String, String> = emptyMap(),
+        method: NavidromeAuthMethod = authMethod
+    ): String {
         val cred = credentials ?: throw IllegalStateException("No credentials configured")
-        val (token, salt) = generateAuthParams(cred.password)
 
         val baseUrl = "${cred.normalizedServerUrl}/rest/$endpoint.view"
 
         val urlBuilder = baseUrl.toHttpUrl().newBuilder()
             .addQueryParameter("u", cred.username)
-            .addQueryParameter("t", token)
-            .addQueryParameter("s", salt)
+
+        subsonicAuthParams(cred.password, method).forEach { (key, value) ->
+            urlBuilder.addQueryParameter(key, value)
+        }
+
+        urlBuilder
             .addQueryParameter("v", API_VERSION)
             .addQueryParameter("c", cred.clientId.ifBlank { DEFAULT_CLIENT_ID })
             .addQueryParameter("f", DEFAULT_FORMAT)
@@ -131,10 +145,14 @@ class NavidromeApiService @Inject constructor(
      * @param params Additional query parameters
      * @return The raw JSON response as a string
      */
-    private suspend fun request(endpoint: String, params: Map<String, String> = emptyMap()): Result<String> {
+    private suspend fun request(
+        endpoint: String,
+        params: Map<String, String> = emptyMap(),
+        method: NavidromeAuthMethod = authMethod
+    ): Result<String> {
         return withContext(Dispatchers.IO) {
             try {
-                val url = buildApiUrl(endpoint, params)
+                val url = buildApiUrl(endpoint, params, method)
                 Timber.d("$TAG: >>> GET $endpoint")
 
                 val request = Request.Builder()
@@ -180,7 +198,7 @@ class NavidromeApiService @Inject constructor(
                 val error = subsonicResponse.optJSONObject("error")
                 val code = error?.optInt("code", -1) ?: -1
                 val message = error?.optString("message", "Unknown error") ?: "Unknown error"
-                return Result.failure(Exception("API Error $code: $message"))
+                return Result.failure(SubsonicApiException(code, message))
             }
 
             Result.success(subsonicResponse)
@@ -192,9 +210,32 @@ class NavidromeApiService @Inject constructor(
 
     /**
      * Make a request and parse the response.
+     *
+     * Servers that store only password hashes (Nextcloud/ownCloud Music) reject the
+     * token/salt parameters instead of checking them, so a single rejection switches
+     * this client to password auth for the rest of the session and retries once.
      */
     private suspend fun requestAndParse(endpoint: String, params: Map<String, String> = emptyMap()): Result<JSONObject> {
-        return request(endpoint, params).fold(
+        val method = authMethod
+        val result = requestParsed(endpoint, params, method)
+
+        val error = result.exceptionOrNull()
+        if (error is SubsonicApiException && shouldFallBackToPasswordAuth(error, method)) {
+            Timber.w("$TAG: Server rejected token auth (${error.message}), retrying with password auth")
+            authMethod = NavidromeAuthMethod.PASSWORD
+            onAuthMethodChanged?.invoke(NavidromeAuthMethod.PASSWORD)
+            return requestParsed(endpoint, params, NavidromeAuthMethod.PASSWORD)
+        }
+
+        return result
+    }
+
+    private suspend fun requestParsed(
+        endpoint: String,
+        params: Map<String, String>,
+        method: NavidromeAuthMethod
+    ): Result<JSONObject> {
+        return request(endpoint, params, method).fold(
             onSuccess = { parseResponse(it) },
             onFailure = { Result.failure(it) }
         )
@@ -418,12 +459,15 @@ class NavidromeApiService @Inject constructor(
      */
     fun getStreamUrl(songId: String, maxBitRate: Int = 0, format: String? = null): String {
         val cred = credentials ?: throw IllegalStateException("No credentials configured")
-        val (token, salt) = generateAuthParams(cred.password)
 
         val urlBuilder = "${cred.normalizedServerUrl}/rest/stream.view".toHttpUrl().newBuilder()
             .addQueryParameter("u", cred.username)
-            .addQueryParameter("t", token)
-            .addQueryParameter("s", salt)
+
+        subsonicAuthParams(cred.password, authMethod).forEach { (key, value) ->
+            urlBuilder.addQueryParameter(key, value)
+        }
+
+        urlBuilder
             .addQueryParameter("v", API_VERSION)
             .addQueryParameter("c", cred.clientId.ifBlank { DEFAULT_CLIENT_ID })
             .addQueryParameter("id", songId)
@@ -446,13 +490,16 @@ class NavidromeApiService @Inject constructor(
      */
     fun getCoverArtUrl(coverArtId: String, size: Int = 500): String {
         val cred = credentials ?: throw IllegalStateException("No credentials configured")
-        val (token, salt) = generateAuthParams(cred.password)
 
-        return "${cred.normalizedServerUrl}/rest/getCoverArt.view"
+        val urlBuilder = "${cred.normalizedServerUrl}/rest/getCoverArt.view"
             .toHttpUrl().newBuilder()
             .addQueryParameter("u", cred.username)
-            .addQueryParameter("t", token)
-            .addQueryParameter("s", salt)
+
+        subsonicAuthParams(cred.password, authMethod).forEach { (key, value) ->
+            urlBuilder.addQueryParameter(key, value)
+        }
+
+        return urlBuilder
             .addQueryParameter("v", API_VERSION)
             .addQueryParameter("c", cred.clientId.ifBlank { DEFAULT_CLIENT_ID })
             .addQueryParameter("id", coverArtId)
@@ -566,3 +613,57 @@ class NavidromeApiService @Inject constructor(
         return requestAndParse("unstar", params).map { true }
     }
 }
+
+/**
+ * A Subsonic API call that reached the server but came back with `status="failed"`.
+ *
+ * Error codes are defined by the Subsonic API (10 = missing parameter, 40 = wrong
+ * credentials, 41 = token auth unsupported, 70 = not found, ...).
+ */
+class SubsonicApiException(
+    val code: Int,
+    val serverMessage: String
+) : Exception("API Error $code: $serverMessage")
+
+/** Subsonic error 41: the server cannot verify salted tokens and wants `p` instead. */
+private const val SUBSONIC_ERROR_TOKEN_AUTH_UNSUPPORTED = 41
+
+/**
+ * Whether a failed call should be retried with password auth.
+ *
+ * Only error 41 qualifies: wrong credentials (40) would fail the same way again, and
+ * a server that already answered a token request has nothing to gain from the switch.
+ */
+internal fun shouldFallBackToPasswordAuth(
+    error: SubsonicApiException,
+    currentMethod: NavidromeAuthMethod
+): Boolean = currentMethod == NavidromeAuthMethod.TOKEN &&
+    error.code == SUBSONIC_ERROR_TOKEN_AUTH_UNSUPPORTED
+
+/**
+ * Build the credential query parameters for [method].
+ *
+ * TOKEN sends `t=md5(password + salt)` with the salt; PASSWORD sends the hex-encoded
+ * `p=enc:...` form, which every Subsonic server accepts and is the only form servers
+ * like Nextcloud Music can verify.
+ */
+internal fun subsonicAuthParams(
+    password: String,
+    method: NavidromeAuthMethod,
+    salt: String = randomSubsonicSalt()
+): Map<String, String> = when (method) {
+    NavidromeAuthMethod.TOKEN -> mapOf(
+        "t" to md5Hex(password + salt),
+        "s" to salt
+    )
+    NavidromeAuthMethod.PASSWORD -> mapOf(
+        "p" to "enc:" + password.toByteArray(Charsets.UTF_8).toHexString()
+    )
+}
+
+private fun randomSubsonicSalt(): String = UUID.randomUUID().toString().take(6)
+
+private fun md5Hex(input: String): String =
+    MessageDigest.getInstance("MD5").digest(input.toByteArray(Charsets.UTF_8)).toHexString()
+
+private fun ByteArray.toHexString(): String = joinToString("") { "%02x".format(it) }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import com.lostf1sh.pixelplayeross.data.equalizer.EqualizerManager
+import com.lostf1sh.pixelplayeross.data.equalizer.ExternalAudioEffectSession
 import com.lostf1sh.pixelplayeross.data.model.WidgetThemeColors
 import com.lostf1sh.pixelplayeross.data.preferences.AlbumArtColorAccuracy
 import com.lostf1sh.pixelplayeross.data.preferences.AlbumArtPaletteStyle
@@ -153,6 +154,8 @@ class MusicService : MediaLibraryService() {
     lateinit var themePreferencesRepository: ThemePreferencesRepository
     @Inject
     lateinit var equalizerManager: EqualizerManager
+    @Inject
+    lateinit var externalAudioEffectSession: ExternalAudioEffectSession
     @Inject
     lateinit var colorSchemeProcessor: ColorSchemeProcessor
     @Inject
@@ -424,6 +427,15 @@ class MusicService : MediaLibraryService() {
                 if (newSessionId != 0) {
                     equalizerManager.attachToAudioSessionIfNeeded(newSessionId)
                 }
+            }
+        }
+
+        // Let external audio effect apps (ViPER4Android, JamesDSP, Wavelet, OEM effect panels)
+        // attach to our session. Independent of the built-in equalizer state: those apps must be
+        // able to process our output even when every built-in effect is switched off.
+        serviceScope.launch {
+            engine.activeAudioSessionId.collect { sessionId ->
+                externalAudioEffectSession.open(sessionId)
             }
         }
 
@@ -982,6 +994,7 @@ class MusicService : MediaLibraryService() {
             mediaSession = null
         }
         equalizerManager.release()
+        externalAudioEffectSession.close()
         engine.release()
         controller.release()
         serviceScope.cancel()

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/player/DualPlayerEngine.kt
@@ -228,6 +228,16 @@ class DualPlayerEngine @Inject constructor(
     private val _activeDecoderInfo = MutableStateFlow<ActiveDecoderInfo?>(null)
     val activeDecoderInfo: StateFlow<ActiveDecoderInfo?> = _activeDecoderInfo.asStateFlow()
 
+    // One audio session shared by player A, player B and every rebuilt player.
+    //
+    // Left to itself ExoPlayer mints a session id per instance, which breaks audio effects twice
+    // over: the effect stack (the built-in equalizer *and* external DSP apps such as
+    // ViPER4Android or JamesDSP, see ExternalAudioEffectSession) only ever covers the current
+    // master player, so the incoming half of a crossfade plays unprocessed, and every player
+    // rebuild (Hi-Fi toggle, offload fallback) forces the whole stack to be torn down and
+    // re-attached to a brand new session.
+    private var sharedAudioSessionId: Int = C.AUDIO_SESSION_ID_UNSET
+
     // Audio Focus Management
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var audioFocusRequest: AudioFocusRequest? = null
@@ -822,6 +832,25 @@ class DualPlayerEngine @Inject constructor(
         }
     }
 
+    /**
+     * Returns the process-wide audio session id every player is pinned to, generating it on first
+     * use, or `null` when the platform refuses to allocate one (then ExoPlayer keeps its
+     * per-instance behaviour).
+     */
+    private fun sharedAudioSessionIdOrNull(): Int? {
+        if (sharedAudioSessionId == C.AUDIO_SESSION_ID_UNSET) {
+            sharedAudioSessionId = try {
+                audioManager.generateAudioSessionId()
+            } catch (e: Exception) {
+                Timber.tag("DualPlayerEngine").w(e, "Failed to generate a shared audio session id")
+                AudioManager.ERROR
+            }
+        }
+        return sharedAudioSessionId.takeIf {
+            it != AudioManager.ERROR && it != C.AUDIO_SESSION_ID_UNSET
+        }
+    }
+
     private fun buildPlayer(): ExoPlayer {
         val mediaCodecSelector = MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
             val decoderInfos = MediaCodecSelector.DEFAULT.getDecoderInfos(
@@ -927,6 +956,7 @@ class DualPlayerEngine @Inject constructor(
             .setMediaSourceFactory(DefaultMediaSourceFactory(resolvingFactory, extractorsFactory))
             .setLoadControl(loadControl)
             .build().apply {
+            sharedAudioSessionIdOrNull()?.let { setAudioSessionId(it) }
             setAudioAttributes(audioAttributes, false)
             val offloadPreferences = TrackSelectionParameters.AudioOffloadPreferences.Builder()
                 .setAudioOffloadMode(

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/equalizer/ExternalAudioEffectSessionTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/equalizer/ExternalAudioEffectSessionTest.kt
@@ -1,0 +1,81 @@
+package com.lostf1sh.pixelplayeross.data.equalizer
+
+import android.content.Context
+import android.content.Intent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ExternalAudioEffectSessionTest {
+
+    private lateinit var context: Context
+    private lateinit var session: ExternalAudioEffectSession
+
+    @BeforeEach
+    fun setUp() {
+        context = mockk(relaxed = true)
+        every { context.packageName } returns "com.lostf1sh.pixelplayeross"
+        session = ExternalAudioEffectSession(context)
+    }
+
+    @Test
+    fun `open announces the session once`() {
+        session.open(42)
+
+        verify(exactly = 1) { context.sendBroadcast(any<Intent>()) }
+    }
+
+    @Test
+    fun `re-opening the same session does not re-announce it`() {
+        session.open(42)
+        session.open(42)
+        session.open(42)
+
+        // Re-announcing would make effect apps tear down and rebuild their engine mid-playback.
+        verify(exactly = 1) { context.sendBroadcast(any<Intent>()) }
+    }
+
+    @Test
+    fun `opening a different session closes the previous one first`() {
+        session.open(42)
+        session.open(43)
+
+        // open(42), close(42), open(43)
+        verify(exactly = 3) { context.sendBroadcast(any<Intent>()) }
+    }
+
+    @Test
+    fun `invalid session ids are ignored`() {
+        session.open(0)
+        session.open(-1)
+
+        verify(exactly = 0) { context.sendBroadcast(any<Intent>()) }
+    }
+
+    @Test
+    fun `close is a no-op when nothing was announced`() {
+        session.close()
+
+        verify(exactly = 0) { context.sendBroadcast(any<Intent>()) }
+    }
+
+    @Test
+    fun `close after open detaches once`() {
+        session.open(42)
+        session.close()
+        session.close()
+
+        verify(exactly = 2) { context.sendBroadcast(any<Intent>()) }
+    }
+
+    @Test
+    fun `a session can be reopened after being closed`() {
+        session.open(42)
+        session.close()
+        session.open(42)
+
+        verify(exactly = 3) { context.sendBroadcast(any<Intent>()) }
+    }
+}

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/network/navidrome/NavidromeApiServiceAuthTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/network/navidrome/NavidromeApiServiceAuthTest.kt
@@ -1,0 +1,80 @@
+package com.lostf1sh.pixelplayeross.data.network.navidrome
+
+import com.google.common.truth.Truth.assertThat
+import com.lostf1sh.pixelplayeross.data.navidrome.model.NavidromeAuthMethod
+import org.junit.jupiter.api.Test
+
+class NavidromeApiServiceAuthTest {
+
+    @Test
+    fun `token auth uses the salted md5 token from the Subsonic spec`() {
+        val params = subsonicAuthParams(
+            password = "sesame",
+            method = NavidromeAuthMethod.TOKEN,
+            salt = "c19b2d"
+        )
+
+        assertThat(params).containsExactly(
+            "t", "26719a1196d2a940705a59634eb18eab",
+            "s", "c19b2d"
+        )
+    }
+
+    @Test
+    fun `password auth sends the hex-encoded password and no token`() {
+        val params = subsonicAuthParams(
+            password = "sesame",
+            method = NavidromeAuthMethod.PASSWORD,
+            salt = "c19b2d"
+        )
+
+        assertThat(params).containsExactly("p", "enc:736573616d65")
+    }
+
+    @Test
+    fun `password auth hex-encodes non-ascii passwords as utf-8`() {
+        val params = subsonicAuthParams(
+            password = "pä",
+            method = NavidromeAuthMethod.PASSWORD
+        )
+
+        assertThat(params["p"]).isEqualTo("enc:70c3a4")
+    }
+
+    @Test
+    fun `token auth salt changes between calls`() {
+        val first = subsonicAuthParams("sesame", NavidromeAuthMethod.TOKEN)
+        val second = subsonicAuthParams("sesame", NavidromeAuthMethod.TOKEN)
+
+        assertThat(first["s"]).isNotEqualTo(second["s"])
+    }
+
+    @Test
+    fun `error 41 makes a token request retry with password auth`() {
+        val error = SubsonicApiException(41, "Token-based authentication not supported")
+
+        assertThat(shouldFallBackToPasswordAuth(error, NavidromeAuthMethod.TOKEN)).isTrue()
+    }
+
+    @Test
+    fun `error 41 does not loop once password auth is already in use`() {
+        val error = SubsonicApiException(41, "Token-based authentication not supported")
+
+        assertThat(shouldFallBackToPasswordAuth(error, NavidromeAuthMethod.PASSWORD)).isFalse()
+    }
+
+    @Test
+    fun `wrong credentials do not trigger the password fallback`() {
+        val error = SubsonicApiException(40, "Wrong username or password")
+
+        assertThat(shouldFallBackToPasswordAuth(error, NavidromeAuthMethod.TOKEN)).isFalse()
+    }
+
+    @Test
+    fun `stored auth method falls back to token when missing or unknown`() {
+        assertThat(NavidromeAuthMethod.fromStorageKey(null)).isEqualTo(NavidromeAuthMethod.TOKEN)
+        assertThat(NavidromeAuthMethod.fromStorageKey("nonsense")).isEqualTo(NavidromeAuthMethod.TOKEN)
+        assertThat(NavidromeAuthMethod.fromStorageKey("PASSWORD"))
+            .isEqualTo(NavidromeAuthMethod.PASSWORD)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a shared audio session ID across DualPlayerEngine player instances and rebuilds.
- Announce session lifecycle events to external audio effect apps.
- Add unit coverage for session open, close, deduplication, and replacement behavior.

## Testing

- Not run (no test results provided).
Fixes #57 
Fixes #59 