### PR TITLE
Add app-private offline caching for cloud music

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -228,6 +228,8 @@ dependencies {
     implementation(libs.androidx.paging.compose)
     implementation(libs.androidx.paging.common)
 
+    implementation(libs.androidx.media3.database)
+    implementation(libs.androidx.media3.datasource)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.ui)
     implementation(libs.androidx.media3.session)

--- a/app/schemas/com.lostf1sh.pixelplayeross.data.database.PixelPlayerDatabase/4.json
+++ b/app/schemas/com.lostf1sh.pixelplayeross.data.database.PixelPlayerDatabase/4.json
@@ -1,0 +1,2408 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "478ae5ca368b6eb4fad3a5571d238903",
+    "entities": [
+      {
+        "tableName": "album_art_themes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumArtUriString` TEXT NOT NULL, `paletteStyle` TEXT NOT NULL, `light_primary` TEXT NOT NULL, `light_onPrimary` TEXT NOT NULL, `light_primaryContainer` TEXT NOT NULL, `light_onPrimaryContainer` TEXT NOT NULL, `light_secondary` TEXT NOT NULL, `light_onSecondary` TEXT NOT NULL, `light_secondaryContainer` TEXT NOT NULL, `light_onSecondaryContainer` TEXT NOT NULL, `light_tertiary` TEXT NOT NULL, `light_onTertiary` TEXT NOT NULL, `light_tertiaryContainer` TEXT NOT NULL, `light_onTertiaryContainer` TEXT NOT NULL, `light_background` TEXT NOT NULL, `light_onBackground` TEXT NOT NULL, `light_surface` TEXT NOT NULL, `light_onSurface` TEXT NOT NULL, `light_surfaceVariant` TEXT NOT NULL, `light_onSurfaceVariant` TEXT NOT NULL, `light_error` TEXT NOT NULL, `light_onError` TEXT NOT NULL, `light_outline` TEXT NOT NULL, `light_errorContainer` TEXT NOT NULL, `light_onErrorContainer` TEXT NOT NULL, `light_inversePrimary` TEXT NOT NULL, `light_inverseSurface` TEXT NOT NULL, `light_inverseOnSurface` TEXT NOT NULL, `light_surfaceTint` TEXT NOT NULL, `light_outlineVariant` TEXT NOT NULL, `light_scrim` TEXT NOT NULL, `light_surfaceBright` TEXT NOT NULL, `light_surfaceDim` TEXT NOT NULL, `light_surfaceContainer` TEXT NOT NULL, `light_surfaceContainerHigh` TEXT NOT NULL, `light_surfaceContainerHighest` TEXT NOT NULL, `light_surfaceContainerLow` TEXT NOT NULL, `light_surfaceContainerLowest` TEXT NOT NULL, `light_primaryFixed` TEXT NOT NULL, `light_primaryFixedDim` TEXT NOT NULL, `light_onPrimaryFixed` TEXT NOT NULL, `light_onPrimaryFixedVariant` TEXT NOT NULL, `light_secondaryFixed` TEXT NOT NULL, `light_secondaryFixedDim` TEXT NOT NULL, `light_onSecondaryFixed` TEXT NOT NULL, `light_onSecondaryFixedVariant` TEXT NOT NULL, `light_tertiaryFixed` TEXT NOT NULL, `light_tertiaryFixedDim` TEXT NOT NULL, `light_onTertiaryFixed` TEXT NOT NULL, `light_onTertiaryFixedVariant` TEXT NOT NULL, `dark_primary` TEXT NOT NULL, `dark_onPrimary` TEXT NOT NULL, `dark_primaryContainer` TEXT NOT NULL, `dark_onPrimaryContainer` TEXT NOT NULL, `dark_secondary` TEXT NOT NULL, `dark_onSecondary` TEXT NOT NULL, `dark_secondaryContainer` TEXT NOT NULL, `dark_onSecondaryContainer` TEXT NOT NULL, `dark_tertiary` TEXT NOT NULL, `dark_onTertiary` TEXT NOT NULL, `dark_tertiaryContainer` TEXT NOT NULL, `dark_onTertiaryContainer` TEXT NOT NULL, `dark_background` TEXT NOT NULL, `dark_onBackground` TEXT NOT NULL, `dark_surface` TEXT NOT NULL, `dark_onSurface` TEXT NOT NULL, `dark_surfaceVariant` TEXT NOT NULL, `dark_onSurfaceVariant` TEXT NOT NULL, `dark_error` TEXT NOT NULL, `dark_onError` TEXT NOT NULL, `dark_outline` TEXT NOT NULL, `dark_errorContainer` TEXT NOT NULL, `dark_onErrorContainer` TEXT NOT NULL, `dark_inversePrimary` TEXT NOT NULL, `dark_inverseSurface` TEXT NOT NULL, `dark_inverseOnSurface` TEXT NOT NULL, `dark_surfaceTint` TEXT NOT NULL, `dark_outlineVariant` TEXT NOT NULL, `dark_scrim` TEXT NOT NULL, `dark_surfaceBright` TEXT NOT NULL, `dark_surfaceDim` TEXT NOT NULL, `dark_surfaceContainer` TEXT NOT NULL, `dark_surfaceContainerHigh` TEXT NOT NULL, `dark_surfaceContainerHighest` TEXT NOT NULL, `dark_surfaceContainerLow` TEXT NOT NULL, `dark_surfaceContainerLowest` TEXT NOT NULL, `dark_primaryFixed` TEXT NOT NULL, `dark_primaryFixedDim` TEXT NOT NULL, `dark_onPrimaryFixed` TEXT NOT NULL, `dark_onPrimaryFixedVariant` TEXT NOT NULL, `dark_secondaryFixed` TEXT NOT NULL, `dark_secondaryFixedDim` TEXT NOT NULL, `dark_onSecondaryFixed` TEXT NOT NULL, `dark_onSecondaryFixedVariant` TEXT NOT NULL, `dark_tertiaryFixed` TEXT NOT NULL, `dark_tertiaryFixedDim` TEXT NOT NULL, `dark_onTertiaryFixed` TEXT NOT NULL, `dark_onTertiaryFixedVariant` TEXT NOT NULL, PRIMARY KEY(`albumArtUriString`))",
+        "fields": [
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "albumArtUriString",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paletteStyle",
+            "columnName": "paletteStyle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primary",
+            "columnName": "light_primary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimary",
+            "columnName": "light_onPrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryContainer",
+            "columnName": "light_primaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryContainer",
+            "columnName": "light_onPrimaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondary",
+            "columnName": "light_secondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondary",
+            "columnName": "light_onSecondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryContainer",
+            "columnName": "light_secondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryContainer",
+            "columnName": "light_onSecondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiary",
+            "columnName": "light_tertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiary",
+            "columnName": "light_onTertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryContainer",
+            "columnName": "light_tertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryContainer",
+            "columnName": "light_onTertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.background",
+            "columnName": "light_background",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onBackground",
+            "columnName": "light_onBackground",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surface",
+            "columnName": "light_surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSurface",
+            "columnName": "light_onSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceVariant",
+            "columnName": "light_surfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSurfaceVariant",
+            "columnName": "light_onSurfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.error",
+            "columnName": "light_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onError",
+            "columnName": "light_onError",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.outline",
+            "columnName": "light_outline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.errorContainer",
+            "columnName": "light_errorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onErrorContainer",
+            "columnName": "light_onErrorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inversePrimary",
+            "columnName": "light_inversePrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inverseSurface",
+            "columnName": "light_inverseSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inverseOnSurface",
+            "columnName": "light_inverseOnSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceTint",
+            "columnName": "light_surfaceTint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.outlineVariant",
+            "columnName": "light_outlineVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.scrim",
+            "columnName": "light_scrim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceBright",
+            "columnName": "light_surfaceBright",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceDim",
+            "columnName": "light_surfaceDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainer",
+            "columnName": "light_surfaceContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerHigh",
+            "columnName": "light_surfaceContainerHigh",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerHighest",
+            "columnName": "light_surfaceContainerHighest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerLow",
+            "columnName": "light_surfaceContainerLow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerLowest",
+            "columnName": "light_surfaceContainerLowest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryFixed",
+            "columnName": "light_primaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryFixedDim",
+            "columnName": "light_primaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryFixed",
+            "columnName": "light_onPrimaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryFixedVariant",
+            "columnName": "light_onPrimaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryFixed",
+            "columnName": "light_secondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryFixedDim",
+            "columnName": "light_secondaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryFixed",
+            "columnName": "light_onSecondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryFixedVariant",
+            "columnName": "light_onSecondaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryFixed",
+            "columnName": "light_tertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryFixedDim",
+            "columnName": "light_tertiaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryFixed",
+            "columnName": "light_onTertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryFixedVariant",
+            "columnName": "light_onTertiaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primary",
+            "columnName": "dark_primary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimary",
+            "columnName": "dark_onPrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryContainer",
+            "columnName": "dark_primaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryContainer",
+            "columnName": "dark_onPrimaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondary",
+            "columnName": "dark_secondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondary",
+            "columnName": "dark_onSecondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryContainer",
+            "columnName": "dark_secondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryContainer",
+            "columnName": "dark_onSecondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiary",
+            "columnName": "dark_tertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiary",
+            "columnName": "dark_onTertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryContainer",
+            "columnName": "dark_tertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryContainer",
+            "columnName": "dark_onTertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.background",
+            "columnName": "dark_background",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onBackground",
+            "columnName": "dark_onBackground",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surface",
+            "columnName": "dark_surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSurface",
+            "columnName": "dark_onSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceVariant",
+            "columnName": "dark_surfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSurfaceVariant",
+            "columnName": "dark_onSurfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.error",
+            "columnName": "dark_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onError",
+            "columnName": "dark_onError",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.outline",
+            "columnName": "dark_outline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.errorContainer",
+            "columnName": "dark_errorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onErrorContainer",
+            "columnName": "dark_onErrorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inversePrimary",
+            "columnName": "dark_inversePrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inverseSurface",
+            "columnName": "dark_inverseSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inverseOnSurface",
+            "columnName": "dark_inverseOnSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceTint",
+            "columnName": "dark_surfaceTint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.outlineVariant",
+            "columnName": "dark_outlineVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.scrim",
+            "columnName": "dark_scrim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceBright",
+            "columnName": "dark_surfaceBright",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceDim",
+            "columnName": "dark_surfaceDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainer",
+            "columnName": "dark_surfaceContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerHigh",
+            "columnName": "dark_surfaceContainerHigh",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerHighest",
+            "columnName": "dark_surfaceContainerHighest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerLow",
+            "columnName": "dark_surfaceContainerLow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerLowest",
+            "columnName": "dark_surfaceContainerLowest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryFixed",
+            "columnName": "dark_primaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryFixedDim",
+            "columnName": "dark_primaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryFixed",
+            "columnName": "dark_onPrimaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryFixedVariant",
+            "columnName": "dark_onPrimaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryFixed",
+            "columnName": "dark_secondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryFixedDim",
+            "columnName": "dark_secondaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryFixed",
+            "columnName": "dark_onSecondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryFixedVariant",
+            "columnName": "dark_onSecondaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryFixed",
+            "columnName": "dark_tertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryFixedDim",
+            "columnName": "dark_tertiaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryFixed",
+            "columnName": "dark_onTertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryFixedVariant",
+            "columnName": "dark_onTertiaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumArtUriString"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_art_themes_albumArtUriString_paletteStyle",
+            "unique": false,
+            "columnNames": [
+              "albumArtUriString",
+              "paletteStyle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_art_themes_albumArtUriString_paletteStyle` ON `${TABLE_NAME}` (`albumArtUriString`, `paletteStyle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `artist_id` INTEGER NOT NULL, `album_artist` TEXT, `album_artist_id` INTEGER NOT NULL DEFAULT 0, `album_name` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `content_uri_string` TEXT NOT NULL, `album_art_uri_string` TEXT, `duration` INTEGER NOT NULL, `genre` TEXT, `file_path` TEXT NOT NULL, `parent_directory_path` TEXT NOT NULL, `is_favorite` INTEGER NOT NULL DEFAULT 0, `lyrics` TEXT DEFAULT null, `track_number` INTEGER NOT NULL DEFAULT 0, `disc_number` INTEGER DEFAULT null, `year` INTEGER NOT NULL DEFAULT 0, `date_added` INTEGER NOT NULL DEFAULT 0, `mime_type` TEXT, `bitrate` INTEGER, `sample_rate` INTEGER, `artists_json` TEXT, `source_type` INTEGER NOT NULL DEFAULT 0, `media_store_date_added` INTEGER NOT NULL DEFAULT 0, `media_store_date_modified` INTEGER NOT NULL DEFAULT 0, `title_user_edited` INTEGER NOT NULL DEFAULT 0, `artist_user_edited` INTEGER NOT NULL DEFAULT 0, `album_user_edited` INTEGER NOT NULL DEFAULT 0, `genre_user_edited` INTEGER NOT NULL DEFAULT 0, `mb_recording_id` TEXT, `mb_release_id` TEXT, `mb_artist_id` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`album_id`) REFERENCES `albums`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artist_id`) REFERENCES `artists`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtistId",
+            "columnName": "album_artist_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "album_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentUriString",
+            "columnName": "content_uri_string",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "album_art_uri_string",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentDirectoryPath",
+            "columnName": "parent_directory_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sample_rate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artists_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaStoreDateAdded",
+            "columnName": "media_store_date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaStoreDateModified",
+            "columnName": "media_store_date_modified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "titleUserEdited",
+            "columnName": "title_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "artistUserEdited",
+            "columnName": "artist_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "albumUserEdited",
+            "columnName": "album_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "genreUserEdited",
+            "columnName": "genre_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mbRecordingId",
+            "columnName": "mb_recording_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mbReleaseId",
+            "columnName": "mb_release_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mbArtistId",
+            "columnName": "mb_artist_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_songs_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_songs_album_id",
+            "unique": false,
+            "columnNames": [
+              "album_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_album_id` ON `${TABLE_NAME}` (`album_id`)"
+          },
+          {
+            "name": "index_songs_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_songs_artist_name",
+            "unique": false,
+            "columnNames": [
+              "artist_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_artist_name` ON `${TABLE_NAME}` (`artist_name`)"
+          },
+          {
+            "name": "index_songs_genre",
+            "unique": false,
+            "columnNames": [
+              "genre"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_genre` ON `${TABLE_NAME}` (`genre`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path` ON `${TABLE_NAME}` (`parent_directory_path`)"
+          },
+          {
+            "name": "index_songs_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_songs_content_uri_string",
+            "unique": false,
+            "columnNames": [
+              "content_uri_string"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_content_uri_string` ON `${TABLE_NAME}` (`content_uri_string`)"
+          },
+          {
+            "name": "index_songs_date_added",
+            "unique": false,
+            "columnNames": [
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_date_added` ON `${TABLE_NAME}` (`date_added`)"
+          },
+          {
+            "name": "index_songs_duration",
+            "unique": false,
+            "columnNames": [
+              "duration"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_duration` ON `${TABLE_NAME}` (`duration`)"
+          },
+          {
+            "name": "index_songs_source_type",
+            "unique": false,
+            "columnNames": [
+              "source_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_source_type` ON `${TABLE_NAME}` (`source_type`)"
+          },
+          {
+            "name": "index_songs_album_artist_id",
+            "unique": false,
+            "columnNames": [
+              "album_artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_album_artist_id` ON `${TABLE_NAME}` (`album_artist_id`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path_source_type_album_id",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path",
+              "source_type",
+              "album_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path_source_type_album_id` ON `${TABLE_NAME}` (`parent_directory_path`, `source_type`, `album_id`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path_source_type_id",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path",
+              "source_type",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path_source_type_id` ON `${TABLE_NAME}` (`parent_directory_path`, `source_type`, `id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "albums",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "album_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artists",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "songs_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, tokenize=unicode61)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": []
+      },
+      {
+        "tableName": "albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `artist_id` INTEGER NOT NULL, `album_art_uri_string` TEXT, `song_count` INTEGER NOT NULL, `date_added` INTEGER NOT NULL, `year` INTEGER NOT NULL, `album_artist` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "album_art_uri_string",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_albums_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_albums_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_albums_artist_name",
+            "unique": false,
+            "columnNames": [
+              "artist_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_artist_name` ON `${TABLE_NAME}` (`artist_name`)"
+          },
+          {
+            "name": "index_albums_album_artist",
+            "unique": false,
+            "columnNames": [
+              "album_artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_album_artist` ON `${TABLE_NAME}` (`album_artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `track_count` INTEGER NOT NULL, `image_url` TEXT, `custom_image_uri` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customImageUri",
+            "columnName": "custom_image_uri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transition_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `fromTrackId` TEXT, `toTrackId` TEXT, `mode` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `curveIn` TEXT NOT NULL, `curveOut` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromTrackId",
+            "columnName": "fromTrackId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toTrackId",
+            "columnName": "toTrackId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "settings.mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.curveIn",
+            "columnName": "curveIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.curveOut",
+            "columnName": "curveOut",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transition_rules_playlistId_fromTrackId_toTrackId",
+            "unique": true,
+            "columnNames": [
+              "playlistId",
+              "fromTrackId",
+              "toTrackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transition_rules_playlistId_fromTrackId_toTrackId` ON `${TABLE_NAME}` (`playlistId`, `fromTrackId`, `toTrackId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "song_artist_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song_id` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `is_primary` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`song_id`, `artist_id`), FOREIGN KEY(`song_id`) REFERENCES `songs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artist_id`) REFERENCES `artists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrimary",
+            "columnName": "is_primary",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song_id",
+            "artist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_cross_ref_song_id",
+            "unique": false,
+            "columnNames": [
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_song_id` ON `${TABLE_NAME}` (`song_id`)"
+          },
+          {
+            "name": "index_song_artist_cross_ref_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_song_artist_cross_ref_is_primary",
+            "unique": false,
+            "columnNames": [
+              "is_primary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_is_primary` ON `${TABLE_NAME}` (`is_primary`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "songs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "song_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_engagements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song_id` TEXT NOT NULL, `play_count` INTEGER NOT NULL, `total_play_duration_ms` INTEGER NOT NULL, `last_played_timestamp` INTEGER NOT NULL, PRIMARY KEY(`song_id`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayDurationMs",
+            "columnName": "total_play_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedTimestamp",
+            "columnName": "last_played_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_engagements_play_count",
+            "unique": false,
+            "columnNames": [
+              "play_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_engagements_play_count` ON `${TABLE_NAME}` (`play_count`)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`songId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorites_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` INTEGER NOT NULL, `content` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, `source` TEXT, PRIMARY KEY(`songId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `last_modified` INTEGER NOT NULL, `is_queue_generated` INTEGER NOT NULL, `cover_image_uri` TEXT, `cover_color_argb` INTEGER, `cover_icon_name` TEXT, `cover_shape_type` TEXT, `cover_shape_detail_1` REAL, `cover_shape_detail_2` REAL, `cover_shape_detail_3` REAL, `cover_shape_detail_4` REAL, `source` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isQueueGenerated",
+            "columnName": "is_queue_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverImageUri",
+            "columnName": "cover_image_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverColorArgb",
+            "columnName": "cover_color_argb",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverIconName",
+            "columnName": "cover_icon_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverShapeType",
+            "columnName": "cover_shape_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverShapeDetail1",
+            "columnName": "cover_shape_detail_1",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail2",
+            "columnName": "cover_shape_detail_2",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail3",
+            "columnName": "cover_shape_detail_3",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail4",
+            "columnName": "cover_shape_detail_4",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_last_modified",
+            "unique": false,
+            "columnNames": [
+              "last_modified"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_last_modified` ON `${TABLE_NAME}` (`last_modified`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` TEXT NOT NULL, `song_id` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `song_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "song_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_songs_playlist_id_sort_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "sort_order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_songs_playlist_id_sort_order` ON `${TABLE_NAME}` (`playlist_id`, `sort_order`)"
+          },
+          {
+            "name": "index_playlist_songs_song_id",
+            "unique": false,
+            "columnNames": [
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_songs_song_id` ON `${TABLE_NAME}` (`song_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "navidrome_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `navidrome_id` TEXT NOT NULL, `playlist_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album_artist` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `cover_art_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `suffix` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "navidromeId",
+            "columnName": "navidrome_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "cover_art_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_navidrome_songs_navidrome_id",
+            "unique": false,
+            "columnNames": [
+              "navidrome_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_navidrome_id` ON `${TABLE_NAME}` (`navidrome_id`)"
+          },
+          {
+            "name": "index_navidrome_songs_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_navidrome_songs_playlist_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_playlist_id_date_added` ON `${TABLE_NAME}` (`playlist_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "navidrome_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `comment` TEXT, `owner` TEXT, `cover_art_id` TEXT, `song_count` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `public` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "cover_art_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "public",
+            "columnName": "public",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "jellyfin_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `jellyfin_id` TEXT NOT NULL, `playlist_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album_artist` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jellyfinId",
+            "columnName": "jellyfin_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_jellyfin_songs_jellyfin_id",
+            "unique": false,
+            "columnNames": [
+              "jellyfin_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_jellyfin_id` ON `${TABLE_NAME}` (`jellyfin_id`)"
+          },
+          {
+            "name": "index_jellyfin_songs_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_jellyfin_songs_playlist_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_playlist_id_date_added` ON `${TABLE_NAME}` (`playlist_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "jellyfin_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `song_count` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "listenbrainz_pending_listens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listened_at_ms` INTEGER NOT NULL, `track_name` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `release_name` TEXT, `duration_ms` INTEGER, `recording_mbid` TEXT, `source` TEXT NOT NULL, `attempts` INTEGER NOT NULL DEFAULT 0, `created_at_ms` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listenedAtMs",
+            "columnName": "listened_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackName",
+            "columnName": "track_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseName",
+            "columnName": "release_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "recordingMbid",
+            "columnName": "recording_mbid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "created_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collection_id` TEXT NOT NULL, `collection_type` TEXT NOT NULL, `source_id` TEXT NOT NULL, `title` TEXT NOT NULL, `subtitle` TEXT, `artwork_uri` TEXT, `created_at_ms` INTEGER NOT NULL, PRIMARY KEY(`collection_id`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collection_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionType",
+            "columnName": "collection_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artworkUri",
+            "columnName": "artwork_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "created_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collection_id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` TEXT NOT NULL, `cache_key` TEXT, `song_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` INTEGER NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `album_artist` TEXT, `path` TEXT NOT NULL, `content_uri` TEXT NOT NULL, `artwork_uri` TEXT, `duration_ms` INTEGER NOT NULL, `genre` TEXT, `track_number` INTEGER NOT NULL, `disc_number` INTEGER, `year` INTEGER NOT NULL, `date_added` INTEGER NOT NULL, `date_modified` INTEGER NOT NULL, `mime_type` TEXT, `bitrate` INTEGER, `sample_rate` INTEGER, `navidrome_id` TEXT, `jellyfin_id` TEXT, `is_remote` INTEGER NOT NULL, `added_at_ms` INTEGER NOT NULL, PRIMARY KEY(`track_id`))",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentUri",
+            "columnName": "content_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artworkUri",
+            "columnName": "artwork_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "date_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sample_rate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "navidromeId",
+            "columnName": "navidrome_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "jellyfinId",
+            "columnName": "jellyfin_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRemote",
+            "columnName": "is_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtMs",
+            "columnName": "added_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_tracks_cache_key",
+            "unique": true,
+            "columnNames": [
+              "cache_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cached_tracks_cache_key` ON `${TABLE_NAME}` (`cache_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_collection_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collection_id` TEXT NOT NULL, `track_id` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`collection_id`, `track_id`), FOREIGN KEY(`collection_id`) REFERENCES `cached_collections`(`collection_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`track_id`) REFERENCES `cached_tracks`(`track_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collection_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collection_id",
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_collection_tracks_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_collection_tracks_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "cached_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collection_id"
+            ],
+            "referencedColumns": [
+              "collection_id"
+            ]
+          },
+          {
+            "table": "cached_tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "track_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '478ae5ca368b6eb4fad3a5571d238903')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/lostf1sh/pixelplayeross/data/database/OfflineMediaDaoTest.kt
+++ b/app/src/androidTest/java/com/lostf1sh/pixelplayeross/data/database/OfflineMediaDaoTest.kt
@@ -1,0 +1,102 @@
+package com.lostf1sh.pixelplayeross.data.database
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.withTransaction
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OfflineMediaDaoTest {
+    private lateinit var database: PixelPlayerDatabase
+    private lateinit var dao: OfflineMediaDao
+
+    @Before
+    fun createDatabase() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, PixelPlayerDatabase::class.java)
+            .addCallback(PixelPlayerDatabase.createRuntimeArtifactsCallback())
+            .allowMainThreadQueries()
+            .build()
+        dao = database.offlineMediaDao()
+    }
+
+    @After
+    fun closeDatabase() {
+        database.close()
+    }
+
+    @Test
+    fun removingLargeCollectionDoesNotUseTrackIdsAsBindParameters() = runTest {
+        val targetCollection = collection("target")
+        val sharedCollection = collection("shared")
+        val tracks = List(1_001) { index -> track("track-$index") }
+        database.withTransaction {
+            dao.upsertCollection(targetCollection)
+            dao.upsertCollection(sharedCollection)
+            dao.upsertTracks(tracks)
+            dao.upsertCrossRefs(
+                tracks.mapIndexed { index, track ->
+                    CachedCollectionTrackCrossRef(targetCollection.collectionId, track.trackId, index)
+                } + CachedCollectionTrackCrossRef(sharedCollection.collectionId, tracks.first().trackId, 0)
+            )
+        }
+
+        val removedTracks = database.withTransaction {
+            val exclusiveTracks = dao.tracksExclusiveToCollection(targetCollection.collectionId)
+            dao.deleteTracksExclusiveToCollection(targetCollection.collectionId)
+            dao.deleteCollection(targetCollection.collectionId)
+            exclusiveTracks
+        }
+
+        assertEquals(1_000, removedTracks.size)
+        assertEquals(listOf(tracks.first().trackId), dao.observeTracks().first().map(CachedTrackEntity::trackId))
+        assertEquals(listOf(sharedCollection.collectionId), dao.observeCollections().first().map(CachedCollectionEntity::collectionId))
+    }
+
+    private fun collection(id: String) = CachedCollectionEntity(
+        collectionId = id,
+        collectionType = "PLAYLIST",
+        sourceId = id,
+        title = id,
+        subtitle = null,
+        artworkUri = null,
+        createdAtMs = 0L,
+    )
+
+    private fun track(id: String) = CachedTrackEntity(
+        trackId = id,
+        cacheKey = "cache-$id",
+        songId = id,
+        title = id,
+        artist = "Artist",
+        artistId = 1L,
+        album = "Album",
+        albumId = 1L,
+        albumArtist = null,
+        path = "",
+        contentUri = "navidrome://$id",
+        artworkUri = null,
+        durationMs = 60_000L,
+        genre = null,
+        trackNumber = 1,
+        discNumber = null,
+        year = 2026,
+        dateAdded = 0L,
+        dateModified = 0L,
+        mimeType = "audio/mpeg",
+        bitrate = 320_000,
+        sampleRate = 44_100,
+        navidromeId = id,
+        jellyfinId = null,
+        isRemote = true,
+        addedAtMs = 0L,
+    )
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission
         android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
@@ -117,6 +118,16 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.APP_MUSIC" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".data.offline.OfflineMediaDownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync">
+            <intent-filter>
+                <action android:name="androidx.media3.exoplayer.downloadService.action.RESTART" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </service>
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/PixelPlayerApplication.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/PixelPlayerApplication.kt
@@ -13,6 +13,7 @@ import androidx.work.Configuration
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
+import com.lostf1sh.pixelplayeross.data.offline.OfflineMediaRepository
 import com.lostf1sh.pixelplayeross.data.repository.ArtistImageRepository
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.LibraryStateHolder
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.ThemeStateHolder
@@ -62,6 +63,9 @@ class PixelPlayerApplication : Application(), ImageLoaderFactory, Configuration.
     @Inject
     lateinit var syncManager: dagger.Lazy<com.lostf1sh.pixelplayeross.data.worker.SyncManager>
 
+    @Inject
+    lateinit var offlineMediaRepository: dagger.Lazy<OfflineMediaRepository>
+
     private val startupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     companion object {
@@ -71,6 +75,7 @@ class PixelPlayerApplication : Application(), ImageLoaderFactory, Configuration.
     private val appLifecycleObserver = object : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {
             libraryStateHolder.get().restoreAfterTrimIfNeeded()
+            offlineMediaRepository.get().resumePendingDownloads()
         }
     }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/Migrations.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/Migrations.kt
@@ -87,3 +87,76 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
         db.addColumnIfMissing("songs", "mb_artist_id", "`mb_artist_id` TEXT")
     }
 }
+
+/** v3 -> v4: metadata and reference counts for user-selected offline collections. */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+                CREATE TABLE IF NOT EXISTS `cached_collections` (
+                    `collection_id` TEXT NOT NULL,
+                    `collection_type` TEXT NOT NULL,
+                    `source_id` TEXT NOT NULL,
+                    `title` TEXT NOT NULL,
+                    `subtitle` TEXT,
+                    `artwork_uri` TEXT,
+                    `created_at_ms` INTEGER NOT NULL,
+                    PRIMARY KEY(`collection_id`)
+                )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+                CREATE TABLE IF NOT EXISTS `cached_tracks` (
+                    `track_id` TEXT NOT NULL,
+                    `cache_key` TEXT,
+                    `song_id` TEXT NOT NULL,
+                    `title` TEXT NOT NULL,
+                    `artist` TEXT NOT NULL,
+                    `artist_id` INTEGER NOT NULL,
+                    `album` TEXT NOT NULL,
+                    `album_id` INTEGER NOT NULL,
+                    `album_artist` TEXT,
+                    `path` TEXT NOT NULL,
+                    `content_uri` TEXT NOT NULL,
+                    `artwork_uri` TEXT,
+                    `duration_ms` INTEGER NOT NULL,
+                    `genre` TEXT,
+                    `track_number` INTEGER NOT NULL,
+                    `disc_number` INTEGER,
+                    `year` INTEGER NOT NULL,
+                    `date_added` INTEGER NOT NULL,
+                    `date_modified` INTEGER NOT NULL,
+                    `mime_type` TEXT,
+                    `bitrate` INTEGER,
+                    `sample_rate` INTEGER,
+                    `navidrome_id` TEXT,
+                    `jellyfin_id` TEXT,
+                    `is_remote` INTEGER NOT NULL,
+                    `added_at_ms` INTEGER NOT NULL,
+                    PRIMARY KEY(`track_id`)
+                )
+            """.trimIndent()
+        )
+        db.execSQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS `index_cached_tracks_cache_key` " +
+                "ON `cached_tracks` (`cache_key`)"
+        )
+        db.execSQL(
+            """
+                CREATE TABLE IF NOT EXISTS `cached_collection_tracks` (
+                    `collection_id` TEXT NOT NULL,
+                    `track_id` TEXT NOT NULL,
+                    `sort_order` INTEGER NOT NULL,
+                    PRIMARY KEY(`collection_id`, `track_id`),
+                    FOREIGN KEY(`collection_id`) REFERENCES `cached_collections`(`collection_id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    FOREIGN KEY(`track_id`) REFERENCES `cached_tracks`(`track_id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+            """.trimIndent()
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_cached_collection_tracks_track_id` " +
+                "ON `cached_collection_tracks` (`track_id`)"
+        )
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/OfflineMediaEntities.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/OfflineMediaEntities.kt
@@ -1,0 +1,150 @@
+package com.lostf1sh.pixelplayeross.data.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Entity(tableName = "cached_collections")
+data class CachedCollectionEntity(
+    @androidx.room.PrimaryKey
+    @ColumnInfo(name = "collection_id")
+    val collectionId: String,
+    @ColumnInfo(name = "collection_type")
+    val collectionType: String,
+    @ColumnInfo(name = "source_id")
+    val sourceId: String,
+    val title: String,
+    val subtitle: String?,
+    @ColumnInfo(name = "artwork_uri")
+    val artworkUri: String?,
+    @ColumnInfo(name = "created_at_ms")
+    val createdAtMs: Long,
+)
+
+@Entity(
+    tableName = "cached_tracks",
+    indices = [Index(value = ["cache_key"], unique = true)],
+)
+data class CachedTrackEntity(
+    @androidx.room.PrimaryKey
+    @ColumnInfo(name = "track_id")
+    val trackId: String,
+    @ColumnInfo(name = "cache_key")
+    val cacheKey: String?,
+    @ColumnInfo(name = "song_id")
+    val songId: String,
+    val title: String,
+    val artist: String,
+    @ColumnInfo(name = "artist_id")
+    val artistId: Long,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "album_artist")
+    val albumArtist: String?,
+    val path: String,
+    @ColumnInfo(name = "content_uri")
+    val contentUri: String,
+    @ColumnInfo(name = "artwork_uri")
+    val artworkUri: String?,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    val genre: String?,
+    @ColumnInfo(name = "track_number")
+    val trackNumber: Int,
+    @ColumnInfo(name = "disc_number")
+    val discNumber: Int?,
+    val year: Int,
+    @ColumnInfo(name = "date_added")
+    val dateAdded: Long,
+    @ColumnInfo(name = "date_modified")
+    val dateModified: Long,
+    @ColumnInfo(name = "mime_type")
+    val mimeType: String?,
+    val bitrate: Int?,
+    @ColumnInfo(name = "sample_rate")
+    val sampleRate: Int?,
+    @ColumnInfo(name = "navidrome_id")
+    val navidromeId: String?,
+    @ColumnInfo(name = "jellyfin_id")
+    val jellyfinId: String?,
+    @ColumnInfo(name = "is_remote")
+    val isRemote: Boolean,
+    @ColumnInfo(name = "added_at_ms")
+    val addedAtMs: Long,
+)
+
+@Entity(
+    tableName = "cached_collection_tracks",
+    primaryKeys = ["collection_id", "track_id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = CachedCollectionEntity::class,
+            parentColumns = ["collection_id"],
+            childColumns = ["collection_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = CachedTrackEntity::class,
+            parentColumns = ["track_id"],
+            childColumns = ["track_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("track_id")],
+)
+data class CachedCollectionTrackCrossRef(
+    @ColumnInfo(name = "collection_id")
+    val collectionId: String,
+    @ColumnInfo(name = "track_id")
+    val trackId: String,
+    @ColumnInfo(name = "sort_order")
+    val sortOrder: Int,
+)
+
+@Dao
+interface OfflineMediaDao {
+    @Query("SELECT * FROM cached_collections ORDER BY created_at_ms DESC")
+    fun observeCollections(): Flow<List<CachedCollectionEntity>>
+
+    @Query("SELECT * FROM cached_tracks")
+    fun observeTracks(): Flow<List<CachedTrackEntity>>
+
+    @Query("SELECT * FROM cached_collection_tracks ORDER BY collection_id, sort_order")
+    fun observeCrossRefs(): Flow<List<CachedCollectionTrackCrossRef>>
+
+    @Upsert
+    suspend fun upsertCollection(collection: CachedCollectionEntity)
+
+    @Upsert
+    suspend fun upsertTracks(tracks: List<CachedTrackEntity>)
+
+    @Upsert
+    suspend fun upsertCrossRefs(crossRefs: List<CachedCollectionTrackCrossRef>)
+
+    @Query("DELETE FROM cached_collections WHERE collection_id = :collectionId")
+    suspend fun deleteCollection(collectionId: String)
+
+    @Query("SELECT track_id FROM cached_collection_tracks WHERE collection_id = :collectionId")
+    suspend fun trackIdsForCollection(collectionId: String): List<String>
+
+    @Query(
+        "SELECT * FROM cached_tracks WHERE track_id IN (:candidateIds) " +
+            "AND track_id NOT IN (SELECT track_id FROM cached_collection_tracks)"
+    )
+    suspend fun orphanedTracks(candidateIds: List<String>): List<CachedTrackEntity>
+
+    @Query("DELETE FROM cached_tracks WHERE track_id IN (:trackIds)")
+    suspend fun deleteTracks(trackIds: List<String>)
+
+    @Query("DELETE FROM cached_collections")
+    suspend fun clearCollections()
+
+    @Query("DELETE FROM cached_tracks")
+    suspend fun clearTracks()
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/OfflineMediaEntities.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/OfflineMediaEntities.kt
@@ -130,17 +130,39 @@ interface OfflineMediaDao {
     @Query("DELETE FROM cached_collections WHERE collection_id = :collectionId")
     suspend fun deleteCollection(collectionId: String)
 
-    @Query("SELECT track_id FROM cached_collection_tracks WHERE collection_id = :collectionId")
-    suspend fun trackIdsForCollection(collectionId: String): List<String>
+    @Query(
+        """
+        SELECT * FROM cached_tracks
+        WHERE EXISTS (
+            SELECT 1 FROM cached_collection_tracks AS target_ref
+            WHERE target_ref.track_id = cached_tracks.track_id
+                AND target_ref.collection_id = :collectionId
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM cached_collection_tracks AS other_ref
+            WHERE other_ref.track_id = cached_tracks.track_id
+                AND other_ref.collection_id != :collectionId
+        )
+        """
+    )
+    suspend fun tracksExclusiveToCollection(collectionId: String): List<CachedTrackEntity>
 
     @Query(
-        "SELECT * FROM cached_tracks WHERE track_id IN (:candidateIds) " +
-            "AND track_id NOT IN (SELECT track_id FROM cached_collection_tracks)"
+        """
+        DELETE FROM cached_tracks
+        WHERE EXISTS (
+            SELECT 1 FROM cached_collection_tracks AS target_ref
+            WHERE target_ref.track_id = cached_tracks.track_id
+                AND target_ref.collection_id = :collectionId
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM cached_collection_tracks AS other_ref
+            WHERE other_ref.track_id = cached_tracks.track_id
+                AND other_ref.collection_id != :collectionId
+        )
+        """
     )
-    suspend fun orphanedTracks(candidateIds: List<String>): List<CachedTrackEntity>
-
-    @Query("DELETE FROM cached_tracks WHERE track_id IN (:trackIds)")
-    suspend fun deleteTracks(trackIds: List<String>)
+    suspend fun deleteTracksExclusiveToCollection(collectionId: String)
 
     @Query("DELETE FROM cached_collections")
     suspend fun clearCollections()

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/PixelPlayerDatabase.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/PixelPlayerDatabase.kt
@@ -23,9 +23,12 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         NavidromePlaylistEntity::class,
         JellyfinSongEntity::class,
         JellyfinPlaylistEntity::class,
-        ListenBrainzPendingListenEntity::class
+        ListenBrainzPendingListenEntity::class,
+        CachedCollectionEntity::class,
+        CachedTrackEntity::class,
+        CachedCollectionTrackCrossRef::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 abstract class PixelPlayerDatabase : RoomDatabase() {
@@ -40,6 +43,7 @@ abstract class PixelPlayerDatabase : RoomDatabase() {
     abstract fun navidromeDao(): NavidromeDao
     abstract fun jellyfinDao(): JellyfinDao
     abstract fun listenBrainzDao(): ListenBrainzDao
+    abstract fun offlineMediaDao(): OfflineMediaDao
 
     companion object {
         fun installFavoriteSyncTriggers(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/model/LibraryTabId.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/model/LibraryTabId.kt
@@ -13,7 +13,8 @@ enum class LibraryTabId(
     ARTISTS("ARTIST", "ARTIST", SortOption.ArtistNameAZ),
     PLAYLISTS("PLAYLISTS", "PLAYLISTS", SortOption.PlaylistNameAZ),
     FOLDERS("FOLDERS", "FOLDERS", SortOption.FolderNameAZ),
-    LIKED("LIKED", "LIKED", SortOption.LikedSongDateLiked);
+    LIKED("LIKED", "LIKED", SortOption.LikedSongDateLiked),
+    CACHED("CACHED", "CACHED", SortOption.SongTitleAZ);
 
     companion object {
         fun fromStorageKey(key: String): LibraryTabId =

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaDownloadService.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaDownloadService.kt
@@ -1,0 +1,59 @@
+package com.lostf1sh.pixelplayeross.data.offline
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Intent
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadManager
+import androidx.media3.exoplayer.offline.DownloadNotificationHelper
+import androidx.media3.exoplayer.offline.DownloadService
+import androidx.media3.exoplayer.scheduler.Scheduler
+import com.lostf1sh.pixelplayeross.MainActivity
+import com.lostf1sh.pixelplayeross.R
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@OptIn(UnstableApi::class)
+@AndroidEntryPoint
+class OfflineMediaDownloadService : DownloadService(
+    NOTIFICATION_ID,
+    DEFAULT_FOREGROUND_NOTIFICATION_UPDATE_INTERVAL,
+    CHANNEL_ID,
+    R.string.offline_cache_notification_channel,
+    R.string.offline_cache_notification_channel_description,
+) {
+    @Inject lateinit var repository: OfflineMediaRepository
+
+    private val notificationHelper by lazy { DownloadNotificationHelper(this, CHANNEL_ID) }
+
+    override fun getDownloadManager(): DownloadManager = repository.downloadManager
+
+    override fun getScheduler(): Scheduler? = null
+
+    override fun getForegroundNotification(
+        downloads: List<Download>,
+        notMetRequirements: Int,
+    ): Notification {
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        return notificationHelper.buildProgressNotification(
+            this,
+            R.drawable.monochrome_player,
+            contentIntent,
+            getString(R.string.offline_cache_notification_message),
+            downloads,
+            notMetRequirements,
+        )
+    }
+
+    private companion object {
+        const val CHANNEL_ID = "offline_media_cache"
+        const val NOTIFICATION_ID = 48
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaRepository.kt
@@ -198,10 +198,17 @@ class OfflineMediaRepository @Inject constructor(
     }.stateIn(appScope, SharingStarted.Eagerly, OfflineMediaUiState())
 
     init {
-        // Repository injection happens from an Application/UI/service main thread.
-        downloadManager
-        mainScope.launch {
+        // Repository injection happens from an Application/UI/service main thread. Constructing
+        // Media3's database and caches performs disk I/O, so warm the manager on AppScope's IO
+        // dispatcher before the polling loop needs it.
+        appScope.launch {
+            downloadManager
             refreshDownloads()
+            launch {
+                preferences.offlineCacheLimitBytesFlow.collect {
+                    enforceRuntimeLimits()
+                }
+            }
             while (true) {
                 val active = downloadSnapshot.value.values.any {
                     it.state == Download.STATE_DOWNLOADING || it.state == Download.STATE_QUEUED ||
@@ -209,12 +216,6 @@ class OfflineMediaRepository @Inject constructor(
                 }
                 delay(if (active) 750L else 5_000L)
                 refreshDownloads()
-                enforceRuntimeLimits()
-            }
-        }
-
-        appScope.launch {
-            preferences.offlineCacheLimitBytesFlow.collect {
                 enforceRuntimeLimits()
             }
         }
@@ -437,15 +438,10 @@ private fun CachedCollectionEntity.toModel(
     downloads: Map<String, Download>,
 ): CachedCollection {
     val remoteDownloads = tracks.filter(CachedTrackEntity::isRemote).mapNotNull { downloads[it.trackId] }
-    val status = when {
-        remoteDownloads.any { it.state == Download.STATE_FAILED } -> OfflineItemStatus.FAILED
-        remoteDownloads.any { it.state == Download.STATE_DOWNLOADING } -> OfflineItemStatus.DOWNLOADING
-        remoteDownloads.any { it.state == Download.STATE_STOPPED } -> OfflineItemStatus.PAUSED
-        remoteDownloads.any { it.state == Download.STATE_QUEUED || it.state == Download.STATE_RESTARTING } ->
-            OfflineItemStatus.QUEUED
-        remoteDownloads.size == tracks.count(CachedTrackEntity::isRemote) -> OfflineItemStatus.COMPLETE
-        else -> OfflineItemStatus.QUEUED
-    }
+    val status = offlineItemStatus(
+        downloadStates = remoteDownloads.map(Download::state),
+        remoteTrackCount = tracks.count(CachedTrackEntity::isRemote),
+    )
     val progress = if (remoteDownloads.isEmpty()) {
         1f
     } else {
@@ -470,6 +466,21 @@ private fun CachedCollectionEntity.toModel(
         progress = progress.coerceIn(0f, 1f),
         downloadedBytes = remoteDownloads.sumOf { it.bytesDownloaded },
     )
+}
+
+internal fun offlineItemStatus(
+    downloadStates: List<Int>,
+    remoteTrackCount: Int,
+): OfflineItemStatus = when {
+    downloadStates.any { it == Download.STATE_FAILED } -> OfflineItemStatus.FAILED
+    downloadStates.any { it == Download.STATE_REMOVING } -> OfflineItemStatus.QUEUED
+    downloadStates.any { it == Download.STATE_DOWNLOADING } -> OfflineItemStatus.DOWNLOADING
+    downloadStates.any { it == Download.STATE_STOPPED } -> OfflineItemStatus.PAUSED
+    downloadStates.any { it == Download.STATE_QUEUED || it == Download.STATE_RESTARTING } ->
+        OfflineItemStatus.QUEUED
+    downloadStates.size == remoteTrackCount &&
+        downloadStates.all { it == Download.STATE_COMPLETED } -> OfflineItemStatus.COMPLETE
+    else -> OfflineItemStatus.QUEUED
 }
 
 private fun CachedTrackEntity.toSong(): Song = Song(

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaRepository.kt
@@ -323,15 +323,10 @@ class OfflineMediaRepository @Inject constructor(
     private suspend fun removeCollectionLocked(collectionId: String) {
         metadataReady.await()
         val orphaned = database.withTransaction {
-            val candidates = dao.trackIdsForCollection(collectionId)
+            val tracks = dao.tracksExclusiveToCollection(collectionId)
+            dao.deleteTracksExclusiveToCollection(collectionId)
             dao.deleteCollection(collectionId)
-            if (candidates.isEmpty()) {
-                emptyList()
-            } else {
-                dao.orphanedTracks(candidates).also { tracks ->
-                    dao.deleteTracks(tracks.map(CachedTrackEntity::trackId))
-                }
-            }
+            tracks
         }
         orphaned.filter(CachedTrackEntity::isRemote).forEach { track ->
             DownloadService.sendRemoveDownload(

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaRepository.kt
@@ -1,0 +1,502 @@
+@file:OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package com.lostf1sh.pixelplayeross.data.offline
+
+import android.content.Context
+import android.net.Uri
+import android.os.StatFs
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.ResolvingDataSource
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadManager
+import androidx.media3.exoplayer.offline.DownloadRequest
+import androidx.media3.exoplayer.offline.DownloadService
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.room.withTransaction
+import com.lostf1sh.pixelplayeross.data.database.CachedCollectionEntity
+import com.lostf1sh.pixelplayeross.data.database.CachedCollectionTrackCrossRef
+import com.lostf1sh.pixelplayeross.data.database.CachedTrackEntity
+import com.lostf1sh.pixelplayeross.data.database.OfflineMediaDao
+import com.lostf1sh.pixelplayeross.data.database.PixelPlayerDatabase
+import com.lostf1sh.pixelplayeross.data.jellyfin.JellyfinStreamProxy
+import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.navidrome.NavidromeStreamProxy
+import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
+import com.lostf1sh.pixelplayeross.data.service.player.PlaybackAudioCache
+import com.lostf1sh.pixelplayeross.data.service.player.MAX_TRANSIENT_PLAYBACK_CACHE_BYTES
+import com.lostf1sh.pixelplayeross.di.AppScope
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.security.MessageDigest
+import java.util.concurrent.Executors
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
+
+enum class CachedCollectionType { SONG, ALBUM, PLAYLIST }
+
+enum class OfflineItemStatus { QUEUED, DOWNLOADING, COMPLETE, PAUSED, FAILED }
+
+data class CachedCollection(
+    val id: String,
+    val type: CachedCollectionType,
+    val sourceId: String,
+    val title: String,
+    val subtitle: String?,
+    val artworkUri: String?,
+    val songs: List<Song>,
+    val status: OfflineItemStatus,
+    val progress: Float,
+    val downloadedBytes: Long,
+)
+
+data class OfflineMediaUiState(
+    val collections: List<CachedCollection> = emptyList(),
+    val offlineBytes: Long = 0L,
+    val transientBytes: Long = 0L,
+    val transientLimitBytes: Long = MAX_TRANSIENT_PLAYBACK_CACHE_BYTES,
+    val limitBytes: Long = UserPreferencesRepository.DEFAULT_OFFLINE_CACHE_LIMIT_BYTES,
+)
+
+sealed interface OfflineCacheRequestResult {
+    data object Accepted : OfflineCacheRequestResult
+    data object AlreadyCached : OfflineCacheRequestResult
+    data class LimitExceeded(val requiredBytes: Long, val availableBytes: Long) : OfflineCacheRequestResult
+    data class LowStorage(val requiredBytes: Long, val availableBytes: Long) : OfflineCacheRequestResult
+    data object NoRemoteMedia : OfflineCacheRequestResult
+}
+
+internal const val OFFLINE_STOP_REASON_QUOTA = 1001
+internal const val OFFLINE_STOP_REASON_LOW_STORAGE = 1002
+private const val MIN_FREE_BYTES = 1024L * 1024L * 1024L
+
+internal fun estimateOfflineBytes(songs: List<Song>): Long = songs.sumOf { song ->
+    val bitrate = song.bitrate?.takeIf { it > 0 } ?: 320_000
+    val durationMs = song.duration.coerceAtLeast(60_000L)
+    ((bitrate.toLong() * durationMs) / 8_000L * 11L / 10L).coerceAtLeast(1L)
+}
+
+internal fun availableForOfflineCache(limitBytes: Long, usedBytes: Long): Long =
+    if (limitBytes == 0L) Long.MAX_VALUE else (limitBytes - usedBytes).coerceAtLeast(0L)
+
+@OptIn(UnstableApi::class)
+@Singleton
+class OfflineMediaRepository @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val database: PixelPlayerDatabase,
+    private val dao: OfflineMediaDao,
+    private val playbackAudioCache: PlaybackAudioCache,
+    private val preferences: UserPreferencesRepository,
+    private val navidromeStreamProxy: NavidromeStreamProxy,
+    private val jellyfinStreamProxy: JellyfinStreamProxy,
+    @param:AppScope private val appScope: CoroutineScope,
+) {
+    private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val mutationMutex = Mutex()
+    private val downloadSnapshot = MutableStateFlow<Map<String, Download>>(emptyMap())
+    private val downloadListener = object : DownloadManager.Listener {
+        override fun onInitialized(downloadManager: DownloadManager) {
+            mainScope.launch { refreshDownloads() }
+        }
+
+        override fun onDownloadChanged(
+            downloadManager: DownloadManager,
+            download: Download,
+            finalException: Exception?,
+        ) {
+            if (download.state == Download.STATE_COMPLETED) {
+                runCatching { playbackAudioCache.removeTransientResource(download.request.id) }
+                    .onFailure { Timber.w(it, "Could not trim transient copy for %s", download.request.id) }
+            }
+            finalException?.let { Timber.w(it, "Offline media cache failed for %s", download.request.id) }
+            mainScope.launch { refreshDownloads() }
+        }
+
+        override fun onDownloadRemoved(downloadManager: DownloadManager, download: Download) {
+            mainScope.launch { refreshDownloads() }
+        }
+    }
+    private val metadataReady = appScope.async {
+        val marker = context.filesDir.resolve("offline_cache_metadata_v1")
+        if (!marker.exists()) {
+            database.withTransaction {
+                dao.clearCollections()
+                dao.clearTracks()
+            }
+            marker.writeText("device-local")
+        }
+    }
+
+    val downloadManager: DownloadManager by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        val directFactory = DefaultDataSource.Factory(context)
+        val resolvingFactory = ResolvingDataSource.Factory(directFactory) { dataSpec ->
+            val original = dataSpec.uri.toString()
+            val resolved = when (dataSpec.uri.scheme?.lowercase()) {
+                "navidrome" -> runBlocking(Dispatchers.IO) {
+                    navidromeStreamProxy.ensureReady()
+                    navidromeStreamProxy.warmUpStreamUrl(original)
+                    navidromeStreamProxy.resolveNavidromeUri(original)
+                }
+                "jellyfin" -> runBlocking(Dispatchers.IO) {
+                    jellyfinStreamProxy.ensureReady()
+                    jellyfinStreamProxy.warmUpStreamUrl(original)
+                    jellyfinStreamProxy.resolveJellyfinUri(original)
+                }
+                else -> null
+            }
+            resolved?.let { dataSpec.buildUpon().setUri(it).build() } ?: dataSpec
+        }
+        DownloadManager(
+            context,
+            playbackAudioCache.media3DatabaseProvider,
+            playbackAudioCache.offlineCache,
+            playbackAudioCache.createDownloadUpstreamFactory(resolvingFactory),
+            Executors.newFixedThreadPool(2),
+        ).apply {
+            maxParallelDownloads = 2
+            addListener(downloadListener)
+        }
+    }
+
+    val uiState: StateFlow<OfflineMediaUiState> = combine(
+        dao.observeCollections(),
+        dao.observeTracks(),
+        dao.observeCrossRefs(),
+        downloadSnapshot,
+        preferences.offlineCacheLimitBytesFlow,
+    ) { collections, tracks, refs, downloads, limit ->
+        val tracksById = tracks.associateBy(CachedTrackEntity::trackId)
+        val refsByCollection = refs.groupBy(CachedCollectionTrackCrossRef::collectionId)
+        OfflineMediaUiState(
+            collections = collections.map { collection ->
+                val collectionTracks = refsByCollection[collection.collectionId]
+                    .orEmpty()
+                    .sortedBy(CachedCollectionTrackCrossRef::sortOrder)
+                    .mapNotNull { tracksById[it.trackId] }
+                collection.toModel(collectionTracks, downloads)
+            },
+            offlineBytes = playbackAudioCache.offlineCacheBytes,
+            transientBytes = playbackAudioCache.transientCacheBytes,
+            limitBytes = limit,
+        )
+    }.stateIn(appScope, SharingStarted.Eagerly, OfflineMediaUiState())
+
+    init {
+        // Repository injection happens from an Application/UI/service main thread.
+        downloadManager
+        mainScope.launch {
+            refreshDownloads()
+            while (true) {
+                val active = downloadSnapshot.value.values.any {
+                    it.state == Download.STATE_DOWNLOADING || it.state == Download.STATE_QUEUED ||
+                        it.state == Download.STATE_RESTARTING
+                }
+                delay(if (active) 750L else 5_000L)
+                refreshDownloads()
+                enforceRuntimeLimits()
+            }
+        }
+
+        appScope.launch {
+            preferences.offlineCacheLimitBytesFlow.collect {
+                enforceRuntimeLimits()
+            }
+        }
+    }
+
+    fun collectionId(type: CachedCollectionType, sourceId: String, songs: List<Song>): String {
+        val identity = songs.mapNotNull { song ->
+            playbackAudioCache.sourceScopeFor(Uri.parse(song.contentUriString))
+        }.distinct().sorted().ifEmpty { listOf("local") }.joinToString("\n")
+        return "${type.name.lowercase()}:" + sha256("${type.name}\n$sourceId\n$identity")
+    }
+
+    fun isCollectionCached(type: CachedCollectionType, sourceId: String, songs: List<Song>): Boolean {
+        val id = collectionId(type, sourceId, songs)
+        return uiState.value.collections.any { it.id == id }
+    }
+
+    suspend fun cacheCollection(
+        type: CachedCollectionType,
+        sourceId: String,
+        title: String,
+        subtitle: String?,
+        artworkUri: String?,
+        songs: List<Song>,
+    ): OfflineCacheRequestResult = mutationMutex.withLock {
+        cacheCollectionLocked(type, sourceId, title, subtitle, artworkUri, songs)
+    }
+
+    private suspend fun cacheCollectionLocked(
+        type: CachedCollectionType,
+        sourceId: String,
+        title: String,
+        subtitle: String?,
+        artworkUri: String?,
+        songs: List<Song>,
+    ): OfflineCacheRequestResult {
+        metadataReady.await()
+        if (songs.isEmpty()) return OfflineCacheRequestResult.NoRemoteMedia
+        val collectionId = collectionId(type, sourceId, songs)
+        if (uiState.value.collections.any { it.id == collectionId }) {
+            return OfflineCacheRequestResult.AlreadyCached
+        }
+
+        val now = System.currentTimeMillis()
+        val trackEntities = songs.map { song -> song.toCachedTrack(now) }
+        val newRemoteTracks = trackEntities.filter { track ->
+            val existing = downloadSnapshot.value[track.trackId]
+            track.isRemote &&
+                !playbackAudioCache.isAvailableOffline(track.cacheKey) &&
+                (existing == null || existing.state == Download.STATE_FAILED)
+        }
+        val estimate = estimateOfflineBytes(
+            songs.filter { song -> newRemoteTracks.any { it.songId == song.id } }
+        )
+        val limit = uiState.value.limitBytes
+        val availableByLimit = availableForOfflineCache(limit, playbackAudioCache.offlineCacheBytes)
+        if (estimate > availableByLimit) {
+            return OfflineCacheRequestResult.LimitExceeded(estimate, availableByLimit)
+        }
+        val stat = StatFs(context.filesDir.path)
+        val diskAvailable = stat.availableBytes
+        val reserve = maxOf(MIN_FREE_BYTES, stat.totalBytes / 20L)
+        val usableDisk = (diskAvailable - reserve).coerceAtLeast(0L)
+        if (estimate > usableDisk) {
+            return OfflineCacheRequestResult.LowStorage(estimate, usableDisk)
+        }
+
+        database.withTransaction {
+            dao.upsertCollection(
+                CachedCollectionEntity(
+                    collectionId = collectionId,
+                    collectionType = type.name,
+                    sourceId = sourceId,
+                    title = title,
+                    subtitle = subtitle,
+                    artworkUri = artworkUri,
+                    createdAtMs = now,
+                )
+            )
+            dao.upsertTracks(trackEntities)
+            dao.upsertCrossRefs(trackEntities.mapIndexed { index, track ->
+                CachedCollectionTrackCrossRef(collectionId, track.trackId, index)
+            })
+        }
+
+        newRemoteTracks.forEach { track ->
+            val request = DownloadRequest.Builder(track.trackId, Uri.parse(track.contentUri))
+                .setMimeType(track.mimeType)
+                .setCustomCacheKey(track.cacheKey)
+                .build()
+            DownloadService.sendAddDownload(
+                context,
+                OfflineMediaDownloadService::class.java,
+                request,
+                true,
+            )
+        }
+        return OfflineCacheRequestResult.Accepted
+    }
+
+    suspend fun removeCollection(collectionId: String) {
+        mutationMutex.withLock { removeCollectionLocked(collectionId) }
+    }
+
+    private suspend fun removeCollectionLocked(collectionId: String) {
+        metadataReady.await()
+        val orphaned = database.withTransaction {
+            val candidates = dao.trackIdsForCollection(collectionId)
+            dao.deleteCollection(collectionId)
+            if (candidates.isEmpty()) {
+                emptyList()
+            } else {
+                dao.orphanedTracks(candidates).also { tracks ->
+                    dao.deleteTracks(tracks.map(CachedTrackEntity::trackId))
+                }
+            }
+        }
+        orphaned.filter(CachedTrackEntity::isRemote).forEach { track ->
+            DownloadService.sendRemoveDownload(
+                context,
+                OfflineMediaDownloadService::class.java,
+                track.trackId,
+                false,
+            )
+        }
+    }
+
+    fun resumePendingDownloads() {
+        appScope.launch {
+            val hasPending = downloadManager.downloadIndex.getDownloads(
+                Download.STATE_QUEUED,
+                Download.STATE_STOPPED,
+                Download.STATE_DOWNLOADING,
+                Download.STATE_RESTARTING,
+            ).use { it.moveToNext() }
+            if (hasPending) {
+                mainScope.launch {
+                    enforceRuntimeLimits()
+                    DownloadService.startForeground(context, OfflineMediaDownloadService::class.java)
+                }
+            }
+        }
+    }
+
+    private suspend fun refreshDownloads() {
+        appScope.launch {
+            val downloads = buildMap {
+                downloadManager.downloadIndex.getDownloads().use { cursor ->
+                    while (cursor.moveToNext()) put(cursor.download.request.id, cursor.download)
+                }
+            }
+            downloadSnapshot.value = downloads
+        }.join()
+    }
+
+    private fun enforceRuntimeLimits() {
+        mainScope.launch {
+            val limit = uiState.value.limitBytes
+            val stat = StatFs(context.filesDir.path)
+            val reserve = maxOf(MIN_FREE_BYTES, stat.totalBytes / 20L)
+            val stopReason = when {
+                stat.availableBytes <= reserve -> OFFLINE_STOP_REASON_LOW_STORAGE
+                limit != 0L && playbackAudioCache.offlineCacheBytes >= limit -> OFFLINE_STOP_REASON_QUOTA
+                else -> Download.STOP_REASON_NONE
+            }
+            var resumedManagedDownload = false
+            downloadManager.currentDownloads.forEach { download ->
+                val quotaManaged = download.stopReason == OFFLINE_STOP_REASON_QUOTA ||
+                    download.stopReason == OFFLINE_STOP_REASON_LOW_STORAGE
+                if (stopReason != Download.STOP_REASON_NONE || quotaManaged) {
+                    downloadManager.setStopReason(download.request.id, stopReason)
+                    resumedManagedDownload = resumedManagedDownload ||
+                        (stopReason == Download.STOP_REASON_NONE && quotaManaged)
+                }
+            }
+            if (
+                resumedManagedDownload &&
+                ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+            ) {
+                DownloadService.startForeground(context, OfflineMediaDownloadService::class.java)
+            }
+        }
+    }
+
+    private fun Song.toCachedTrack(now: Long): CachedTrackEntity {
+        val cacheKey = playbackAudioCache.cacheKeyFor(Uri.parse(contentUriString))
+        return CachedTrackEntity(
+            trackId = cacheKey ?: "local:${sha256(contentUriString)}",
+            cacheKey = cacheKey,
+            songId = id,
+            title = title,
+            artist = artist,
+            artistId = artistId,
+            album = album,
+            albumId = albumId,
+            albumArtist = albumArtist,
+            path = path,
+            contentUri = contentUriString,
+            artworkUri = albumArtUriString,
+            durationMs = duration,
+            genre = genre,
+            trackNumber = trackNumber,
+            discNumber = discNumber,
+            year = year,
+            dateAdded = dateAdded,
+            dateModified = dateModified,
+            mimeType = mimeType,
+            bitrate = bitrate,
+            sampleRate = sampleRate,
+            navidromeId = navidromeId,
+            jellyfinId = jellyfinId,
+            isRemote = cacheKey != null,
+            addedAtMs = now,
+        )
+    }
+}
+
+private fun CachedCollectionEntity.toModel(
+    tracks: List<CachedTrackEntity>,
+    downloads: Map<String, Download>,
+): CachedCollection {
+    val remoteDownloads = tracks.filter(CachedTrackEntity::isRemote).mapNotNull { downloads[it.trackId] }
+    val status = when {
+        remoteDownloads.any { it.state == Download.STATE_FAILED } -> OfflineItemStatus.FAILED
+        remoteDownloads.any { it.state == Download.STATE_DOWNLOADING } -> OfflineItemStatus.DOWNLOADING
+        remoteDownloads.any { it.state == Download.STATE_STOPPED } -> OfflineItemStatus.PAUSED
+        remoteDownloads.any { it.state == Download.STATE_QUEUED || it.state == Download.STATE_RESTARTING } ->
+            OfflineItemStatus.QUEUED
+        remoteDownloads.size == tracks.count(CachedTrackEntity::isRemote) -> OfflineItemStatus.COMPLETE
+        else -> OfflineItemStatus.QUEUED
+    }
+    val progress = if (remoteDownloads.isEmpty()) {
+        1f
+    } else {
+        remoteDownloads.map { download ->
+            when {
+                download.state == Download.STATE_COMPLETED -> 1f
+                download.percentDownloaded >= 0f -> download.percentDownloaded / 100f
+                else -> 0f
+            }
+        }.average().toFloat()
+    }
+    return CachedCollection(
+        id = collectionId,
+        type = runCatching { CachedCollectionType.valueOf(collectionType) }
+            .getOrDefault(CachedCollectionType.SONG),
+        sourceId = sourceId,
+        title = title,
+        subtitle = subtitle,
+        artworkUri = artworkUri,
+        songs = tracks.map(CachedTrackEntity::toSong),
+        status = status,
+        progress = progress.coerceIn(0f, 1f),
+        downloadedBytes = remoteDownloads.sumOf { it.bytesDownloaded },
+    )
+}
+
+private fun CachedTrackEntity.toSong(): Song = Song(
+    id = songId,
+    title = title,
+    artist = artist,
+    artistId = artistId,
+    album = album,
+    albumId = albumId,
+    albumArtist = albumArtist,
+    path = path,
+    contentUriString = contentUri,
+    albumArtUriString = artworkUri,
+    duration = durationMs,
+    genre = genre,
+    trackNumber = trackNumber,
+    discNumber = discNumber,
+    year = year,
+    dateAdded = dateAdded,
+    dateModified = dateModified,
+    mimeType = mimeType,
+    bitrate = bitrate,
+    sampleRate = sampleRate,
+    navidromeId = navidromeId,
+    jellyfinId = jellyfinId,
+)
+
+private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+    .digest(value.toByteArray(Charsets.UTF_8))
+    .joinToString("") { "%02x".format(it.toInt() and 0xff) }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepository.kt
@@ -196,6 +196,7 @@ constructor(
 
         val ALBUM_ART_QUALITY = stringPreferencesKey("album_art_quality")
         val ALBUM_ART_CACHE_LIMIT_MB = intPreferencesKey("album_art_cache_limit_mb")
+        val OFFLINE_CACHE_LIMIT_BYTES = longPreferencesKey("offline_cache_limit_bytes")
         val TAP_BACKGROUND_CLOSES_PLAYER = booleanPreferencesKey("tap_background_closes_player")
         val HAPTICS_ENABLED = booleanPreferencesKey("haptics_enabled")
         val IMMERSIVE_LYRICS_ENABLED = booleanPreferencesKey("immersive_lyrics_enabled")
@@ -1187,6 +1188,7 @@ constructor(
         /** Default word-based delimiters (matched case-insensitively with whitespace boundaries) */
         val DEFAULT_ARTIST_WORD_DELIMITERS = listOf("featuring", "feat.", "feat", "ft.", "ft", "vs.", "vs", "versus", "with", "prod.", "prod")
         const val DEFAULT_ALBUM_ART_CACHE_LIMIT_MB = 200
+        const val DEFAULT_OFFLINE_CACHE_LIMIT_BYTES = 5L * 1024L * 1024L * 1024L
     }
 
     val navBarCornerRadiusFlow: Flow<Int> =
@@ -1405,6 +1407,10 @@ constructor(
                         }
                         preferences[PreferencesKeys.LIBRARY_TABS_ORDER] = json.encodeToString(order)
                     }
+                    if (!order.contains("CACHED")) {
+                        order.add("CACHED")
+                        preferences[PreferencesKeys.LIBRARY_TABS_ORDER] = json.encodeToString(order)
+                    }
                 } catch (e: Exception) {
                 }
             }
@@ -1550,6 +1556,24 @@ constructor(
     suspend fun setAlbumArtCacheLimitMb(limitMb: Int) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.ALBUM_ART_CACHE_LIMIT_MB] = limitMb.coerceIn(50, 1500)
+        }
+    }
+
+    /** User-selected media limit. Zero means unlimited; existing media is never auto-deleted. */
+    val offlineCacheLimitBytesFlow: Flow<Long> =
+        dataStore.data.map { preferences ->
+            preferences[PreferencesKeys.OFFLINE_CACHE_LIMIT_BYTES]
+                ?: DEFAULT_OFFLINE_CACHE_LIMIT_BYTES
+        }.distinctUntilChanged()
+
+    suspend fun setOfflineCacheLimitBytes(limitBytes: Long) {
+        val sanitized = if (limitBytes == 0L) {
+            0L
+        } else {
+            limitBytes.coerceIn(1L * 1024L * 1024L * 1024L, 100L * 1024L * 1024L * 1024L)
+        }
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.OFFLINE_CACHE_LIMIT_BYTES] = sanitized
         }
     }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/MusicService.kt
@@ -50,6 +50,7 @@ import com.lostf1sh.pixelplayeross.data.preferences.ThemePreferencesRepository
 import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
 import com.lostf1sh.pixelplayeross.data.repository.MusicRepository
 import com.lostf1sh.pixelplayeross.data.service.player.DualPlayerEngine
+import com.lostf1sh.pixelplayeross.data.service.player.ORIGINAL_CLOUD_URI_EXTRA
 import com.lostf1sh.pixelplayeross.data.service.player.TransitionController
 import com.lostf1sh.pixelplayeross.ui.glancewidget.ControlWidget4x2
 import com.lostf1sh.pixelplayeross.ui.glancewidget.PixelPlayerGlanceWidget
@@ -1523,7 +1524,8 @@ class MusicService : MediaLibraryService() {
         for (index in 0 until mediaItemCount) {
             val mediaItem = player.getMediaItemAt(index)
             val metadata = mediaItem.mediaMetadata
-            val uri = mediaItem.localConfiguration?.uri?.toString()
+            val uri = metadata.extras?.getString(ORIGINAL_CLOUD_URI_EXTRA)
+                ?: mediaItem.localConfiguration?.uri?.toString()
                 ?: metadata.extras?.getString(MediaItemBuilder.EXTERNAL_EXTRA_CONTENT_URI)
 
             if (mediaItem.mediaId.isBlank() || uri.isNullOrBlank()) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/player/DualPlayerEngine.kt
@@ -167,7 +167,8 @@ internal fun shouldDisableAudioOffloadOnEarlyBuffering(
 class DualPlayerEngine @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val navidromeStreamProxy: NavidromeStreamProxy,
-    private val jellyfinStreamProxy: com.lostf1sh.pixelplayeross.data.jellyfin.JellyfinStreamProxy
+    private val jellyfinStreamProxy: com.lostf1sh.pixelplayeross.data.jellyfin.JellyfinStreamProxy,
+    private val playbackAudioCache: PlaybackAudioCache,
 ) {
     private companion object {
         private const val AUDIO_OFFLOAD_STALL_FALLBACK_MS = 4_000L
@@ -865,22 +866,32 @@ class DualPlayerEngine @Inject constructor(
                 val uri = dataSpec.uri
                 val scheme = uri.scheme
                 if (scheme in CLOUD_PROXY_SCHEMES) {
+                    var resolvedDataSpec = dataSpec
+                    if (!shouldUsePlaybackCache(dataSpec.key)) {
+                        playbackAudioCache.cacheKeyFor(uri)?.let { cacheKey ->
+                            resolvedDataSpec = resolvedDataSpec.buildUpon()
+                                .setKey(cacheKey)
+                                .build()
+                        }
+                    }
                     val originalUri = uri.toString()
                     val resolved = resolvedUriCache.get(originalUri)
                         ?: resolveReadyCloudProxyUri(uri)?.also { proxyUri ->
                             resolvedUriCache.put(originalUri, proxyUri)
                         }
                     if (resolved != null) {
-                        return dataSpec.buildUpon().setUri(resolved).build()
+                        return resolvedDataSpec.buildUpon().setUri(resolved).build()
                     }
                     Timber.tag("DualPlayerEngine").d("resolveDataSpec: Cache MISS for %s — using original URI", scheme)
+                    return resolvedDataSpec
                 }
                 return dataSpec
             }
         }
-        
+
         val dataSourceFactory = DefaultDataSource.Factory(context)
-        val resolvingFactory = ResolvingDataSource.Factory(dataSourceFactory, resolver)
+        val cacheFactory = playbackAudioCache.createDataSourceFactory(dataSourceFactory)
+        val resolvingFactory = ResolvingDataSource.Factory(cacheFactory, resolver)
         val extractorsFactory = DefaultExtractorsFactory()
             .setMp3ExtractorFlags(Mp3Extractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING)
             .setFlacExtractorFlags(FlacExtractor.FLAG_DISABLE_ID3_METADATA)
@@ -999,11 +1010,24 @@ class DualPlayerEngine @Inject constructor(
     }
 
     suspend fun resolveMediaItem(mediaItem: MediaItem): MediaItem {
-        val uri = mediaItem.localConfiguration?.uri ?: return mediaItem
+        val cacheableMediaItem = playbackAudioCache.withCacheKey(mediaItem)
+        val cacheKey = cacheableMediaItem.localConfiguration?.customCacheKey
+        if (playbackAudioCache.isAvailableOffline(cacheKey)) {
+            val originalUri = cacheableMediaItem.mediaMetadata.extras
+                ?.getString(ORIGINAL_CLOUD_URI_EXTRA)
+                ?.let(Uri::parse)
+            return originalUri?.let { cacheableMediaItem.buildUpon().setUri(it).build() }
+                ?: cacheableMediaItem
+        }
+        val uri = cacheableMediaItem.localConfiguration?.uri ?: return cacheableMediaItem
         val scheme = uri.scheme
-        if (scheme !in CLOUD_PROXY_SCHEMES) return mediaItem
+        if (scheme !in CLOUD_PROXY_SCHEMES) return cacheableMediaItem
         val resolvedUri = resolveCloudUri(uri)
-        return if (resolvedUri == uri) mediaItem else mediaItem.buildUpon().setUri(resolvedUri).build()
+        return if (resolvedUri == uri) {
+            cacheableMediaItem
+        } else {
+            cacheableMediaItem.buildUpon().setUri(resolvedUri).build()
+        }
     }
 
     suspend fun prepareNext(target: TransitionTarget, startPositionMs: Long = 0L) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/player/PlaybackAudioCache.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/service/player/PlaybackAudioCache.kt
@@ -1,0 +1,229 @@
+package com.lostf1sh.pixelplayeross.data.service.player
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.ContentMetadata
+import androidx.media3.datasource.cache.NoOpCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import com.lostf1sh.pixelplayeross.data.jellyfin.JellyfinRepository
+import com.lostf1sh.pixelplayeross.data.navidrome.NavidromeRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal const val PLAYBACK_CACHE_KEY_PREFIX = "pixelplayer:audio:v1:"
+internal const val ORIGINAL_CLOUD_URI_EXTRA =
+    "com.lostf1sh.pixelplayeross.playback.ORIGINAL_CLOUD_URI"
+const val MAX_TRANSIENT_PLAYBACK_CACHE_BYTES = 256L * 1024L * 1024L
+
+internal fun buildPlaybackCacheKey(sourceIdentity: String, mediaUri: String): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+        .digest("$sourceIdentity\n$mediaUri".toByteArray(Charsets.UTF_8))
+        .joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    return PLAYBACK_CACHE_KEY_PREFIX + digest
+}
+
+internal fun shouldUsePlaybackCache(cacheKey: String?): Boolean =
+    cacheKey?.startsWith(PLAYBACK_CACHE_KEY_PREFIX) == true
+
+/**
+ * Process-wide caches for cloud audio.
+ *
+ * Normal streaming fills a small LRU cache. User-selected offline media is kept in a separate,
+ * non-evicting cache under filesDir. Playback reads the explicit cache first, then the transient
+ * cache, then the network. Local MediaStore/file playback never passes through either cache.
+ */
+@OptIn(UnstableApi::class)
+@Singleton
+class PlaybackAudioCache @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val navidromeRepository: NavidromeRepository,
+    private val jellyfinRepository: JellyfinRepository,
+) {
+    private companion object {
+        private const val TRANSIENT_CACHE_DIRECTORY = "playback_audio"
+        private const val OFFLINE_CACHE_DIRECTORY = "cached_media"
+    }
+
+    private val databaseProvider by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        StandaloneDatabaseProvider(context)
+    }
+
+    private val transientCache by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        SimpleCache(
+            context.cacheDir.resolve(TRANSIENT_CACHE_DIRECTORY),
+            LeastRecentlyUsedCacheEvictor(MAX_TRANSIENT_PLAYBACK_CACHE_BYTES),
+            databaseProvider,
+        )
+    }
+
+    val offlineCache: SimpleCache by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        SimpleCache(
+            context.filesDir.resolve(OFFLINE_CACHE_DIRECTORY),
+            NoOpCacheEvictor(),
+            databaseProvider,
+        )
+    }
+
+    val media3DatabaseProvider: StandaloneDatabaseProvider
+        get() = databaseProvider
+
+    val transientCacheBytes: Long
+        get() = transientCache.cacheSpace
+
+    val offlineCacheBytes: Long
+        get() = offlineCache.cacheSpace
+
+    fun cacheKeyFor(uri: Uri): String? {
+        val sourceIdentity = sourceIdentityFor(uri) ?: return null
+        return buildPlaybackCacheKey(sourceIdentity, uri.toString())
+    }
+
+    fun sourceScopeFor(uri: Uri): String? {
+        val sourceIdentity = sourceIdentityFor(uri) ?: return null
+        return buildPlaybackCacheKey(sourceIdentity, "collection-scope")
+    }
+
+    private fun sourceIdentityFor(uri: Uri): String? {
+        return when (uri.scheme?.lowercase()) {
+            "navidrome" -> sourceIdentity(
+                provider = "navidrome",
+                serverUrl = navidromeRepository.serverUrl,
+                username = navidromeRepository.username,
+            )
+            "jellyfin" -> sourceIdentity(
+                provider = "jellyfin",
+                serverUrl = jellyfinRepository.serverUrl,
+                username = jellyfinRepository.username,
+            )
+            else -> null
+        }
+    }
+
+    fun withCacheKey(mediaItem: MediaItem): MediaItem {
+        val localConfiguration = mediaItem.localConfiguration ?: return mediaItem
+        val originalUri = mediaItem.mediaMetadata.extras
+            ?.getString(ORIGINAL_CLOUD_URI_EXTRA)
+            ?.let(Uri::parse)
+            ?: localConfiguration.uri
+        val cacheKey = cacheKeyFor(originalUri) ?: return mediaItem
+
+        val metadataExtras = Bundle(mediaItem.mediaMetadata.extras ?: Bundle()).apply {
+            putString(ORIGINAL_CLOUD_URI_EXTRA, originalUri.toString())
+        }
+        return mediaItem.buildUpon()
+            .setCustomCacheKey(cacheKey)
+            .setMediaMetadata(
+                mediaItem.mediaMetadata.buildUpon()
+                    .setExtras(metadataExtras)
+                    .build()
+            )
+            .build()
+    }
+
+    fun createDataSourceFactory(upstreamFactory: DataSource.Factory): DataSource.Factory {
+        val transientFactory = CacheDataSource.Factory()
+            .setCache(transientCache)
+            .setUpstreamDataSourceFactory(upstreamFactory)
+            .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+
+        val offlineFirstFactory = CacheDataSource.Factory()
+            .setCache(offlineCache)
+            .setUpstreamDataSourceFactory(transientFactory)
+            .setCacheWriteDataSinkFactory(null)
+            .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+
+        return DataSource.Factory {
+            CacheRoutingDataSource(
+                directDataSource = upstreamFactory.createDataSource(),
+                cacheDataSource = offlineFirstFactory.createDataSource(),
+            )
+        }
+    }
+
+    /** Reuses already-streamed bytes while copying a user-requested item to the offline cache. */
+    fun createDownloadUpstreamFactory(upstreamFactory: DataSource.Factory): DataSource.Factory =
+        CacheDataSource.Factory()
+            .setCache(transientCache)
+            .setUpstreamDataSourceFactory(upstreamFactory)
+            .setCacheWriteDataSinkFactory(null)
+            .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+
+    fun removeTransientResource(cacheKey: String) {
+        transientCache.removeResource(cacheKey)
+    }
+
+    fun isAvailableOffline(cacheKey: String?): Boolean {
+        if (!shouldUsePlaybackCache(cacheKey)) return false
+        val contentLength = ContentMetadata.getContentLength(offlineCache.getContentMetadata(cacheKey!!))
+        return contentLength != C.LENGTH_UNSET.toLong() &&
+            contentLength > 0L &&
+            offlineCache.isCached(cacheKey, 0L, contentLength)
+    }
+
+    private fun sourceIdentity(
+        provider: String,
+        serverUrl: String?,
+        username: String?,
+    ): String? {
+        val normalizedServerUrl = serverUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() }
+            ?: return null
+        val normalizedUsername = username?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        return "$provider|$normalizedServerUrl|$normalizedUsername"
+    }
+}
+
+@OptIn(UnstableApi::class)
+private class CacheRoutingDataSource(
+    private val directDataSource: DataSource,
+    private val cacheDataSource: DataSource,
+) : DataSource {
+    private var activeDataSource: DataSource? = null
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        directDataSource.addTransferListener(transferListener)
+        cacheDataSource.addTransferListener(transferListener)
+    }
+
+    override fun open(dataSpec: DataSpec): Long {
+        check(activeDataSource == null) { "DataSource is already open" }
+        val selectedDataSource = if (shouldUsePlaybackCache(dataSpec.key)) {
+            cacheDataSource
+        } else {
+            directDataSource
+        }
+        activeDataSource = selectedDataSource
+        return selectedDataSource.open(dataSpec)
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        return activeDataSource?.read(buffer, offset, length)
+            ?: throw IOException("DataSource is not open")
+    }
+
+    override fun getUri(): Uri? = activeDataSource?.uri
+
+    override fun getResponseHeaders(): Map<String, List<String>> =
+        activeDataSource?.responseHeaders.orEmpty()
+
+    override fun close() {
+        try {
+            activeDataSource?.close()
+        } finally {
+            activeDataSource = null
+        }
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/di/AppModule.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/di/AppModule.kt
@@ -25,7 +25,9 @@ import com.lostf1sh.pixelplayeross.data.database.LocalPlaylistDao
 import com.lostf1sh.pixelplayeross.data.database.ListenBrainzDao
 import com.lostf1sh.pixelplayeross.data.database.MIGRATION_1_2
 import com.lostf1sh.pixelplayeross.data.database.MIGRATION_2_3
+import com.lostf1sh.pixelplayeross.data.database.MIGRATION_3_4
 import com.lostf1sh.pixelplayeross.data.database.MusicDao
+import com.lostf1sh.pixelplayeross.data.database.OfflineMediaDao
 import com.lostf1sh.pixelplayeross.data.database.PixelPlayerDatabase
 import com.lostf1sh.pixelplayeross.data.database.SearchHistoryDao
 import com.lostf1sh.pixelplayeross.data.database.TransitionDao
@@ -126,7 +128,7 @@ object AppModule {
             "pixelplayer_database"
         )
             .addCallback(PixelPlayerDatabase.createRuntimeArtifactsCallback())
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
 
         if (BuildConfig.DEBUG) {
@@ -200,6 +202,12 @@ object AppModule {
     @Provides
     fun provideListenBrainzDao(database: PixelPlayerDatabase): ListenBrainzDao {
         return database.listenBrainzDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideOfflineMediaDao(database: PixelPlayerDatabase): OfflineMediaDao {
+        return database.offlineMediaDao()
     }
 
     @Provides

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/SongInfoBottomSheet.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/SongInfoBottomSheet.kt
@@ -34,6 +34,8 @@ import androidx.compose.material.icons.filled.QueueMusic
 import androidx.compose.material.icons.rounded.Album
 import androidx.compose.material.icons.rounded.AudioFile
 import androidx.compose.material.icons.rounded.Cloud
+import androidx.compose.material.icons.rounded.CloudDownload
+import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.FavoriteBorder
 import androidx.compose.material.icons.rounded.MusicNote
@@ -71,6 +73,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.offline.CachedCollectionType
+import com.lostf1sh.pixelplayeross.presentation.utils.messageRes
 import com.lostf1sh.pixelplayeross.presentation.components.subcomps.AutoSizingTextToFill
 import com.lostf1sh.pixelplayeross.utils.formatDuration
 import com.lostf1sh.pixelplayeross.utils.shapes.RoundedStarShape
@@ -120,7 +124,8 @@ fun SongInfoBottomSheet(
         coverArtUpdate: CoverArtUpdate?
     ) -> Unit,
     removeFromListTrigger: () -> Unit,
-    songInfoViewModel: SongInfoBottomSheetViewModel = hiltViewModel()
+    songInfoViewModel: SongInfoBottomSheetViewModel = hiltViewModel(),
+    offlineMediaViewModel: com.lostf1sh.pixelplayeross.presentation.viewmodel.OfflineMediaViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     var showEditSheet by remember { mutableStateOf(false) }
@@ -131,6 +136,13 @@ fun SongInfoBottomSheet(
     var pendingTonePermissionTarget by remember { mutableStateOf<ToneTarget?>(null) }
     val audioMeta by songInfoViewModel.audioMeta.collectAsStateWithLifecycle()
     val resolvedArtists by songInfoViewModel.resolvedArtists.collectAsStateWithLifecycle()
+    val offlineState by offlineMediaViewModel.uiState.collectAsStateWithLifecycle()
+    val isCloudMedia = remember(song.contentUriString) {
+        song.contentUriString.startsWith("navidrome:") || song.contentUriString.startsWith("jellyfin:")
+    }
+    val isIndividuallyCached = remember(song, offlineState.collections) {
+        offlineMediaViewModel.isCached(CachedCollectionType.SONG, song.id, listOf(song))
+    }
     val ringtonePermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
     ) {
@@ -541,32 +553,71 @@ fun SongInfoBottomSheet(
                                                     Text(stringResource(R.string.shortcut_playlist_short))
                                                 }
 
-                                                FilledTonalButton(
-                                                    modifier = Modifier
-                                                        .weight(0.5f)
-                                                        .heightIn(min = 66.dp),
-                                                    colors = ButtonDefaults.filledTonalButtonColors(
-                                                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                                                        contentColor = MaterialTheme.colorScheme.onErrorContainer
-                                                    ),
-                                                    shape = CircleShape,
-                                                    onClick = {
-                                                        (context as? Activity)?.let { activity ->
-                                                            onDeleteFromDevice(activity, song) { result ->
-                                                                if (result) {
-                                                                    removeFromListTrigger()
-                                                                    onDismiss()
+                                                if (isCloudMedia) {
+                                                    FilledTonalButton(
+                                                        modifier = Modifier.weight(0.5f).heightIn(min = 66.dp),
+                                                        shape = CircleShape,
+                                                        onClick = {
+                                                            if (isIndividuallyCached) {
+                                                                offlineMediaViewModel.remove(
+                                                                    CachedCollectionType.SONG,
+                                                                    song.id,
+                                                                    listOf(song),
+                                                                )
+                                                            } else {
+                                                                offlineMediaViewModel.cache(
+                                                                    type = CachedCollectionType.SONG,
+                                                                    sourceId = song.id,
+                                                                    title = song.title,
+                                                                    subtitle = song.displayArtist,
+                                                                    artworkUri = song.albumArtUriString,
+                                                                    songs = listOf(song),
+                                                                ) { result ->
+                                                                    Toast.makeText(
+                                                                        context,
+                                                                        result.messageRes(),
+                                                                        Toast.LENGTH_SHORT,
+                                                                    ).show()
+                                                                }
+                                                            }
+                                                        },
+                                                    ) {
+                                                        Icon(
+                                                            if (isIndividuallyCached) Icons.Rounded.DeleteOutline else Icons.Rounded.CloudDownload,
+                                                            contentDescription = null,
+                                                        )
+                                                        Spacer(Modifier.width(8.dp))
+                                                        Text(
+                                                            stringResource(
+                                                                if (isIndividuallyCached) R.string.offline_cache_remove_action
+                                                                else R.string.offline_cache_action
+                                                            ),
+                                                            maxLines = 1,
+                                                        )
+                                                    }
+                                                } else {
+                                                    FilledTonalButton(
+                                                        modifier = Modifier.weight(0.5f).heightIn(min = 66.dp),
+                                                        colors = ButtonDefaults.filledTonalButtonColors(
+                                                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                                                            contentColor = MaterialTheme.colorScheme.onErrorContainer
+                                                        ),
+                                                        shape = CircleShape,
+                                                        onClick = {
+                                                            (context as? Activity)?.let { activity ->
+                                                                onDeleteFromDevice(activity, song) { result ->
+                                                                    if (result) {
+                                                                        removeFromListTrigger()
+                                                                        onDismiss()
+                                                                    }
                                                                 }
                                                             }
                                                         }
+                                                    ) {
+                                                        Icon(Icons.Default.DeleteForever, contentDescription = stringResource(R.string.delete_action))
+                                                        Spacer(Modifier.width(8.dp))
+                                                        Text(stringResource(R.string.delete_action))
                                                     }
-                                                ) {
-                                                    Icon(
-                                                        Icons.Default.DeleteForever,
-                                                        contentDescription = stringResource(R.string.delete_action)
-                                                    )
-                                                    Spacer(Modifier.width(8.dp))
-                                                    Text(stringResource(R.string.delete_action))
                                                 }
                                             }
                                         }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/model/LibraryTabId.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/model/LibraryTabId.kt
@@ -87,6 +87,11 @@ enum class LibraryTabId(
             SortOption.LikedSongDateLiked,
             SortOption.LikedSongDateLikedAsc
         )
+    ),
+    Cached(
+        stableKey = "CACHED",
+        label = "CACHED",
+        sortOptions = emptyList()
     );
 
     companion object {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AlbumDetailScreen.kt
@@ -2,6 +2,7 @@
 
 package com.lostf1sh.pixelplayeross.presentation.screens
 
+import android.widget.Toast
 import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
 import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafelyReplacing
 
@@ -30,7 +31,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.Shuffle
+import androidx.compose.material.icons.rounded.CloudDownload
+import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
@@ -40,6 +44,7 @@ import androidx.compose.material3.LargeExtendedFloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -65,6 +70,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextGeometricTransform
@@ -86,6 +92,8 @@ import coil.compose.AsyncImagePainter
 import coil.size.Size
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.model.Album
+import com.lostf1sh.pixelplayeross.data.offline.CachedCollectionType
+import com.lostf1sh.pixelplayeross.presentation.utils.messageRes
 import com.lostf1sh.pixelplayeross.presentation.components.CollapsibleCommonTopBar
 import com.lostf1sh.pixelplayeross.presentation.components.ExpressiveScrollBar
 import com.lostf1sh.pixelplayeross.presentation.components.MiniPlayerHeight
@@ -115,9 +123,12 @@ fun AlbumDetailScreen(
     navController: NavController,
     playerViewModel: PlayerViewModel,
     viewModel: AlbumDetailViewModel = hiltViewModel(),
-    playlistViewModel: PlaylistViewModel = hiltViewModel()
+    playlistViewModel: PlaylistViewModel = hiltViewModel(),
+    offlineMediaViewModel: com.lostf1sh.pixelplayeross.presentation.viewmodel.OfflineMediaViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val offlineState by offlineMediaViewModel.uiState.collectAsStateWithLifecycle()
     val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
     val isMiniPlayerVisible by remember {
         derivedStateOf { stablePlayerState.currentSong != null }
@@ -130,6 +141,7 @@ fun AlbumDetailScreen(
     val systemNavBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val bottomBarHeightDp = resolveNavBarOccupiedHeight(systemNavBarInset, navBarCompactMode)
     var showPlaylistBottomSheet by remember { mutableStateOf(false) }
+    var showRemoveOfflineDialog by remember { mutableStateOf(false) }
     val isDarkTheme = LocalPixelPlayerDarkTheme.current
     val baseColorScheme = MaterialTheme.colorScheme
     val albumArtUri = uiState.album?.albumArtUriString?.takeIf { it.isNotBlank() }
@@ -197,6 +209,34 @@ fun AlbumDetailScreen(
             uiState.album != null -> {
                 val album = uiState.album!!
                 val songs = uiState.songs
+                val isCached = remember(album.id, songs, offlineState.collections) {
+                    offlineMediaViewModel.isCached(CachedCollectionType.ALBUM, album.id.toString(), songs)
+                }
+                val hasCloudSongs = remember(songs) {
+                    songs.any { it.contentUriString.startsWith("navidrome:") || it.contentUriString.startsWith("jellyfin:") }
+                }
+                if (showRemoveOfflineDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showRemoveOfflineDialog = false },
+                        title = { Text(stringResource(R.string.offline_cache_remove_title)) },
+                        text = { Text(stringResource(R.string.offline_cache_remove_message)) },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                offlineMediaViewModel.remove(
+                                    CachedCollectionType.ALBUM,
+                                    album.id.toString(),
+                                    songs,
+                                )
+                                showRemoveOfflineDialog = false
+                            }) { Text(stringResource(R.string.offline_cache_remove_action)) }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showRemoveOfflineDialog = false }) {
+                                Text(stringResource(R.string.cancel))
+                            }
+                        },
+                    )
+                }
                 val songsByDisc = remember(songs) {
                     songs.groupBy { it.discNumber ?: 1 }
                 }
@@ -404,6 +444,45 @@ fun AlbumDetailScreen(
                                 }
                             }
                         )
+                    }
+
+                    if (hasCloudSongs) {
+                        FilledIconButton(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .statusBarsPadding()
+                                .padding(top = 8.dp, end = 12.dp),
+                            onClick = {
+                                if (isCached) {
+                                    showRemoveOfflineDialog = true
+                                } else {
+                                    offlineMediaViewModel.cache(
+                                        type = CachedCollectionType.ALBUM,
+                                        sourceId = album.id.toString(),
+                                        title = album.title,
+                                        subtitle = album.albumArtist ?: album.artist,
+                                        artworkUri = album.albumArtUriString,
+                                        songs = songs,
+                                    ) { result ->
+                                        Toast.makeText(
+                                            context,
+                                            result.messageRes(),
+                                            Toast.LENGTH_SHORT,
+                                        ).show()
+                                    }
+                                }
+                            },
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            ),
+                        ) {
+                            Icon(
+                                if (isCached) Icons.Rounded.DeleteOutline else Icons.Rounded.CloudDownload,
+                                contentDescription = stringResource(
+                                    if (isCached) R.string.offline_cache_remove_action else R.string.offline_cache_action
+                                ),
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryCachedTab.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryCachedTab.kt
@@ -1,0 +1,242 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.lostf1sh.pixelplayeross.presentation.screens
+
+import android.text.format.Formatter
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.DeleteOutline
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.data.offline.CachedCollection
+import com.lostf1sh.pixelplayeross.data.offline.CachedCollectionType
+import com.lostf1sh.pixelplayeross.data.offline.OfflineItemStatus
+import com.lostf1sh.pixelplayeross.data.offline.OfflineMediaUiState
+import com.lostf1sh.pixelplayeross.presentation.components.SmartImage
+
+@Composable
+fun LibraryCachedTab(
+    state: OfflineMediaUiState,
+    bottomBarHeight: Dp,
+    onPlay: (CachedCollection) -> Unit,
+    onRemove: (CachedCollection) -> Unit,
+) {
+    var filter by remember { mutableStateOf<CachedCollectionType?>(null) }
+    var pendingRemoval by remember { mutableStateOf<CachedCollection?>(null) }
+    val context = LocalContext.current
+    val visible = remember(state.collections, filter) {
+        state.collections.filter { filter == null || it.type == filter }
+    }
+
+    pendingRemoval?.let { collection ->
+        AlertDialog(
+            onDismissRequest = { pendingRemoval = null },
+            title = { Text(stringResource(R.string.offline_cache_remove_title)) },
+            text = { Text(stringResource(R.string.offline_cache_remove_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    onRemove(collection)
+                    pendingRemoval = null
+                }) { Text(stringResource(R.string.offline_cache_remove_action)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRemoval = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+
+    LazyColumn(
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = bottomBarHeight + 24.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        item {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+                shape = RoundedCornerShape(24.dp),
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(18.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        if (state.limitBytes == 0L) {
+                            stringResource(
+                                R.string.offline_cache_used_unlimited,
+                                Formatter.formatShortFileSize(context, state.offlineBytes),
+                            )
+                        } else {
+                            stringResource(
+                                R.string.offline_cache_used,
+                                Formatter.formatShortFileSize(context, state.offlineBytes),
+                                Formatter.formatShortFileSize(context, state.limitBytes),
+                            )
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    if (state.limitBytes > 0L) {
+                        LinearProgressIndicator(
+                            progress = { (state.offlineBytes.toFloat() / state.limitBytes).coerceIn(0f, 1f) },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    Text(
+                        stringResource(
+                            R.string.offline_cache_streaming_used,
+                            Formatter.formatShortFileSize(context, state.transientBytes),
+                            Formatter.formatShortFileSize(context, state.transientLimitBytes),
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilterChip(
+                    selected = filter == null,
+                    onClick = { filter = null },
+                    label = { Text(stringResource(R.string.offline_cache_filter_all)) },
+                )
+                FilterChip(
+                    selected = filter == CachedCollectionType.ALBUM,
+                    onClick = { filter = CachedCollectionType.ALBUM },
+                    label = { Text(stringResource(R.string.offline_cache_filter_albums)) },
+                )
+                FilterChip(
+                    selected = filter == CachedCollectionType.PLAYLIST,
+                    onClick = { filter = CachedCollectionType.PLAYLIST },
+                    label = { Text(stringResource(R.string.offline_cache_filter_playlists)) },
+                )
+                FilterChip(
+                    selected = filter == CachedCollectionType.SONG,
+                    onClick = { filter = CachedCollectionType.SONG },
+                    label = { Text(stringResource(R.string.offline_cache_filter_songs)) },
+                )
+            }
+        }
+
+        if (visible.isEmpty()) {
+            item {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 48.dp, horizontal = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(stringResource(R.string.offline_cache_empty_title), style = MaterialTheme.typography.titleLarge)
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        stringResource(R.string.offline_cache_empty_message),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        items(visible, key = CachedCollection::id) { collection ->
+            Card(
+                modifier = Modifier.fillMaxWidth().clickable { onPlay(collection) },
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLowest),
+                shape = RoundedCornerShape(22.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    SmartImage(
+                        model = collection.artworkUri,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        shape = RoundedCornerShape(14.dp),
+                    )
+                    Column(
+                        modifier = Modifier.weight(1f).padding(horizontal = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(collection.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Text(
+                            collection.subtitle ?: pluralStringResource(
+                                R.plurals.offline_cache_song_count,
+                                collection.songs.size,
+                                collection.songs.size,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            collection.statusLabel(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        if (collection.status != OfflineItemStatus.COMPLETE) {
+                            LinearProgressIndicator(
+                                progress = { collection.progress },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                    IconButton(onClick = { onPlay(collection) }) {
+                        Icon(Icons.Rounded.PlayArrow, contentDescription = null)
+                    }
+                    IconButton(onClick = { pendingRemoval = collection }) {
+                        Icon(Icons.Rounded.DeleteOutline, contentDescription = stringResource(R.string.offline_cache_remove_action))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CachedCollection.statusLabel(): String = when (status) {
+    OfflineItemStatus.QUEUED -> stringResource(R.string.offline_cache_status_queued)
+    OfflineItemStatus.DOWNLOADING -> stringResource(R.string.offline_cache_status_downloading, (progress * 100).toInt())
+    OfflineItemStatus.COMPLETE -> stringResource(R.string.offline_cache_status_complete)
+    OfflineItemStatus.PAUSED -> stringResource(R.string.offline_cache_status_paused)
+    OfflineItemStatus.FAILED -> stringResource(R.string.offline_cache_status_failed)
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryEmptyState.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryEmptyState.kt
@@ -122,6 +122,12 @@ private fun libraryEmptySpec(
             titleRes = R.string.lib_empty_playlists_title,
             subtitleRes = R.string.lib_empty_playlists_subtitle
         )
+
+        LibraryTabId.CACHED -> LibraryEmptySpec(
+            iconRes = R.drawable.rounded_cloud_download_24,
+            titleRes = R.string.offline_cache_empty_title,
+            subtitleRes = R.string.offline_cache_empty_message
+        )
     }
 }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/LibraryScreen.kt
@@ -314,7 +314,8 @@ fun LibraryScreen(
     playerViewModel: PlayerViewModel = hiltViewModel(),
     playlistViewModel: PlaylistViewModel = hiltViewModel(),
     libraryViewModel: LibraryViewModel = hiltViewModel(),
-    songInfoBottomSheetViewModel: SongInfoBottomSheetViewModel = hiltViewModel()
+    songInfoBottomSheetViewModel: SongInfoBottomSheetViewModel = hiltViewModel(),
+    offlineMediaViewModel: com.lostf1sh.pixelplayeross.presentation.viewmodel.OfflineMediaViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
@@ -334,6 +335,7 @@ fun LibraryScreen(
     val selectedSongForInfo by playerViewModel.selectedSongForInfo.collectAsStateWithLifecycle()
     val tabTitles by playerViewModel.libraryTabsFlow.collectAsStateWithLifecycle()
     val currentTabId by playerViewModel.currentLibraryTabId.collectAsStateWithLifecycle()
+    val offlineMediaState by offlineMediaViewModel.uiState.collectAsStateWithLifecycle()
     val libraryNavigationMode by playerViewModel.libraryNavigationMode.collectAsStateWithLifecycle()
     val isCompactNavigation = libraryNavigationMode == LibraryNavigationMode.COMPACT_PILL
     val tabCount = tabTitles.size.coerceAtLeast(1)
@@ -533,7 +535,8 @@ fun LibraryScreen(
                 LibraryTabId.SONGS,
                 LibraryTabId.LIKED,
                 LibraryTabId.FOLDERS -> isSelectionMode
-                LibraryTabId.ARTISTS -> false
+                LibraryTabId.ARTISTS,
+                LibraryTabId.CACHED -> false
             }
         }
     }
@@ -568,7 +571,8 @@ fun LibraryScreen(
                         showMultiSelectionSheet = false
                     }
 
-                    LibraryTabId.ARTISTS -> Unit
+                    LibraryTabId.ARTISTS,
+                    LibraryTabId.CACHED -> Unit
                 }
             }
 
@@ -818,21 +822,25 @@ fun LibraryScreen(
                     Column(Modifier.fillMaxSize()) {
                         val availableSortOptions by playerViewModel.availableSortOptions.collectAsStateWithLifecycle()
                         val sanitizedSortOptions = remember(availableSortOptions, currentTabId) {
-                            val cleaned = availableSortOptions.filterIsInstance<SortOption>()
-                            val ensured = if (cleaned.any { option ->
-                                    option.storageKey == currentTabId.defaultSort.storageKey
-                                }
-                            ) {
-                                cleaned
+                            if (currentTabId == LibraryTabId.CACHED) {
+                                persistentListOf()
                             } else {
-                                buildList {
-                                    add(currentTabId.defaultSort)
-                                    addAll(cleaned)
+                                val cleaned = availableSortOptions.filterIsInstance<SortOption>()
+                                val ensured = if (cleaned.any { option ->
+                                        option.storageKey == currentTabId.defaultSort.storageKey
+                                    }
+                                ) {
+                                    cleaned
+                                } else {
+                                    buildList {
+                                        add(currentTabId.defaultSort)
+                                        addAll(cleaned)
+                                    }
                                 }
-                            }
 
-                            val distinctByKey = ensured.distinctBy { it.storageKey }
-                            distinctByKey.ifEmpty { listOf(currentTabId.defaultSort) }.toImmutableList()
+                                val distinctByKey = ensured.distinctBy { it.storageKey }
+                                distinctByKey.ifEmpty { listOf(currentTabId.defaultSort) }.toImmutableList()
+                            }
                         }
 
                         val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
@@ -860,6 +868,7 @@ fun LibraryScreen(
                             LibraryTabId.PLAYLISTS -> playlistUiState.currentPlaylistSortOption
                             LibraryTabId.LIKED -> playerUiState.currentFavoriteSortOption
                             LibraryTabId.FOLDERS -> playerUiState.currentFolderSortOption
+                            LibraryTabId.CACHED -> null
                         }
 
                         val showLocateButton = when (currentTabId) {
@@ -884,6 +893,7 @@ fun LibraryScreen(
                                     LibraryTabId.PLAYLISTS -> playlistViewModel.sortPlaylists(option)
                                     LibraryTabId.LIKED -> playerViewModel.sortFavoriteSongs(option)
                                     LibraryTabId.FOLDERS -> playerViewModel.sortFolders(option)
+                                    LibraryTabId.CACHED -> Unit
                                 }
                             }
                         }
@@ -965,43 +975,46 @@ fun LibraryScreen(
                                     )
                                 }
                             } else {
-                                LibraryActionRow(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(end = 4.dp),
-                                    onMainActionClick = {
-                                        when (tabTitles.getOrNull(currentTabIndex)?.toLibraryTabIdOrNull()) {
-                                            LibraryTabId.PLAYLISTS -> showPlaylistCreationTypeDialog = true
-                                            LibraryTabId.LIKED -> playerViewModel.shuffleFavoriteSongs()
-                                            LibraryTabId.ALBUMS -> playerViewModel.shuffleRandomAlbum()
-                                            LibraryTabId.ARTISTS -> playerViewModel.shuffleRandomArtist()
-                                            else -> playerViewModel.shuffleAllSongs()
-                                        }
-                                    },
-                                    iconRotation = iconRotation,
-                                    showSortButton = sanitizedSortOptions.isNotEmpty(),
-                                    showLocateButton = showLocateButton,
-                                    onSortClick = { playerViewModel.showSortingSheet() },
-                                    onLocateClick = { locateAction?.invoke() },
-                                    isPlaylistTab = currentTabId == LibraryTabId.PLAYLISTS,
-                                    isFoldersTab = currentTabId == LibraryTabId.FOLDERS && (!playerUiState.isFoldersPlaylistView || playerUiState.currentFolder != null),
-                                    onImportM3uClick = { m3uImportLauncher.launch("audio/x-mpegurl") },
-                                    currentFolder = playerUiState.currentFolder,
-                                    folderRootPath = playerUiState.folderSourceRootPath.ifBlank {
-                                        Environment.getExternalStorageDirectory().path
-                                    },
-                                    folderRootLabel = playerUiState.folderSource.displayName,
-                                    onFolderClick = { playerViewModel.navigateToFolder(it) },
-                                    onNavigateBack = { playerViewModel.navigateBackFolder() },
-                                    isShuffleEnabled = isShuffleEnabled,
-                                    showStorageFilterButton = currentTabId == LibraryTabId.SONGS ||
+                                if (currentTabId != LibraryTabId.CACHED) {
+                                    LibraryActionRow(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(end = 4.dp),
+                                        onMainActionClick = {
+                                            when (tabTitles.getOrNull(currentTabIndex)?.toLibraryTabIdOrNull()) {
+                                                LibraryTabId.PLAYLISTS -> showPlaylistCreationTypeDialog = true
+                                                LibraryTabId.LIKED -> playerViewModel.shuffleFavoriteSongs()
+                                                LibraryTabId.ALBUMS -> playerViewModel.shuffleRandomAlbum()
+                                                LibraryTabId.ARTISTS -> playerViewModel.shuffleRandomArtist()
+                                                LibraryTabId.CACHED -> Unit
+                                                else -> playerViewModel.shuffleAllSongs()
+                                            }
+                                        },
+                                        iconRotation = iconRotation,
+                                        showSortButton = sanitizedSortOptions.isNotEmpty(),
+                                        showLocateButton = showLocateButton,
+                                        onSortClick = { playerViewModel.showSortingSheet() },
+                                        onLocateClick = { locateAction?.invoke() },
+                                        isPlaylistTab = currentTabId == LibraryTabId.PLAYLISTS,
+                                        isFoldersTab = currentTabId == LibraryTabId.FOLDERS && (!playerUiState.isFoldersPlaylistView || playerUiState.currentFolder != null),
+                                        onImportM3uClick = { m3uImportLauncher.launch("audio/x-mpegurl") },
+                                        currentFolder = playerUiState.currentFolder,
+                                        folderRootPath = playerUiState.folderSourceRootPath.ifBlank {
+                                            Environment.getExternalStorageDirectory().path
+                                        },
+                                        folderRootLabel = playerUiState.folderSource.displayName,
+                                        onFolderClick = { playerViewModel.navigateToFolder(it) },
+                                        onNavigateBack = { playerViewModel.navigateBackFolder() },
+                                        isShuffleEnabled = isShuffleEnabled,
+                                        showStorageFilterButton = currentTabId == LibraryTabId.SONGS ||
                                             currentTabId == LibraryTabId.ALBUMS ||
                                             currentTabId == LibraryTabId.ARTISTS ||
                                             currentTabId == LibraryTabId.LIKED ||
                                             (ENABLE_FOLDERS_STORAGE_FILTER && currentTabId == LibraryTabId.FOLDERS),
-                                    currentStorageFilter = playerUiState.currentStorageFilter,
-                                    onStorageFilterClick = { playerViewModel.toggleStorageFilter() }
-                                )
+                                        currentStorageFilter = playerUiState.currentStorageFilter,
+                                        onStorageFilterClick = { playerViewModel.toggleStorageFilter() }
+                                    )
+                                }
                             }
                         }
 
@@ -1259,6 +1272,25 @@ fun LibraryScreen(
                                             onPlaylistLongPress = onPlaylistLongPress,
                                             onPlaylistSelectionToggle = onPlaylistSelectionToggle,
                                             onPlaylistOptionsClick = { showPlaylistMultiSelectionSheet = true }
+                                        )
+                                    }
+
+                                    LibraryTabId.CACHED -> {
+                                        LibraryCachedTab(
+                                            state = offlineMediaState,
+                                            bottomBarHeight = bottomBarHeightDp,
+                                            onPlay = { collection ->
+                                                collection.songs.firstOrNull()?.let { first ->
+                                                    playerViewModel.showAndPlaySong(
+                                                        first,
+                                                        collection.songs,
+                                                        collection.title,
+                                                    )
+                                                }
+                                            },
+                                            onRemove = { collection ->
+                                                offlineMediaViewModel.remove(collection.id)
+                                            },
                                         )
                                     }
 
@@ -2355,6 +2387,7 @@ private fun LibraryTabId.iconRes(): Int = when (this) {
     LibraryTabId.ALBUMS -> R.drawable.rounded_album_24
     LibraryTabId.ARTISTS -> R.drawable.rounded_artist_24
     LibraryTabId.PLAYLISTS -> R.drawable.rounded_playlist_play_24
+    LibraryTabId.CACHED -> R.drawable.rounded_cloud_download_24
     LibraryTabId.FOLDERS -> R.drawable.rounded_folder_24
     LibraryTabId.LIKED -> R.drawable.round_favorite_24
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/PlaylistDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.lostf1sh.pixelplayeross.presentation.screens
 
+import android.widget.Toast
 import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
 import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafelyReplacing
 
@@ -48,6 +49,7 @@ import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.DragIndicator
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Shuffle
+import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -104,6 +106,8 @@ import androidx.navigation.NavController
 import coil.size.Size
 import com.lostf1sh.pixelplayeross.R
 import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.offline.CachedCollectionType
+import com.lostf1sh.pixelplayeross.presentation.utils.messageRes
 import com.lostf1sh.pixelplayeross.presentation.components.MiniPlayerHeight
 import com.lostf1sh.pixelplayeross.presentation.components.PlaylistBottomSheet
 import com.lostf1sh.pixelplayeross.presentation.components.QueuePlaylistSongItem
@@ -147,9 +151,11 @@ fun PlaylistDetailScreen(
     onDeletePlayListClick: () -> Unit,
     playerViewModel: PlayerViewModel,
     playlistViewModel: PlaylistViewModel = hiltViewModel(),
-    navController: NavController
+    navController: NavController,
+    offlineMediaViewModel: com.lostf1sh.pixelplayeross.presentation.viewmodel.OfflineMediaViewModel = hiltViewModel(),
 ) {
     val uiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
+    val offlineState by offlineMediaViewModel.uiState.collectAsStateWithLifecycle()
     val playerStableState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
     val hasCurrentSong by remember {
         derivedStateOf { playerStableState.currentSong != null }
@@ -185,6 +191,16 @@ fun PlaylistDetailScreen(
     val isSmartPlaylist = currentPlaylist?.isSmartPlaylist == true
     val isEditablePlaylist = !isFolderPlaylist && !isSmartPlaylist
     val songsInPlaylist = uiState.currentPlaylistSongs
+    val hasCloudSongs = remember(songsInPlaylist) {
+        songsInPlaylist.any {
+            it.contentUriString.startsWith("navidrome:") || it.contentUriString.startsWith("jellyfin:")
+        }
+    }
+    val isCached = remember(currentPlaylist?.id, songsInPlaylist, offlineState.collections) {
+        currentPlaylist?.let {
+            offlineMediaViewModel.isCached(CachedCollectionType.PLAYLIST, it.id, songsInPlaylist)
+        } ?: false
+    }
 
     LaunchedEffect(playlistId) {
         playlistViewModel.loadPlaylistDetails(playlistId)
@@ -198,6 +214,7 @@ fun PlaylistDetailScreen(
     var showPlaylistOptionsSheet by remember { mutableStateOf(false) }
     var showEditPlaylistDialog by remember { mutableStateOf(false) }
     var showDeleteConfirmation by remember { mutableStateOf(false) }
+    var showRemoveOfflineDialog by remember { mutableStateOf(false) }
 
     val m3uExportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("audio/x-mpegurl")
@@ -301,6 +318,38 @@ fun PlaylistDetailScreen(
                     }
                 },
                 actions = {
+                    if (hasCloudSongs && currentPlaylist != null) {
+                        IconButton(
+                            onClick = {
+                                val playlist = currentPlaylist
+                                if (isCached) {
+                                    showRemoveOfflineDialog = true
+                                } else {
+                                    offlineMediaViewModel.cache(
+                                        type = CachedCollectionType.PLAYLIST,
+                                        sourceId = playlist.id,
+                                        title = playlist.name,
+                                        subtitle = formatSongCount(songsInPlaylist.size),
+                                        artworkUri = playlist.coverImageUri ?: songsInPlaylist.firstOrNull()?.albumArtUriString,
+                                        songs = songsInPlaylist,
+                                    ) { result ->
+                                        Toast.makeText(
+                                            context,
+                                            result.messageRes(),
+                                            Toast.LENGTH_SHORT,
+                                        ).show()
+                                    }
+                                }
+                            }
+                        ) {
+                            Icon(
+                                if (isCached) Icons.Filled.DeleteOutline else Icons.Rounded.CloudDownload,
+                                contentDescription = stringResource(
+                                    if (isCached) R.string.offline_cache_remove_action else R.string.offline_cache_action
+                                ),
+                            )
+                        }
+                    }
                     IconButton(
                         onClick = {
                             playerViewModel.showSortingSheet() 
@@ -712,6 +761,28 @@ fun PlaylistDetailScreen(
                 playlistViewModel.addSongsToPlaylist(currentPlaylist.id, selectedIds.toList())
                 showAddSongsSheet = false
             }
+        )
+    }
+    if (showRemoveOfflineDialog && currentPlaylist != null) {
+        AlertDialog(
+            onDismissRequest = { showRemoveOfflineDialog = false },
+            title = { Text(stringResource(R.string.offline_cache_remove_title)) },
+            text = { Text(stringResource(R.string.offline_cache_remove_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    offlineMediaViewModel.remove(
+                        CachedCollectionType.PLAYLIST,
+                        currentPlaylist.id,
+                        songsInPlaylist,
+                    )
+                    showRemoveOfflineDialog = false
+                }) { Text(stringResource(R.string.offline_cache_remove_action)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRemoveOfflineDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
         )
     }
     if (showPlaylistOptionsSheet && !isFolderPlaylist) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsCategoryScreen.kt
@@ -174,6 +174,15 @@ import com.lostf1sh.pixelplayeross.presentation.components.rememberModalSheetSta
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
+private val OFFLINE_CACHE_LIMIT_OPTIONS = longArrayOf(
+    1L * 1024L * 1024L * 1024L,
+    2L * 1024L * 1024L * 1024L,
+    5L * 1024L * 1024L * 1024L,
+    10L * 1024L * 1024L * 1024L,
+    20L * 1024L * 1024L * 1024L,
+    0L,
+)
+
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -225,6 +234,12 @@ fun SettingsCategoryScreen(
     }
     var albumArtCacheLimitDraft by remember(uiState.albumArtCacheLimitMb) {
         mutableStateOf(uiState.albumArtCacheLimitMb.toFloat())
+    }
+    var offlineCacheLimitDraft by remember(uiState.offlineCacheLimitBytes) {
+        mutableStateOf(
+            OFFLINE_CACHE_LIMIT_OPTIONS.indexOf(uiState.offlineCacheLimitBytes)
+                .takeIf { it >= 0 }?.toFloat() ?: 2f
+        )
     }
 
     val exportLauncher = rememberLauncherForActivityResult(
@@ -444,6 +459,29 @@ fun SettingsCategoryScreen(
                                         }
                                     },
                                     valueText = { value -> "${value.toInt()} MB" }
+                                )
+                                SliderSettingsItem(
+                                    label = stringResource(R.string.offline_cache_limit_title),
+                                    value = offlineCacheLimitDraft,
+                                    valueRange = 0f..5f,
+                                    steps = 4,
+                                    onValueChange = { offlineCacheLimitDraft = it },
+                                    onValueChangeFinished = {
+                                        val selected = OFFLINE_CACHE_LIMIT_OPTIONS[
+                                            offlineCacheLimitDraft.toInt().coerceIn(0, 5)
+                                        ]
+                                        if (selected != uiState.offlineCacheLimitBytes) {
+                                            settingsViewModel.setOfflineCacheLimitBytes(selected)
+                                        }
+                                    },
+                                    valueText = { value ->
+                                        val selected = OFFLINE_CACHE_LIMIT_OPTIONS[value.toInt().coerceIn(0, 5)]
+                                        if (selected == 0L) {
+                                            context.getString(R.string.offline_cache_unlimited)
+                                        } else {
+                                            "${selected / (1024L * 1024L * 1024L)} GB"
+                                        }
+                                    }
                                 )
                             }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/utils/OfflineCacheMessages.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/utils/OfflineCacheMessages.kt
@@ -1,0 +1,14 @@
+package com.lostf1sh.pixelplayeross.presentation.utils
+
+import androidx.annotation.StringRes
+import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.data.offline.OfflineCacheRequestResult
+
+@StringRes
+fun OfflineCacheRequestResult.messageRes(): Int = when (this) {
+    OfflineCacheRequestResult.Accepted -> R.string.offline_cache_started
+    OfflineCacheRequestResult.AlreadyCached -> R.string.offline_cache_already_saved
+    is OfflineCacheRequestResult.LimitExceeded -> R.string.offline_cache_limit_reached
+    is OfflineCacheRequestResult.LowStorage -> R.string.offline_cache_low_storage
+    OfflineCacheRequestResult.NoRemoteMedia -> R.string.offline_cache_no_remote_media
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/OfflineMediaViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/OfflineMediaViewModel.kt
@@ -1,0 +1,43 @@
+package com.lostf1sh.pixelplayeross.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.offline.CachedCollectionType
+import com.lostf1sh.pixelplayeross.data.offline.OfflineCacheRequestResult
+import com.lostf1sh.pixelplayeross.data.offline.OfflineMediaRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class OfflineMediaViewModel @Inject constructor(
+    private val repository: OfflineMediaRepository,
+) : ViewModel() {
+    val uiState = repository.uiState
+
+    fun isCached(type: CachedCollectionType, sourceId: String, songs: List<Song>): Boolean =
+        repository.isCollectionCached(type, sourceId, songs)
+
+    fun cache(
+        type: CachedCollectionType,
+        sourceId: String,
+        title: String,
+        subtitle: String?,
+        artworkUri: String?,
+        songs: List<Song>,
+        onResult: (OfflineCacheRequestResult) -> Unit = {},
+    ) {
+        viewModelScope.launch {
+            onResult(repository.cacheCollection(type, sourceId, title, subtitle, artworkUri, songs))
+        }
+    }
+
+    fun remove(collectionId: String) {
+        viewModelScope.launch { repository.removeCollection(collectionId) }
+    }
+
+    fun remove(type: CachedCollectionType, sourceId: String, songs: List<Song>) {
+        remove(repository.collectionId(type, sourceId, songs))
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
@@ -941,13 +941,13 @@ class PlayerViewModel @Inject constructor(
                 try {
                     Json.decodeFromString<List<String>>(orderJson).toImmutableList()
                 } catch (e: Exception) {
-                    persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED")
+                    persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED", "CACHED")
                 }
             } else {
-                persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED")
+                persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED", "CACHED")
             }
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED"))
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), persistentListOf("SONGS", "ALBUMS", "ARTIST", "PLAYLISTS", "FOLDERS", "LIKED", "CACHED"))
 
     private val _loadedTabs = MutableStateFlow(emptySet<String>())
     private var lastBlockedDirectories: Set<String>? = null
@@ -967,6 +967,7 @@ class PlayerViewModel @Inject constructor(
                     LibraryTabId.ALBUMS -> SortOption.ALBUMS
                     LibraryTabId.ARTISTS -> SortOption.ARTISTS
                     LibraryTabId.PLAYLISTS -> SortOption.PLAYLISTS
+                    LibraryTabId.CACHED -> emptyList()
                     LibraryTabId.FOLDERS -> SortOption.FOLDERS
                     LibraryTabId.LIKED -> SortOption.LIKED
                 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/SettingsViewModel.kt
@@ -80,6 +80,7 @@ data class SettingsUiState(
     val showPlayerFileInfo: Boolean = true,
     val albumArtQuality: AlbumArtQuality = AlbumArtQuality.MEDIUM,
     val albumArtCacheLimitMb: Int = 200,
+    val offlineCacheLimitBytes: Long = UserPreferencesRepository.DEFAULT_OFFLINE_CACHE_LIMIT_BYTES,
     val tapBackgroundClosesPlayer: Boolean = false,
     val hapticsEnabled: Boolean = true,
     val immersiveLyricsEnabled: Boolean = false,
@@ -393,6 +394,12 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             userPreferencesRepository.albumArtCacheLimitMbFlow.collect { limitMb ->
                 _uiState.update { it.copy(albumArtCacheLimitMb = limitMb) }
+            }
+        }
+
+        viewModelScope.launch {
+            userPreferencesRepository.offlineCacheLimitBytesFlow.collect { limitBytes ->
+                _uiState.update { it.copy(offlineCacheLimitBytes = limitBytes) }
             }
         }
 
@@ -843,6 +850,12 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             userPreferencesRepository.setAlbumArtCacheLimitMb(limitMb)
             com.lostf1sh.pixelplayeross.utils.AlbumArtCacheManager.configuredCacheLimitMb = limitMb.toLong()
+        }
+    }
+
+    fun setOfflineCacheLimitBytes(limitBytes: Long) {
+        viewModelScope.launch {
+            userPreferencesRepository.setOfflineCacheLimitBytes(limitBytes)
         }
     }
 

--- a/app/src/main/res/drawable/rounded_cloud_download_24.xml
+++ b/app/src/main/res/drawable/rounded_cloud_download_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19.35,10.04A7.49,7.49 0,0 0,5.5 8A6,6 0,0 0,6 20h13a5,5 0,0 0,0.35 -9.96zM17,13l-5,5 -5,-5h3V9h4v4h3z" />
+</vector>

--- a/app/src/main/res/values/strings_offline_cache.xml
+++ b/app/src/main/res/values/strings_offline_cache.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="offline_cache_notification_channel">Offline caching</string>
+    <string name="offline_cache_notification_channel_description">Progress for music saved inside PixelPlayer</string>
+    <string name="offline_cache_notification_message">Saving music for offline playback</string>
+    <string name="offline_cache_empty_title">Nothing cached yet</string>
+    <string name="offline_cache_empty_message">Cache a song, album, or playlist to listen when your server is unavailable.</string>
+    <string name="offline_cache_action">Cache offline</string>
+    <string name="offline_cache_remove_action">Remove from cache</string>
+    <string name="offline_cache_already_saved">Already cached</string>
+    <string name="offline_cache_started">Caching started</string>
+    <string name="offline_cache_limit_reached">Not enough space within your cache limit</string>
+    <string name="offline_cache_low_storage">Not enough free device storage</string>
+    <string name="offline_cache_no_remote_media">There’s no media to cache</string>
+    <string name="offline_cache_used">Offline %1$s of %2$s</string>
+    <string name="offline_cache_used_unlimited">Offline %1$s · Unlimited</string>
+    <string name="offline_cache_streaming_used">Streaming cache %1$s of %2$s</string>
+    <string name="offline_cache_status_queued">Queued</string>
+    <string name="offline_cache_status_downloading">Caching %1$d%%</string>
+    <string name="offline_cache_status_complete">Available offline</string>
+    <string name="offline_cache_status_paused">Paused by storage limit</string>
+    <string name="offline_cache_status_failed">Caching failed</string>
+    <string name="offline_cache_remove_title">Remove cached media?</string>
+    <string name="offline_cache_remove_message">This removes the app-private offline copy. It does not delete the original song.</string>
+    <string name="offline_cache_limit_title">Offline cache limit</string>
+    <string name="offline_cache_unlimited">Unlimited</string>
+    <string name="offline_cache_filter_all">All</string>
+    <string name="offline_cache_filter_albums">Albums</string>
+    <string name="offline_cache_filter_playlists">Playlists</string>
+    <string name="offline_cache_filter_songs">Songs</string>
+    <plurals name="offline_cache_song_count">
+        <item quantity="one">%d song</item>
+        <item quantity="other">%d songs</item>
+    </plurals>
+</resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -10,6 +10,9 @@
     <exclude domain="sharedpref" path="listenbrainz_prefs_plain.xml"/>
 
     <exclude domain="file" path="datastore/settings.preferences_pb"/>
+    <exclude domain="file" path="cached_media/"/>
+    <exclude domain="file" path="offline_cache_metadata_v1"/>
+    <exclude domain="database" path="exoplayer_internal.db"/>
 
     <exclude domain="sharedpref" path="crash_handler_prefs.xml"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -11,6 +11,9 @@
         <exclude domain="sharedpref" path="listenbrainz_prefs_plain.xml"/>
 
         <exclude domain="file" path="datastore/settings.preferences_pb"/>
+        <exclude domain="file" path="cached_media/"/>
+        <exclude domain="file" path="offline_cache_metadata_v1"/>
+        <exclude domain="database" path="exoplayer_internal.db"/>
 
         <exclude domain="sharedpref" path="crash_handler_prefs.xml"/>
     </cloud-backup>
@@ -25,6 +28,9 @@
         <exclude domain="sharedpref" path="listenbrainz_prefs_plain.xml"/>
 
         <exclude domain="file" path="datastore/settings.preferences_pb"/>
+        <exclude domain="file" path="cached_media/"/>
+        <exclude domain="file" path="offline_cache_metadata_v1"/>
+        <exclude domain="database" path="exoplayer_internal.db"/>
         <exclude domain="sharedpref" path="crash_handler_prefs.xml"/>
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaQuotaTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaQuotaTest.kt
@@ -1,0 +1,51 @@
+package com.lostf1sh.pixelplayeross.data.offline
+
+import com.lostf1sh.pixelplayeross.data.model.Song
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OfflineMediaQuotaTest {
+    @Test
+    fun `unlimited cache reports effectively unlimited capacity`() {
+        assertEquals(Long.MAX_VALUE, availableForOfflineCache(limitBytes = 0L, usedBytes = 9_000L))
+    }
+
+    @Test
+    fun `bounded cache never reports negative capacity`() {
+        assertEquals(2_000L, availableForOfflineCache(limitBytes = 5_000L, usedBytes = 3_000L))
+        assertEquals(0L, availableForOfflineCache(limitBytes = 5_000L, usedBytes = 8_000L))
+    }
+
+    @Test
+    fun `estimate uses bitrate duration and safety margin`() {
+        val song = testSong(durationMs = 60_000L, bitrate = 320_000)
+
+        val estimate = estimateOfflineBytes(listOf(song))
+
+        assertEquals(2_640_000L, estimate)
+    }
+
+    @Test
+    fun `estimate has conservative fallbacks for missing metadata`() {
+        val estimate = estimateOfflineBytes(listOf(testSong(durationMs = 0L, bitrate = null)))
+
+        assertTrue(estimate >= 2_640_000L)
+    }
+
+    private fun testSong(durationMs: Long, bitrate: Int?): Song = Song(
+        id = "song",
+        title = "Song",
+        artist = "Artist",
+        artistId = 1L,
+        album = "Album",
+        albumId = 2L,
+        path = "",
+        contentUriString = "navidrome://song",
+        albumArtUriString = null,
+        duration = durationMs,
+        mimeType = "audio/mpeg",
+        bitrate = bitrate,
+        sampleRate = 44_100,
+    )
+}

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaQuotaTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/offline/OfflineMediaQuotaTest.kt
@@ -1,5 +1,6 @@
 package com.lostf1sh.pixelplayeross.data.offline
 
+import androidx.media3.exoplayer.offline.Download
 import com.lostf1sh.pixelplayeross.data.model.Song
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -31,6 +32,34 @@ class OfflineMediaQuotaTest {
         val estimate = estimateOfflineBytes(listOf(testSong(durationMs = 0L, bitrate = null)))
 
         assertTrue(estimate >= 2_640_000L)
+    }
+
+    @Test
+    fun `removing download is not reported as complete`() {
+        val status = offlineItemStatus(
+            downloadStates = listOf(Download.STATE_REMOVING),
+            remoteTrackCount = 1,
+        )
+
+        assertEquals(OfflineItemStatus.QUEUED, status)
+    }
+
+    @Test
+    fun `all remote downloads must be completed before collection is complete`() {
+        assertEquals(
+            OfflineItemStatus.COMPLETE,
+            offlineItemStatus(
+                downloadStates = listOf(Download.STATE_COMPLETED, Download.STATE_COMPLETED),
+                remoteTrackCount = 2,
+            ),
+        )
+        assertEquals(
+            OfflineItemStatus.QUEUED,
+            offlineItemStatus(
+                downloadStates = listOf(Download.STATE_COMPLETED, Download.STATE_REMOVING),
+                remoteTrackCount = 2,
+            ),
+        )
     }
 
     private fun testSong(durationMs: Long, bitrate: Int?): Song = Song(

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/service/player/PlaybackAudioCacheTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/service/player/PlaybackAudioCacheTest.kt
@@ -1,0 +1,52 @@
+package com.lostf1sh.pixelplayeross.data.service.player
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PlaybackAudioCacheTest {
+
+    @Test
+    fun `cache key is stable and does not expose account or track details`() {
+        val sourceIdentity = "navidrome|https://music.example.test|listener"
+        val mediaUri = "navidrome://secret-track-id"
+
+        val first = buildPlaybackCacheKey(sourceIdentity, mediaUri)
+        val second = buildPlaybackCacheKey(sourceIdentity, mediaUri)
+
+        assertEquals(first, second)
+        assertTrue(first.startsWith(PLAYBACK_CACHE_KEY_PREFIX))
+        assertFalse(first.contains("music.example.test"))
+        assertFalse(first.contains("listener"))
+        assertFalse(first.contains("secret-track-id"))
+    }
+
+    @Test
+    fun `cache key is scoped to account and provider`() {
+        val mediaUri = "navidrome://track-id"
+        val firstAccount = buildPlaybackCacheKey(
+            "navidrome|https://music.example.test|first",
+            mediaUri,
+        )
+        val secondAccount = buildPlaybackCacheKey(
+            "navidrome|https://music.example.test|second",
+            mediaUri,
+        )
+        val otherProvider = buildPlaybackCacheKey(
+            "jellyfin|https://music.example.test|first",
+            mediaUri,
+        )
+
+        assertNotEquals(firstAccount, secondAccount)
+        assertNotEquals(firstAccount, otherProvider)
+    }
+
+    @Test
+    fun `only app playback cache keys are routed through disk cache`() {
+        assertTrue(shouldUsePlaybackCache(buildPlaybackCacheKey("source", "track")))
+        assertFalse(shouldUsePlaybackCache(null))
+        assertFalse(shouldUsePlaybackCache("https://music.example.test/stream?token=secret"))
+    }
+}

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/presentation/library/LibraryTabIdTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/presentation/library/LibraryTabIdTest.kt
@@ -32,6 +32,24 @@ class LibraryTabIdTest {
     }
 
     @Test
+    fun `cached tab is appended without shifting legacy tab indices`() {
+        val legacyOrder = listOf(
+            LibraryTabId.Songs,
+            LibraryTabId.Albums,
+            LibraryTabId.Artists,
+            LibraryTabId.Playlists,
+            LibraryTabId.Folders,
+            LibraryTabId.Liked,
+        )
+
+        val order = decodeLibraryTabOrder(
+            Json.encodeToString(legacyOrder.map(LibraryTabId::stableKey))
+        )
+
+        assertIterableEquals(legacyOrder + LibraryTabId.Cached, order)
+    }
+
+    @Test
     fun `sort associations remain tied to tab ids after reordering`() {
         val persistedSorts = LibraryTabId.defaultOrder.associateWith { tab ->
             tab.sortOptions.firstOrNull() ?: SortOption.SongTitleAZ

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,6 +108,8 @@ androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltNa
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "composeMaterialIcons" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeMaterialIcons" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Session" }
+androidx-media3-database = { module = "androidx.media3:media3-database", version.ref = "media3Session" }
+androidx-media3-datasource = { module = "androidx.media3:media3-datasource", version.ref = "media3Session" }
 androidx-media3-exoplayer-midi = { module = "androidx.media3:media3-exoplayer-midi", version.ref = "media3Session" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3Session" }
 androidx-media3-transformer = { module = "androidx.media3:media3-transformer", version.ref = "media3Transformer" }


### PR DESCRIPTION
## Summary
- add a small LRU cache for normal cloud streaming and a separate non-evicting app-private cache for user-selected offline media
- let users cache songs, albums, and playlists and manage them from a new Cached library tab
- add configurable offline cache limits, storage safeguards, background progress, Room metadata/refcounts, and resume support

## Why
Issue #47 asks for server music to be available offline. This keeps offline audio inside the PixelPlayer Media3 cache instead of exporting user-visible files, while preserving a small transient cache for ordinary streaming.

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:compileDebugKotlin`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:testDebugUnitTest`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:lintDebug`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:assembleDebug -Ppixelplayer.enableAbiSplits=false`
- CodeRabbit review: 0 findings after fixes

## Screenshots
Not included; no device or emulator runtime pass was performed for this change.

Closes #47