### PR TITLE
Fix playback service lifecycle handling

### DIFF
--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
@@ -346,8 +346,9 @@ class MusicService : MediaLibraryService() {
             }
         }
 
-        temporaryForegroundStartedInOnCreate =
-            consumePendingMediaButtonForegroundStart() || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+        temporaryForegroundStartedInOnCreate = shouldStartTemporaryForegroundOnCreate(
+            hasPendingMediaButtonStart = consumePendingMediaButtonForegroundStart()
+        )
         if (temporaryForegroundStartedInOnCreate) {
             startTemporaryForegroundForCommand()
         }
@@ -923,6 +924,31 @@ class MusicService : MediaLibraryService() {
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaSession
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        val player = mediaSession?.player ?: engine.masterPlayer
+        when (
+            taskRemovalAction(
+                keepPlayingInBackground = keepPlayingInBackground,
+                isPlaybackOngoing = isPlaybackOngoing(),
+                playWhenReady = player.playWhenReady,
+                mediaItemCount = player.mediaItemCount,
+                playbackState = player.playbackState,
+            )
+        ) {
+            TaskRemovalAction.KEEP_RUNNING -> {
+                Timber.tag(TAG).d("Keeping active playback after task removal")
+                schedulePlaybackSnapshotPersist(immediate = true)
+            }
+            TaskRemovalAction.STOP_AND_PRESERVE -> {
+                stopPlaybackAndUnload(
+                    reason = "task_removed_background_playback_disabled",
+                    preservePlaybackSnapshot = true,
+                )
+            }
+            TaskRemovalAction.DEFER_TO_MEDIA3 -> super.onTaskRemoved(rootIntent)
+        }
+    }
 
     override fun onDestroy() {
         PlaybackActivityTracker.setPlaybackActive(false)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/PlaybackServiceLifecyclePolicy.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/PlaybackServiceLifecyclePolicy.kt
@@ -1,0 +1,36 @@
+package com.lostf1sh.pixelplayeross.data.service
+
+import androidx.media3.common.Player
+
+internal enum class TaskRemovalAction {
+    KEEP_RUNNING,
+    STOP_AND_PRESERVE,
+    DEFER_TO_MEDIA3,
+}
+
+internal fun shouldStartTemporaryForegroundOnCreate(
+    hasPendingMediaButtonStart: Boolean,
+): Boolean = hasPendingMediaButtonStart
+
+internal fun taskRemovalAction(
+    keepPlayingInBackground: Boolean,
+    isPlaybackOngoing: Boolean,
+    playWhenReady: Boolean,
+    mediaItemCount: Int,
+    playbackState: Int,
+): TaskRemovalAction {
+    val hasPlaybackIntent =
+        playWhenReady &&
+            mediaItemCount > 0 &&
+            playbackState != Player.STATE_IDLE &&
+            playbackState != Player.STATE_ENDED
+
+    return when {
+        !keepPlayingInBackground && hasPlaybackIntent ->
+            TaskRemovalAction.STOP_AND_PRESERVE
+        keepPlayingInBackground && isPlaybackOngoing && hasPlaybackIntent ->
+            TaskRemovalAction.KEEP_RUNNING
+        else ->
+            TaskRemovalAction.DEFER_TO_MEDIA3
+    }
+}

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/service/PlaybackServiceLifecyclePolicyTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/service/PlaybackServiceLifecyclePolicyTest.kt
@@ -1,0 +1,84 @@
+package com.lostf1sh.pixelplayeross.data.service
+
+import androidx.media3.common.Player
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PlaybackServiceLifecyclePolicyTest {
+
+    @Test
+    fun `normal controller connection does not start temporary foreground notification`() {
+        assertFalse(
+            shouldStartTemporaryForegroundOnCreate(
+                hasPendingMediaButtonStart = false
+            )
+        )
+    }
+
+    @Test
+    fun `cold media button start gets temporary foreground protection`() {
+        assertTrue(
+            shouldStartTemporaryForegroundOnCreate(
+                hasPendingMediaButtonStart = true
+            )
+        )
+    }
+
+    @Test
+    fun `enabled background playback survives task removal while buffering`() {
+        assertEquals(
+            TaskRemovalAction.KEEP_RUNNING,
+            taskRemovalAction(
+                keepPlayingInBackground = true,
+                isPlaybackOngoing = true,
+                playWhenReady = true,
+                mediaItemCount = 1,
+                playbackState = Player.STATE_BUFFERING,
+            )
+        )
+    }
+
+    @Test
+    fun `disabled background playback stops active playback on task removal`() {
+        assertEquals(
+            TaskRemovalAction.STOP_AND_PRESERVE,
+            taskRemovalAction(
+                keepPlayingInBackground = false,
+                isPlaybackOngoing = true,
+                playWhenReady = true,
+                mediaItemCount = 1,
+                playbackState = Player.STATE_READY,
+            )
+        )
+    }
+
+    @Test
+    fun `non-foreground service teardown remains with Media3`() {
+        assertEquals(
+            TaskRemovalAction.DEFER_TO_MEDIA3,
+            taskRemovalAction(
+                keepPlayingInBackground = true,
+                isPlaybackOngoing = false,
+                playWhenReady = true,
+                mediaItemCount = 1,
+                playbackState = Player.STATE_BUFFERING,
+            )
+        )
+    }
+
+    @Test
+    fun `paused playback teardown remains with Media3`() {
+        assertEquals(
+            TaskRemovalAction.DEFER_TO_MEDIA3,
+            taskRemovalAction(
+                keepPlayingInBackground = false,
+                isPlaybackOngoing = false,
+                playWhenReady = false,
+                mediaItemCount = 1,
+                playbackState = Player.STATE_READY,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- avoid showing the temporary processing notification for normal controller connections
- honor the background playback preference when the app is removed from recents
- keep foreground playback alive during transient buffering states
- add regression coverage for notification startup and task-removal policy

Closes #56
Closes #60

## Verification

- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:testDebugUnitTest`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:lintDebug`
- `git diff --check`