### PR TITLE
Stop flashing and stranding the processing-action notification

### DIFF
--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
@@ -16,6 +16,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.glance.appwidget.GlanceAppWidgetManager
@@ -214,6 +215,7 @@ class MusicService : MediaLibraryService() {
     private var lastNoisyPauseRealtimeMs = 0L
     private var resumeOnHeadsetReconnectEnabled = false
     private var temporaryForegroundStartedInOnCreate = false
+    private var temporaryForegroundNotificationVisible = false
 
     companion object {
         private const val TAG = "MusicService_PixelPlayer"
@@ -358,8 +360,13 @@ class MusicService : MediaLibraryService() {
             }
         }
 
-        temporaryForegroundStartedInOnCreate =
-            consumePendingMediaButtonForegroundStart() || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+        // Only promote to foreground here when a media-button start is actually
+        // pending. Promoting unconditionally made every service creation — including
+        // plain in-app binds when the user opens the app — flash the "Processing
+        // playback action…" placeholder notification. Started paths that require
+        // foreground (widget actions, media buttons) are promoted in onStartCommand,
+        // which runs right after onCreate and well within the FGS grace window.
+        temporaryForegroundStartedInOnCreate = consumePendingMediaButtonForegroundStart()
         if (temporaryForegroundStartedInOnCreate) {
             startTemporaryForegroundForCommand()
         }
@@ -752,6 +759,7 @@ class MusicService : MediaLibraryService() {
                 delay(2_000L)
                 if (mediaSession?.player?.hasForegroundPlaybackIntent() != true) {
                     stopForeground(STOP_FOREGROUND_REMOVE)
+                    clearTemporaryForegroundNotification()
                 }
             }
         }
@@ -803,8 +811,25 @@ class MusicService : MediaLibraryService() {
                 notification,
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
             )
+            temporaryForegroundNotificationVisible = true
         } catch (e: Exception) {
             Timber.tag(TAG).w(e, "Failed to promote service to foreground for external command")
+        }
+    }
+
+    /**
+     * Media3's notification provider posts under its own id, so promoting the real
+     * media notification does not replace the temporary placeholder — without an
+     * explicit cancel the "Processing playback action…" notification stays behind
+     * forever once the session notification takes over the foreground.
+     */
+    private fun clearTemporaryForegroundNotification() {
+        if (!temporaryForegroundNotificationVisible) return
+        temporaryForegroundNotificationVisible = false
+        runCatching {
+            NotificationManagerCompat.from(this).cancel(NOTIFICATION_ID)
+        }.onFailure { e ->
+            Timber.tag(TAG).w(e, "Failed to cancel temporary foreground notification")
         }
     }
 
@@ -926,6 +951,7 @@ class MusicService : MediaLibraryService() {
         if (needsTemporaryForeground || startedTemporaryForegroundInOnCreate) {
             if (mediaSession?.player?.hasForegroundPlaybackIntent() != true) {
                 stopForeground(STOP_FOREGROUND_REMOVE)
+                clearTemporaryForegroundNotification()
                 if (needsTemporaryForeground) {
                     stopSelfResult(startId)
                 }
@@ -2190,6 +2216,9 @@ class MusicService : MediaLibraryService() {
 
         try {
             super.onUpdateNotification(session, shouldStartInForeground)
+            if (session.player.mediaItemCount > 0) {
+                clearTemporaryForegroundNotification()
+            }
         } catch (e: Exception) {
             Timber.tag(TAG).w(e, "onUpdateNotification suppressed: ${e.message}")
         }
@@ -2283,6 +2312,7 @@ class MusicService : MediaLibraryService() {
 
         requestWidgetFullUpdate(force = true)
         stopForeground(STOP_FOREGROUND_REMOVE)
+        clearTemporaryForegroundNotification()
 
         stopSelf()
     }


### PR DESCRIPTION
Fixes #56

Stacked on #64.

## What

Stops the "Processing playback action…" placeholder notification from appearing on plain app opens and from being stranded in the notification shade.

## Why

Two defects combined into the reported behavior:

1. `onCreate` promoted the service to foreground on **every** creation on API 26+, including plain in-app binds when the user simply opens the app — flashing the placeholder each time. The promotion is now done only when a media-button start is actually pending; started paths that need foreground (widget actions, media buttons, forced starts) are already promoted in `onStartCommand`, which runs immediately after `onCreate` and well within the FGS grace window. All cold-start paths were audited: the media-button receiver sets the pending flag, widget actions carry `EXTRA_FORCE_FOREGROUND_ON_START` or a handled action, and the sleep-timer receiver uses a plain `startService` while playback is already foreground.
2. The placeholder is posted under id 101 while Media3's `DefaultMediaNotificationProvider` posts under its own id (1001). When the real media notification took over the foreground, the placeholder was orphaned — nothing ever cancelled it, so it sat in the shade until reboot. The service now tracks placeholder visibility and cancels it explicitly whenever the session notification takes over or the temporary foreground ends.

## Testing

- `:app:compileDebugKotlin` ✅
- `:app:lintDebug` ✅ (clean)
- `:app:testDebugUnitTest` ✅