### PR TITLE
Keep background playback alive when task is removed

### DIFF
--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
@@ -97,6 +97,18 @@ import coil.size.Precision
 import javax.inject.Inject
 import androidx.core.net.toUri
 
+/**
+ * Task removal must never tear down active playback when the user has opted into
+ * background playback; in every other case the service should shut down cleanly
+ * instead of lingering half-alive until the system reclaims it.
+ */
+internal fun shouldContinuePlaybackAfterTaskRemoved(
+    hasForegroundPlaybackIntent: Boolean,
+    keepPlayingInBackground: Boolean
+): Boolean {
+    return hasForegroundPlaybackIntent && keepPlayingInBackground
+}
+
 suspend fun loadArtworkBytesViaCoil(context: Context, uri: Uri): ByteArray? {
     val appContext = context.applicationContext
     val request = ImageRequest.Builder(appContext)
@@ -924,11 +936,33 @@ class MusicService : MediaLibraryService() {
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaSession
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        val session = mediaSession
+        val continuePlayback = shouldContinuePlaybackAfterTaskRemoved(
+            hasForegroundPlaybackIntent = session?.player?.hasForegroundPlaybackIntent() == true,
+            keepPlayingInBackground = keepPlayingInBackground
+        )
+        if (continuePlayback && session != null) {
+            // Media3's default onTaskRemoved pauses all players and stops the service
+            // whenever it is not in foreground state, and OEMs freeze cached processes
+            // that have no foreground service — either way playback dies with the task.
+            if (!isPlaybackOngoing()) {
+                Timber.tag(TAG).w(
+                    "Task removed while playing without foreground state; re-promoting."
+                )
+                onUpdateNotification(session, startInForegroundRequired = true)
+            }
+            return
+        }
+        stopPlaybackAndUnload(reason = "task_removed")
+    }
+
     override fun onDestroy() {
         PlaybackActivityTracker.setPlaybackActive(false)
         listeningStatsTracker.finalizeCurrentSession(forceSynchronousPersistence = true)
         reportNavidromePlayback("stopped")
         stopNavidromePlaybackReporting()
+        flushPendingPlaybackSnapshotOnDestroy()
         playbackSnapshotPersistJob?.cancel()
         mediaSessionButtonRefreshJob?.cancel()
         followUpMediaSessionUiRefreshJob?.cancel()
@@ -2271,6 +2305,22 @@ class MusicService : MediaLibraryService() {
                 Timber.tag(TAG).w(e, "Failed to persist playback snapshot during unload")
             }
         }
+    }
+
+    /**
+     * A debounced snapshot persist that is still pending at [onDestroy] would be
+     * silently cancelled, leaving a stale "playing" snapshot behind — reopening the
+     * app would then fake-resume playback that the system already tore down. Flush
+     * it now, forced to a paused state, so the next restore comes back paused at
+     * the correct position.
+     */
+    private fun flushPendingPlaybackSnapshotOnDestroy() {
+        if (isPlaybackUnloadInProgress || isRestoringPlaybackSnapshot) return
+        if (playbackSnapshotPersistJob?.isActive != true) return
+        playbackSnapshotPersistJob?.cancel()
+        val snapshot = capturePlaybackSnapshotFromPlayer(playWhenReadyOverride = false)
+            ?: return
+        writePlaybackSnapshotOnUnload(snapshot)
     }
 
     private fun refreshMediaSessionUiWithFollowUp(

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/service/TaskRemovedPolicyTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/service/TaskRemovedPolicyTest.kt
@@ -1,0 +1,47 @@
+package com.lostf1sh.pixelplayeross.data.service
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class TaskRemovedPolicyTest {
+
+    @Test
+    fun taskRemoved_continuesPlaybackWhenPlayingAndBackgroundPlaybackEnabled() {
+        val shouldContinue = shouldContinuePlaybackAfterTaskRemoved(
+            hasForegroundPlaybackIntent = true,
+            keepPlayingInBackground = true
+        )
+
+        assertThat(shouldContinue).isTrue()
+    }
+
+    @Test
+    fun taskRemoved_stopsWhenBackgroundPlaybackDisabled() {
+        val shouldContinue = shouldContinuePlaybackAfterTaskRemoved(
+            hasForegroundPlaybackIntent = true,
+            keepPlayingInBackground = false
+        )
+
+        assertThat(shouldContinue).isFalse()
+    }
+
+    @Test
+    fun taskRemoved_stopsWhenNothingIsPlaying() {
+        val shouldContinue = shouldContinuePlaybackAfterTaskRemoved(
+            hasForegroundPlaybackIntent = false,
+            keepPlayingInBackground = true
+        )
+
+        assertThat(shouldContinue).isFalse()
+    }
+
+    @Test
+    fun taskRemoved_stopsWhenIdleAndBackgroundPlaybackDisabled() {
+        val shouldContinue = shouldContinuePlaybackAfterTaskRemoved(
+            hasForegroundPlaybackIntent = false,
+            keepPlayingInBackground = false
+        )
+
+        assertThat(shouldContinue).isFalse()
+    }
+}


### PR DESCRIPTION
Fixes #60

## What

Handles task removal explicitly in `MusicService` instead of inheriting Media3's default, and flushes the pending debounced queue snapshot (forced to paused) when the service is destroyed.

## Why

Media3's default `onTaskRemoved` pauses every player and stops the service whenever the service is not in foreground state, so swiping the app out of recents killed playback even with **Keep playing in background** enabled. OEM battery managers (ColorOS on the reporter's OPPO A3 among them) additionally freeze cached processes that hold no foreground service, which produced the reported zombie state: position advancing, no audio.

- When playback is ongoing and background playback is enabled, task removal now keeps the service alive and re-promotes it to foreground if it lost that state (the decision is extracted as `shouldContinuePlaybackAfterTaskRemoved`, tested).
- Otherwise the service shuts down through the existing `stopPlaybackAndUnload` path, which persists a paused snapshot.
- `onDestroy` previously cancelled a still-pending debounced snapshot persist, leaving a stale "playing" snapshot behind — reopening the app then fake-resumed playback the system had already torn down. The pending persist is now flushed as paused before teardown.

## Testing

- `:app:compileDebugKotlin` ✅
- `:app:lintDebug` ✅ (clean)
- `:app:testDebugUnitTest` ✅ (includes new `TaskRemovedPolicyTest`)