### PR TITLE
Add settings search, audio bookmarks, advanced stats and most listened

### DIFF
--- a/app/schemas/com.lostf1sh.pixelplayeross.data.database.PixelPlayerDatabase/4.json
+++ b/app/schemas/com.lostf1sh.pixelplayeross.data.database.PixelPlayerDatabase/4.json
@@ -1,0 +1,2180 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "2e5b2ad2796ef4ef6ad7eb6f805dee2c",
+    "entities": [
+      {
+        "tableName": "album_art_themes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumArtUriString` TEXT NOT NULL, `paletteStyle` TEXT NOT NULL, `light_primary` TEXT NOT NULL, `light_onPrimary` TEXT NOT NULL, `light_primaryContainer` TEXT NOT NULL, `light_onPrimaryContainer` TEXT NOT NULL, `light_secondary` TEXT NOT NULL, `light_onSecondary` TEXT NOT NULL, `light_secondaryContainer` TEXT NOT NULL, `light_onSecondaryContainer` TEXT NOT NULL, `light_tertiary` TEXT NOT NULL, `light_onTertiary` TEXT NOT NULL, `light_tertiaryContainer` TEXT NOT NULL, `light_onTertiaryContainer` TEXT NOT NULL, `light_background` TEXT NOT NULL, `light_onBackground` TEXT NOT NULL, `light_surface` TEXT NOT NULL, `light_onSurface` TEXT NOT NULL, `light_surfaceVariant` TEXT NOT NULL, `light_onSurfaceVariant` TEXT NOT NULL, `light_error` TEXT NOT NULL, `light_onError` TEXT NOT NULL, `light_outline` TEXT NOT NULL, `light_errorContainer` TEXT NOT NULL, `light_onErrorContainer` TEXT NOT NULL, `light_inversePrimary` TEXT NOT NULL, `light_inverseSurface` TEXT NOT NULL, `light_inverseOnSurface` TEXT NOT NULL, `light_surfaceTint` TEXT NOT NULL, `light_outlineVariant` TEXT NOT NULL, `light_scrim` TEXT NOT NULL, `light_surfaceBright` TEXT NOT NULL, `light_surfaceDim` TEXT NOT NULL, `light_surfaceContainer` TEXT NOT NULL, `light_surfaceContainerHigh` TEXT NOT NULL, `light_surfaceContainerHighest` TEXT NOT NULL, `light_surfaceContainerLow` TEXT NOT NULL, `light_surfaceContainerLowest` TEXT NOT NULL, `light_primaryFixed` TEXT NOT NULL, `light_primaryFixedDim` TEXT NOT NULL, `light_onPrimaryFixed` TEXT NOT NULL, `light_onPrimaryFixedVariant` TEXT NOT NULL, `light_secondaryFixed` TEXT NOT NULL, `light_secondaryFixedDim` TEXT NOT NULL, `light_onSecondaryFixed` TEXT NOT NULL, `light_onSecondaryFixedVariant` TEXT NOT NULL, `light_tertiaryFixed` TEXT NOT NULL, `light_tertiaryFixedDim` TEXT NOT NULL, `light_onTertiaryFixed` TEXT NOT NULL, `light_onTertiaryFixedVariant` TEXT NOT NULL, `dark_primary` TEXT NOT NULL, `dark_onPrimary` TEXT NOT NULL, `dark_primaryContainer` TEXT NOT NULL, `dark_onPrimaryContainer` TEXT NOT NULL, `dark_secondary` TEXT NOT NULL, `dark_onSecondary` TEXT NOT NULL, `dark_secondaryContainer` TEXT NOT NULL, `dark_onSecondaryContainer` TEXT NOT NULL, `dark_tertiary` TEXT NOT NULL, `dark_onTertiary` TEXT NOT NULL, `dark_tertiaryContainer` TEXT NOT NULL, `dark_onTertiaryContainer` TEXT NOT NULL, `dark_background` TEXT NOT NULL, `dark_onBackground` TEXT NOT NULL, `dark_surface` TEXT NOT NULL, `dark_onSurface` TEXT NOT NULL, `dark_surfaceVariant` TEXT NOT NULL, `dark_onSurfaceVariant` TEXT NOT NULL, `dark_error` TEXT NOT NULL, `dark_onError` TEXT NOT NULL, `dark_outline` TEXT NOT NULL, `dark_errorContainer` TEXT NOT NULL, `dark_onErrorContainer` TEXT NOT NULL, `dark_inversePrimary` TEXT NOT NULL, `dark_inverseSurface` TEXT NOT NULL, `dark_inverseOnSurface` TEXT NOT NULL, `dark_surfaceTint` TEXT NOT NULL, `dark_outlineVariant` TEXT NOT NULL, `dark_scrim` TEXT NOT NULL, `dark_surfaceBright` TEXT NOT NULL, `dark_surfaceDim` TEXT NOT NULL, `dark_surfaceContainer` TEXT NOT NULL, `dark_surfaceContainerHigh` TEXT NOT NULL, `dark_surfaceContainerHighest` TEXT NOT NULL, `dark_surfaceContainerLow` TEXT NOT NULL, `dark_surfaceContainerLowest` TEXT NOT NULL, `dark_primaryFixed` TEXT NOT NULL, `dark_primaryFixedDim` TEXT NOT NULL, `dark_onPrimaryFixed` TEXT NOT NULL, `dark_onPrimaryFixedVariant` TEXT NOT NULL, `dark_secondaryFixed` TEXT NOT NULL, `dark_secondaryFixedDim` TEXT NOT NULL, `dark_onSecondaryFixed` TEXT NOT NULL, `dark_onSecondaryFixedVariant` TEXT NOT NULL, `dark_tertiaryFixed` TEXT NOT NULL, `dark_tertiaryFixedDim` TEXT NOT NULL, `dark_onTertiaryFixed` TEXT NOT NULL, `dark_onTertiaryFixedVariant` TEXT NOT NULL, PRIMARY KEY(`albumArtUriString`))",
+        "fields": [
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "albumArtUriString",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paletteStyle",
+            "columnName": "paletteStyle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primary",
+            "columnName": "light_primary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimary",
+            "columnName": "light_onPrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryContainer",
+            "columnName": "light_primaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryContainer",
+            "columnName": "light_onPrimaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondary",
+            "columnName": "light_secondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondary",
+            "columnName": "light_onSecondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryContainer",
+            "columnName": "light_secondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryContainer",
+            "columnName": "light_onSecondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiary",
+            "columnName": "light_tertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiary",
+            "columnName": "light_onTertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryContainer",
+            "columnName": "light_tertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryContainer",
+            "columnName": "light_onTertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.background",
+            "columnName": "light_background",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onBackground",
+            "columnName": "light_onBackground",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surface",
+            "columnName": "light_surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSurface",
+            "columnName": "light_onSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceVariant",
+            "columnName": "light_surfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSurfaceVariant",
+            "columnName": "light_onSurfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.error",
+            "columnName": "light_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onError",
+            "columnName": "light_onError",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.outline",
+            "columnName": "light_outline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.errorContainer",
+            "columnName": "light_errorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onErrorContainer",
+            "columnName": "light_onErrorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inversePrimary",
+            "columnName": "light_inversePrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inverseSurface",
+            "columnName": "light_inverseSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inverseOnSurface",
+            "columnName": "light_inverseOnSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceTint",
+            "columnName": "light_surfaceTint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.outlineVariant",
+            "columnName": "light_outlineVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.scrim",
+            "columnName": "light_scrim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceBright",
+            "columnName": "light_surfaceBright",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceDim",
+            "columnName": "light_surfaceDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainer",
+            "columnName": "light_surfaceContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerHigh",
+            "columnName": "light_surfaceContainerHigh",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerHighest",
+            "columnName": "light_surfaceContainerHighest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerLow",
+            "columnName": "light_surfaceContainerLow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerLowest",
+            "columnName": "light_surfaceContainerLowest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryFixed",
+            "columnName": "light_primaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryFixedDim",
+            "columnName": "light_primaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryFixed",
+            "columnName": "light_onPrimaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryFixedVariant",
+            "columnName": "light_onPrimaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryFixed",
+            "columnName": "light_secondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryFixedDim",
+            "columnName": "light_secondaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryFixed",
+            "columnName": "light_onSecondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryFixedVariant",
+            "columnName": "light_onSecondaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryFixed",
+            "columnName": "light_tertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryFixedDim",
+            "columnName": "light_tertiaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryFixed",
+            "columnName": "light_onTertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryFixedVariant",
+            "columnName": "light_onTertiaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primary",
+            "columnName": "dark_primary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimary",
+            "columnName": "dark_onPrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryContainer",
+            "columnName": "dark_primaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryContainer",
+            "columnName": "dark_onPrimaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondary",
+            "columnName": "dark_secondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondary",
+            "columnName": "dark_onSecondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryContainer",
+            "columnName": "dark_secondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryContainer",
+            "columnName": "dark_onSecondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiary",
+            "columnName": "dark_tertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiary",
+            "columnName": "dark_onTertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryContainer",
+            "columnName": "dark_tertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryContainer",
+            "columnName": "dark_onTertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.background",
+            "columnName": "dark_background",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onBackground",
+            "columnName": "dark_onBackground",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surface",
+            "columnName": "dark_surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSurface",
+            "columnName": "dark_onSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceVariant",
+            "columnName": "dark_surfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSurfaceVariant",
+            "columnName": "dark_onSurfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.error",
+            "columnName": "dark_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onError",
+            "columnName": "dark_onError",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.outline",
+            "columnName": "dark_outline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.errorContainer",
+            "columnName": "dark_errorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onErrorContainer",
+            "columnName": "dark_onErrorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inversePrimary",
+            "columnName": "dark_inversePrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inverseSurface",
+            "columnName": "dark_inverseSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inverseOnSurface",
+            "columnName": "dark_inverseOnSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceTint",
+            "columnName": "dark_surfaceTint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.outlineVariant",
+            "columnName": "dark_outlineVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.scrim",
+            "columnName": "dark_scrim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceBright",
+            "columnName": "dark_surfaceBright",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceDim",
+            "columnName": "dark_surfaceDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainer",
+            "columnName": "dark_surfaceContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerHigh",
+            "columnName": "dark_surfaceContainerHigh",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerHighest",
+            "columnName": "dark_surfaceContainerHighest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerLow",
+            "columnName": "dark_surfaceContainerLow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerLowest",
+            "columnName": "dark_surfaceContainerLowest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryFixed",
+            "columnName": "dark_primaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryFixedDim",
+            "columnName": "dark_primaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryFixed",
+            "columnName": "dark_onPrimaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryFixedVariant",
+            "columnName": "dark_onPrimaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryFixed",
+            "columnName": "dark_secondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryFixedDim",
+            "columnName": "dark_secondaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryFixed",
+            "columnName": "dark_onSecondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryFixedVariant",
+            "columnName": "dark_onSecondaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryFixed",
+            "columnName": "dark_tertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryFixedDim",
+            "columnName": "dark_tertiaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryFixed",
+            "columnName": "dark_onTertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryFixedVariant",
+            "columnName": "dark_onTertiaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumArtUriString"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_art_themes_albumArtUriString_paletteStyle",
+            "unique": false,
+            "columnNames": [
+              "albumArtUriString",
+              "paletteStyle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_art_themes_albumArtUriString_paletteStyle` ON `${TABLE_NAME}` (`albumArtUriString`, `paletteStyle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `artist_id` INTEGER NOT NULL, `album_artist` TEXT, `album_artist_id` INTEGER NOT NULL DEFAULT 0, `album_name` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `content_uri_string` TEXT NOT NULL, `album_art_uri_string` TEXT, `duration` INTEGER NOT NULL, `genre` TEXT, `file_path` TEXT NOT NULL, `parent_directory_path` TEXT NOT NULL, `is_favorite` INTEGER NOT NULL DEFAULT 0, `lyrics` TEXT DEFAULT null, `track_number` INTEGER NOT NULL DEFAULT 0, `disc_number` INTEGER DEFAULT null, `year` INTEGER NOT NULL DEFAULT 0, `date_added` INTEGER NOT NULL DEFAULT 0, `mime_type` TEXT, `bitrate` INTEGER, `sample_rate` INTEGER, `artists_json` TEXT, `source_type` INTEGER NOT NULL DEFAULT 0, `media_store_date_added` INTEGER NOT NULL DEFAULT 0, `media_store_date_modified` INTEGER NOT NULL DEFAULT 0, `title_user_edited` INTEGER NOT NULL DEFAULT 0, `artist_user_edited` INTEGER NOT NULL DEFAULT 0, `album_user_edited` INTEGER NOT NULL DEFAULT 0, `genre_user_edited` INTEGER NOT NULL DEFAULT 0, `mb_recording_id` TEXT, `mb_release_id` TEXT, `mb_artist_id` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`album_id`) REFERENCES `albums`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artist_id`) REFERENCES `artists`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtistId",
+            "columnName": "album_artist_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "album_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentUriString",
+            "columnName": "content_uri_string",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "album_art_uri_string",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentDirectoryPath",
+            "columnName": "parent_directory_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sample_rate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artists_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaStoreDateAdded",
+            "columnName": "media_store_date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaStoreDateModified",
+            "columnName": "media_store_date_modified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "titleUserEdited",
+            "columnName": "title_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "artistUserEdited",
+            "columnName": "artist_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "albumUserEdited",
+            "columnName": "album_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "genreUserEdited",
+            "columnName": "genre_user_edited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mbRecordingId",
+            "columnName": "mb_recording_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mbReleaseId",
+            "columnName": "mb_release_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mbArtistId",
+            "columnName": "mb_artist_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_songs_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_songs_album_id",
+            "unique": false,
+            "columnNames": [
+              "album_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_album_id` ON `${TABLE_NAME}` (`album_id`)"
+          },
+          {
+            "name": "index_songs_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_songs_artist_name",
+            "unique": false,
+            "columnNames": [
+              "artist_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_artist_name` ON `${TABLE_NAME}` (`artist_name`)"
+          },
+          {
+            "name": "index_songs_genre",
+            "unique": false,
+            "columnNames": [
+              "genre"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_genre` ON `${TABLE_NAME}` (`genre`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path` ON `${TABLE_NAME}` (`parent_directory_path`)"
+          },
+          {
+            "name": "index_songs_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_songs_content_uri_string",
+            "unique": false,
+            "columnNames": [
+              "content_uri_string"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_content_uri_string` ON `${TABLE_NAME}` (`content_uri_string`)"
+          },
+          {
+            "name": "index_songs_date_added",
+            "unique": false,
+            "columnNames": [
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_date_added` ON `${TABLE_NAME}` (`date_added`)"
+          },
+          {
+            "name": "index_songs_duration",
+            "unique": false,
+            "columnNames": [
+              "duration"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_duration` ON `${TABLE_NAME}` (`duration`)"
+          },
+          {
+            "name": "index_songs_source_type",
+            "unique": false,
+            "columnNames": [
+              "source_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_source_type` ON `${TABLE_NAME}` (`source_type`)"
+          },
+          {
+            "name": "index_songs_album_artist_id",
+            "unique": false,
+            "columnNames": [
+              "album_artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_album_artist_id` ON `${TABLE_NAME}` (`album_artist_id`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path_source_type_album_id",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path",
+              "source_type",
+              "album_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path_source_type_album_id` ON `${TABLE_NAME}` (`parent_directory_path`, `source_type`, `album_id`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path_source_type_id",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path",
+              "source_type",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path_source_type_id` ON `${TABLE_NAME}` (`parent_directory_path`, `source_type`, `id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "albums",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "album_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artists",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "songs_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, tokenize=unicode61)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": []
+      },
+      {
+        "tableName": "albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `artist_id` INTEGER NOT NULL, `album_art_uri_string` TEXT, `song_count` INTEGER NOT NULL, `date_added` INTEGER NOT NULL, `year` INTEGER NOT NULL, `album_artist` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "album_art_uri_string",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_albums_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_albums_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_albums_artist_name",
+            "unique": false,
+            "columnNames": [
+              "artist_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_artist_name` ON `${TABLE_NAME}` (`artist_name`)"
+          },
+          {
+            "name": "index_albums_album_artist",
+            "unique": false,
+            "columnNames": [
+              "album_artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_album_artist` ON `${TABLE_NAME}` (`album_artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `track_count` INTEGER NOT NULL, `image_url` TEXT, `custom_image_uri` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customImageUri",
+            "columnName": "custom_image_uri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transition_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `fromTrackId` TEXT, `toTrackId` TEXT, `mode` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `curveIn` TEXT NOT NULL, `curveOut` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromTrackId",
+            "columnName": "fromTrackId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toTrackId",
+            "columnName": "toTrackId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "settings.mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.curveIn",
+            "columnName": "curveIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.curveOut",
+            "columnName": "curveOut",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transition_rules_playlistId_fromTrackId_toTrackId",
+            "unique": true,
+            "columnNames": [
+              "playlistId",
+              "fromTrackId",
+              "toTrackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transition_rules_playlistId_fromTrackId_toTrackId` ON `${TABLE_NAME}` (`playlistId`, `fromTrackId`, `toTrackId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "song_artist_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song_id` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `is_primary` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`song_id`, `artist_id`), FOREIGN KEY(`song_id`) REFERENCES `songs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artist_id`) REFERENCES `artists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrimary",
+            "columnName": "is_primary",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song_id",
+            "artist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_cross_ref_song_id",
+            "unique": false,
+            "columnNames": [
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_song_id` ON `${TABLE_NAME}` (`song_id`)"
+          },
+          {
+            "name": "index_song_artist_cross_ref_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_song_artist_cross_ref_is_primary",
+            "unique": false,
+            "columnNames": [
+              "is_primary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_is_primary` ON `${TABLE_NAME}` (`is_primary`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "songs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "song_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_engagements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song_id` TEXT NOT NULL, `play_count` INTEGER NOT NULL, `total_play_duration_ms` INTEGER NOT NULL, `last_played_timestamp` INTEGER NOT NULL, PRIMARY KEY(`song_id`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayDurationMs",
+            "columnName": "total_play_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedTimestamp",
+            "columnName": "last_played_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_engagements_play_count",
+            "unique": false,
+            "columnNames": [
+              "play_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_engagements_play_count` ON `${TABLE_NAME}` (`play_count`)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`songId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorites_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` INTEGER NOT NULL, `content` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, `source` TEXT, PRIMARY KEY(`songId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `last_modified` INTEGER NOT NULL, `is_queue_generated` INTEGER NOT NULL, `cover_image_uri` TEXT, `cover_color_argb` INTEGER, `cover_icon_name` TEXT, `cover_shape_type` TEXT, `cover_shape_detail_1` REAL, `cover_shape_detail_2` REAL, `cover_shape_detail_3` REAL, `cover_shape_detail_4` REAL, `source` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isQueueGenerated",
+            "columnName": "is_queue_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverImageUri",
+            "columnName": "cover_image_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverColorArgb",
+            "columnName": "cover_color_argb",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverIconName",
+            "columnName": "cover_icon_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverShapeType",
+            "columnName": "cover_shape_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverShapeDetail1",
+            "columnName": "cover_shape_detail_1",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail2",
+            "columnName": "cover_shape_detail_2",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail3",
+            "columnName": "cover_shape_detail_3",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail4",
+            "columnName": "cover_shape_detail_4",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_last_modified",
+            "unique": false,
+            "columnNames": [
+              "last_modified"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_last_modified` ON `${TABLE_NAME}` (`last_modified`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` TEXT NOT NULL, `song_id` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `song_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "song_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_songs_playlist_id_sort_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "sort_order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_songs_playlist_id_sort_order` ON `${TABLE_NAME}` (`playlist_id`, `sort_order`)"
+          },
+          {
+            "name": "index_playlist_songs_song_id",
+            "unique": false,
+            "columnNames": [
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_songs_song_id` ON `${TABLE_NAME}` (`song_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "navidrome_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `navidrome_id` TEXT NOT NULL, `playlist_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album_artist` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `cover_art_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `suffix` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "navidromeId",
+            "columnName": "navidrome_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "cover_art_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_navidrome_songs_navidrome_id",
+            "unique": false,
+            "columnNames": [
+              "navidrome_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_navidrome_id` ON `${TABLE_NAME}` (`navidrome_id`)"
+          },
+          {
+            "name": "index_navidrome_songs_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_navidrome_songs_playlist_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_playlist_id_date_added` ON `${TABLE_NAME}` (`playlist_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "navidrome_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `comment` TEXT, `owner` TEXT, `cover_art_id` TEXT, `song_count` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `public` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "cover_art_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "public",
+            "columnName": "public",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "jellyfin_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `jellyfin_id` TEXT NOT NULL, `playlist_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album_artist` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jellyfinId",
+            "columnName": "jellyfin_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_jellyfin_songs_jellyfin_id",
+            "unique": false,
+            "columnNames": [
+              "jellyfin_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_jellyfin_id` ON `${TABLE_NAME}` (`jellyfin_id`)"
+          },
+          {
+            "name": "index_jellyfin_songs_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_jellyfin_songs_playlist_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_playlist_id_date_added` ON `${TABLE_NAME}` (`playlist_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "jellyfin_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `song_count` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "listenbrainz_pending_listens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listened_at_ms` INTEGER NOT NULL, `track_name` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `release_name` TEXT, `duration_ms` INTEGER, `recording_mbid` TEXT, `source` TEXT NOT NULL, `attempts` INTEGER NOT NULL DEFAULT 0, `created_at_ms` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listenedAtMs",
+            "columnName": "listened_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackName",
+            "columnName": "track_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseName",
+            "columnName": "release_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "recordingMbid",
+            "columnName": "recording_mbid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "created_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "audio_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `song_id` TEXT NOT NULL, `song_title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `album_art_uri` TEXT, `title` TEXT NOT NULL, `timestamp_ms` INTEGER NOT NULL, `created_time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songTitle",
+            "columnName": "song_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUri",
+            "columnName": "album_art_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestamp_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdTime",
+            "columnName": "created_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2e5b2ad2796ef4ef6ad7eb6f805dee2c')"
+    ]
+  }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/MainActivity.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/MainActivity.kt
@@ -574,7 +574,11 @@ class MainActivity : ComponentActivity() {
                 Screen.RecentlyPlayed.route,
                 Screen.DeviceCapabilities.route,
                 Screen.EasterEgg.route,
-                Screen.WordDelimiterConfig.route
+                Screen.WordDelimiterConfig.route,
+                Screen.AdvancedStats.route,
+                Screen.MostListened.route,
+                Screen.AudioBookmarks.route,
+                Screen.AudioBookmarkFolder.route
             )
         }
         val shouldHideNavigationBar by remember(currentRoute, isSearchBarActive) {
@@ -694,6 +698,8 @@ class MainActivity : ComponentActivity() {
                             popUpTo(Screen.Home.route) { inclusive = true }
                         }
                         DrawerDestination.Equalizer -> navController.navigateSafely(Screen.Equalizer.route)
+                        DrawerDestination.AudioBookmarks -> navController.navigateSafely(Screen.AudioBookmarks.route)
+                        DrawerDestination.MostListened -> navController.navigateSafely(Screen.MostListened.route)
                         DrawerDestination.Settings -> navController.navigateSafely(Screen.Settings.route)
                     }
                 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/model/BackupManifest.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/model/BackupManifest.kt
@@ -9,7 +9,7 @@ data class BackupManifest(
     val modules: Map<String, BackupModuleInfo> = emptyMap()
 ) {
     companion object {
-        const val CURRENT_SCHEMA_VERSION = 3
+        const val CURRENT_SCHEMA_VERSION = 4
         const val MIN_SUPPORTED_VERSION = 1
         const val MANIFEST_FILENAME = "manifest.json"
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/model/BackupSection.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/model/BackupSection.kt
@@ -77,6 +77,13 @@ enum class BackupSection(
         description = "Your custom equalizer presets and audio profiles.",
         iconRes = R.drawable.rounded_surround_sound_24,
         sinceVersion = 3
+    ),
+    AUDIO_BOOKMARKS(
+        key = "audio_bookmarks",
+        label = "Bookmarks",
+        description = "Saved moments inside your tracks.",
+        iconRes = R.drawable.round_bookmark_24,
+        sinceVersion = 4
     );
 
     companion object {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/module/AudioBookmarksModuleHandler.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/module/AudioBookmarksModuleHandler.kt
@@ -1,0 +1,39 @@
+package com.lostf1sh.pixelplayeross.data.backup.module
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.lostf1sh.pixelplayeross.data.backup.model.BackupSection
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkDao
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkEntity
+import com.lostf1sh.pixelplayeross.di.BackupGson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AudioBookmarksModuleHandler @Inject constructor(
+    private val audioBookmarkDao: AudioBookmarkDao,
+    @param:BackupGson private val gson: Gson
+) : BackupModuleHandler {
+
+    override val section = BackupSection.AUDIO_BOOKMARKS
+
+    override suspend fun export(): String = withContext(Dispatchers.IO) {
+        gson.toJson(audioBookmarkDao.getAllBookmarksOnce())
+    }
+
+    override suspend fun countEntries(): Int = withContext(Dispatchers.IO) {
+        audioBookmarkDao.getAllBookmarksOnce().size
+    }
+
+    override suspend fun snapshot(): String = export()
+
+    override suspend fun restore(payload: String) = withContext(Dispatchers.IO) {
+        val type = TypeToken.getParameterized(List::class.java, AudioBookmarkEntity::class.java).type
+        val bookmarks: List<AudioBookmarkEntity> = gson.fromJson(payload, type)
+        audioBookmarkDao.replaceAll(bookmarks)
+    }
+
+    override suspend fun rollback(snapshot: String) = restore(snapshot)
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/validation/ModuleSchemaValidator.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/backup/validation/ModuleSchemaValidator.kt
@@ -66,6 +66,7 @@ class ModuleSchemaValidator @Inject constructor(
             BackupSection.PLAYBACK_HISTORY -> validatePlaybackHistory(jsonElement.asJsonArray, errors)
             BackupSection.ARTIST_IMAGES -> validateArtistImages(jsonElement.asJsonArray, errors)
             BackupSection.TRANSITIONS -> validateTransitions(jsonElement.asJsonArray, errors)
+            BackupSection.AUDIO_BOOKMARKS -> validateAudioBookmarks(jsonElement.asJsonArray, errors)
             BackupSection.GLOBAL_SETTINGS,
             BackupSection.QUICK_FILL,
             BackupSection.EQUALIZER -> {
@@ -342,6 +343,20 @@ class ModuleSchemaValidator @Inject constructor(
             }
             if (imageUrl.length > 2000) {
                 errors.add(ValidationError("URL_TOO_LONG", "ArtistImages[$i]: URL exceeds 2000 chars", module = "artist_images", severity = Severity.WARNING))
+            }
+        }
+    }
+
+    private fun validateAudioBookmarks(array: com.google.gson.JsonArray, errors: MutableList<ValidationError>) {
+        array.forEachIndexed { i, element ->
+            if (!element.isJsonObject) return@forEachIndexed
+            val obj = element.asJsonObject
+            if (readStringField(obj, "songId", "song_id").isNullOrBlank()) {
+                errors.add(ValidationError("MISSING_SONG_ID", "AudioBookmarks[$i]: missing songId", module = "audio_bookmarks", severity = Severity.ERROR))
+            }
+            val timestampMs = readNumericField(obj, "timestampMs", "timestamp_ms").value ?: 0L
+            if (timestampMs < 0L) {
+                errors.add(ValidationError("NEGATIVE_TIMESTAMP", "AudioBookmarks[$i]: timestampMs is negative", module = "audio_bookmarks", severity = Severity.ERROR))
             }
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/AudioBookmarkDao.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/AudioBookmarkDao.kt
@@ -1,0 +1,41 @@
+package com.lostf1sh.pixelplayeross.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AudioBookmarkDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertBookmark(bookmark: AudioBookmarkEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(bookmarks: List<AudioBookmarkEntity>)
+
+    @Query("SELECT * FROM audio_bookmarks ORDER BY created_time DESC")
+    suspend fun getAllBookmarksOnce(): List<AudioBookmarkEntity>
+
+    @Query("DELETE FROM audio_bookmarks")
+    suspend fun deleteAll()
+
+    @Transaction
+    suspend fun replaceAll(bookmarks: List<AudioBookmarkEntity>) {
+        deleteAll()
+        insertAll(bookmarks)
+    }
+
+    @Query("DELETE FROM audio_bookmarks WHERE id = :id")
+    suspend fun deleteBookmark(id: Long)
+
+    @Query("SELECT * FROM audio_bookmarks ORDER BY created_time DESC")
+    fun getAllBookmarksFlow(): Flow<List<AudioBookmarkEntity>>
+
+    @Query("SELECT * FROM audio_bookmarks WHERE song_id = :songId ORDER BY created_time DESC")
+    suspend fun getBookmarksForSong(songId: String): List<AudioBookmarkEntity>
+
+    @Query("SELECT * FROM audio_bookmarks WHERE id = :id")
+    suspend fun getBookmarkById(id: Long): AudioBookmarkEntity?
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/AudioBookmarkEntity.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/AudioBookmarkEntity.kt
@@ -1,0 +1,17 @@
+package com.lostf1sh.pixelplayeross.data.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "audio_bookmarks")
+data class AudioBookmarkEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "song_id") val songId: String,
+    @ColumnInfo(name = "song_title") val songTitle: String,
+    @ColumnInfo(name = "artist_name") val artistName: String,
+    @ColumnInfo(name = "album_art_uri") val albumArtUri: String?,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "timestamp_ms") val timestampMs: Long,
+    @ColumnInfo(name = "created_time") val createdTime: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/Migrations.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/Migrations.kt
@@ -87,3 +87,32 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
         db.addColumnIfMissing("songs", "mb_artist_id", "`mb_artist_id` TEXT")
     }
 }
+
+/**
+ * v3 -> v4: audio bookmarks.
+ *
+ * `audio_bookmarks`: user-saved moments inside a track. Rows snapshot the song's title, artist
+ * and artwork at save time so a bookmark still renders after the underlying file is moved,
+ * retagged or removed from the library — the screen only falls back to the live song row when
+ * one is still present.
+ *
+ * Additive and idempotent, per the Auto Backup drift guard above.
+ */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+                CREATE TABLE IF NOT EXISTS `audio_bookmarks` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `song_id` TEXT NOT NULL,
+                    `song_title` TEXT NOT NULL,
+                    `artist_name` TEXT NOT NULL,
+                    `album_art_uri` TEXT,
+                    `title` TEXT NOT NULL,
+                    `timestamp_ms` INTEGER NOT NULL,
+                    `created_time` INTEGER NOT NULL
+                )
+            """.trimIndent()
+        )
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/MusicDao.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/MusicDao.kt
@@ -328,6 +328,14 @@ interface MusicDao {
     @Query("SELECT DISTINCT parent_directory_path FROM songs")
     suspend fun getDistinctParentDirectories(): List<String>
 
+    /**
+     * Reactive variant of [getDistinctParentDirectories]. Re-emits whenever the songs table
+     * changes, so a cached directory filter stays consistent with the library instead of
+     * freezing at an early snapshot taken before the first sync populated any folders.
+     */
+    @Query("SELECT DISTINCT parent_directory_path FROM songs")
+    fun getDistinctParentDirectoriesFlow(): Flow<List<String>>
+
     @Query("SELECT " + SONG_LIST_PROJECTION + """
         FROM songs
         WHERE (:applyDirectoryFilter = 0 OR id < 0 OR parent_directory_path IN (:allowedParentDirs))

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/PixelPlayerDatabase.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/database/PixelPlayerDatabase.kt
@@ -23,9 +23,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         NavidromePlaylistEntity::class,
         JellyfinSongEntity::class,
         JellyfinPlaylistEntity::class,
-        ListenBrainzPendingListenEntity::class
+        ListenBrainzPendingListenEntity::class,
+        AudioBookmarkEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 abstract class PixelPlayerDatabase : RoomDatabase() {
@@ -40,6 +41,7 @@ abstract class PixelPlayerDatabase : RoomDatabase() {
     abstract fun navidromeDao(): NavidromeDao
     abstract fun jellyfinDao(): JellyfinDao
     abstract fun listenBrainzDao(): ListenBrainzDao
+    abstract fun audioBookmarkDao(): AudioBookmarkDao
 
     companion object {
         fun installFavoriteSyncTriggers(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/MostListenedType.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/MostListenedType.kt
@@ -1,0 +1,13 @@
+package com.lostf1sh.pixelplayeross.data.preferences
+
+/** What the Most Listened screen groups plays by. */
+enum class MostListenedType(val storageKey: String) {
+    SONGS("songs"),
+    ALBUMS("albums"),
+    ARTISTS("artists");
+
+    companion object {
+        fun fromStorageKey(value: String?): MostListenedType =
+            entries.firstOrNull { it.storageKey == value } ?: SONGS
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/preferences/UserPreferencesRepository.kt
@@ -50,6 +50,9 @@ object AppThemeMode {
 const val MIN_NAV_BAR_CORNER_RADIUS = 0
 const val MAX_NAV_BAR_CORNER_RADIUS = 60
 
+const val DEFAULT_LISTENING_GOAL_MINUTES = 45
+val LISTENING_GOAL_PRESET_MINUTES = listOf(15, 30, 45, 60, 90)
+
 internal fun sanitizeNavBarCornerRadius(radius: Int): Int =
         radius.coerceIn(MIN_NAV_BAR_CORNER_RADIUS, MAX_NAV_BAR_CORNER_RADIUS)
 
@@ -131,6 +134,8 @@ constructor(
         val KEEP_PLAYING_IN_BACKGROUND = booleanPreferencesKey("keep_playing_in_background")
         val IS_CROSSFADE_ENABLED = booleanPreferencesKey("is_crossfade_enabled")
         val HI_FI_MODE_ENABLED = booleanPreferencesKey("hi_fi_mode_enabled")
+        val LISTENING_GOAL_MINUTES = intPreferencesKey("listening_goal_minutes")
+        val MOST_LISTENED_TYPE = stringPreferencesKey("most_listened_type")
         val CROSSFADE_DURATION = intPreferencesKey("crossfade_duration")
         val PLAYBACK_SPEED = androidx.datastore.preferences.core.floatPreferencesKey("playback_speed")
         val CUSTOM_GENRES = androidx.datastore.preferences.core.stringSetPreferencesKey("custom_genres")
@@ -241,6 +246,31 @@ constructor(
     suspend fun setCrossfadeEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.IS_CROSSFADE_ENABLED] = enabled
+        }
+    }
+
+    /** What the Most Listened screen groups plays by. */
+    val mostListenedTypeFlow: Flow<MostListenedType> =
+        dataStore.data.map { preferences ->
+            MostListenedType.fromStorageKey(preferences[PreferencesKeys.MOST_LISTENED_TYPE])
+        }
+
+    suspend fun setMostListenedType(type: MostListenedType) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.MOST_LISTENED_TYPE] = type.storageKey
+        }
+    }
+
+    /** Daily listening target in minutes, shown as a progress ring and streak in Advanced Stats. */
+    val listeningGoalMinutesFlow: Flow<Int> =
+        dataStore.data.map { preferences ->
+            (preferences[PreferencesKeys.LISTENING_GOAL_MINUTES] ?: DEFAULT_LISTENING_GOAL_MINUTES)
+                .coerceIn(5, 480)
+        }
+
+    suspend fun setListeningGoalMinutes(minutes: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.LISTENING_GOAL_MINUTES] = minutes.coerceIn(5, 480)
         }
     }
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/repository/AudioBookmarkRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/repository/AudioBookmarkRepository.kt
@@ -1,0 +1,12 @@
+package com.lostf1sh.pixelplayeross.data.repository
+
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkEntity
+import kotlinx.coroutines.flow.Flow
+
+interface AudioBookmarkRepository {
+    fun getAllBookmarksFlow(): Flow<List<AudioBookmarkEntity>>
+    suspend fun getBookmarksForSong(songId: String): List<AudioBookmarkEntity>
+    suspend fun insertBookmark(bookmark: AudioBookmarkEntity)
+    suspend fun deleteBookmark(id: Long)
+    suspend fun getBookmarkById(id: Long): AudioBookmarkEntity?
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/repository/AudioBookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/repository/AudioBookmarkRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.lostf1sh.pixelplayeross.data.repository
+
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkDao
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AudioBookmarkRepositoryImpl @Inject constructor(
+    private val audioBookmarkDao: AudioBookmarkDao
+) : AudioBookmarkRepository {
+    override fun getAllBookmarksFlow(): Flow<List<AudioBookmarkEntity>> =
+        audioBookmarkDao.getAllBookmarksFlow()
+
+    override suspend fun getBookmarksForSong(songId: String): List<AudioBookmarkEntity> =
+        audioBookmarkDao.getBookmarksForSong(songId)
+
+    override suspend fun insertBookmark(bookmark: AudioBookmarkEntity) =
+        audioBookmarkDao.insertBookmark(bookmark)
+
+    override suspend fun deleteBookmark(id: Long) =
+        audioBookmarkDao.deleteBookmark(id)
+
+    override suspend fun getBookmarkById(id: Long): AudioBookmarkEntity? =
+        audioBookmarkDao.getBookmarkById(id)
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/repository/MusicRepositoryImpl.kt
@@ -112,21 +112,42 @@ class MusicRepositoryImpl @Inject constructor(
     private fun normalizePath(path: String): String =
         runCatching { File(path).canonicalPath }.getOrElse { File(path).absolutePath }
 
-    /** Cached directory filter — recomputed only when allowed/blocked dirs preferences change. */
+    /**
+     * Cached directory filter — recomputed when the allowed/blocked directory preferences change
+     * or when the set of folders holding songs changes.
+     *
+     * Watching the songs table matters: computing this once eagerly at construction runs it
+     * before the first sync, which on some devices leaves `allowedParentDirs` empty while
+     * `applyFilter` stays true. Queue-building queries such as `getSongIdsSorted` then match
+     * nothing and the playback queue collapses to just the tapped song.
+     */
     data class CachedDirFilter(val allowedParentDirs: List<String> = emptyList(), val applyFilter: Boolean = false)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val cachedDirFilter: StateFlow<CachedDirFilter> = combine(
         userPreferencesRepository.allowedDirectoriesFlow,
         userPreferencesRepository.blockedDirectoriesFlow
-    ) { allowed, blocked ->
-        val (dirs, apply) = DirectoryFilterUtils.computeAllowedParentDirs(
-            allowedDirs = allowed,
-            blockedDirs = blocked,
-            getAllParentDirs = { musicDao.getDistinctParentDirectories() },
-            normalizePath = ::normalizePath
-        )
-        CachedDirFilter(dirs, apply)
-    }.stateIn(repositoryScope, SharingStarted.Eagerly, CachedDirFilter())
+    ) { allowed, blocked -> allowed to blocked }
+        .flatMapLatest { (allowed, blocked) ->
+            if (blocked.isEmpty()) {
+                // No blocked dirs means no filter is applied, so there is no reason to observe
+                // the songs table at all in this (common) case.
+                flowOf(CachedDirFilter(emptyList(), false))
+            } else {
+                musicDao.getDistinctParentDirectoriesFlow()
+                    .distinctUntilChanged()
+                    .map { parentDirs ->
+                        val (dirs, apply) = DirectoryFilterUtils.computeAllowedParentDirs(
+                            allowedDirs = allowed,
+                            blockedDirs = blocked,
+                            getAllParentDirs = { parentDirs },
+                            normalizePath = ::normalizePath
+                        )
+                        CachedDirFilter(dirs, apply)
+                    }
+            }
+        }
+        .stateIn(repositoryScope, SharingStarted.Eagerly, CachedDirFilter())
 
     private fun List<Artist>.missingImageCandidates(): List<Pair<Long, String>> =
         asSequence()

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/data/stats/PlaybackStatsRepository.kt
@@ -192,6 +192,64 @@ class PlaybackStatsRepository @Inject constructor(
         }
     }
 
+    suspend fun getDailyPlaybackDurationMap(
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): Map<LocalDate, Long> = withContext(Dispatchers.IO) {
+        val zoneId = ZoneId.systemDefault()
+        val durationMap = mutableMapOf<LocalDate, Long>()
+        for (event in readEvents()) {
+            val eventDate = Instant.ofEpochMilli(event.timestamp).atZone(zoneId).toLocalDate()
+            if (!eventDate.isBefore(startDate) && !eventDate.isAfter(endDate)) {
+                durationMap[eventDate] = (durationMap[eventDate] ?: 0L) + event.durationMs
+            }
+        }
+        durationMap
+    }
+
+    /**
+     * Consecutive days (ending today or yesterday) whose total listening duration met [targetMs].
+     *
+     * Today does not break the streak while it is still in progress — it is simply excluded from
+     * the count until the goal is actually met, so the number never drops overnight.
+     */
+    suspend fun getGoalStreak(
+        targetMs: Long,
+        nowMillis: Long = System.currentTimeMillis(),
+        maxLookbackDays: Int = 400
+    ): Int = withContext(Dispatchers.IO) {
+        if (targetMs <= 0L) return@withContext 0
+        val zoneId = ZoneId.systemDefault()
+        val today = Instant.ofEpochMilli(nowMillis).atZone(zoneId).toLocalDate()
+        val durations = getDailyPlaybackDurationMap(today.minusDays(maxLookbackDays.toLong()), today)
+
+        var cursor = today
+        if ((durations[cursor] ?: 0L) < targetMs) {
+            cursor = cursor.minusDays(1)
+        }
+        var streak = 0
+        while ((durations[cursor] ?: 0L) >= targetMs) {
+            streak += 1
+            cursor = cursor.minusDays(1)
+        }
+        streak
+    }
+
+    suspend fun loadDaySummary(
+        date: LocalDate,
+        songs: List<Song>
+    ): PlaybackStatsSummary = withContext(Dispatchers.IO) {
+        val zoneId = ZoneId.systemDefault()
+        buildSummaryFromEventsWithBounds(
+            range = StatsTimeRange.DAY,
+            songs = songs,
+            startBound = date.atStartOfDay(zoneId).toInstant().toEpochMilli(),
+            endBound = date.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli() - 1,
+            allEvents = readEvents(),
+            zoneId = zoneId
+        )
+    }
+
     suspend fun loadSummary(
         range: StatsTimeRange,
         songs: List<Song>,
@@ -216,6 +274,30 @@ class PlaybackStatsRepository @Inject constructor(
         zoneId: ZoneId = ZoneId.systemDefault()
     ): PlaybackStatsSummary {
         val (startBound, endBound) = range.resolveBounds(allEvents, nowMillis, zoneId)
+        return buildSummaryFromEventsWithBounds(
+            range = range,
+            songs = songs,
+            startBound = startBound,
+            endBound = endBound,
+            allEvents = allEvents,
+            zoneId = zoneId
+        )
+    }
+
+    /**
+     * Builds a summary over an explicit window instead of one derived from [range].
+     *
+     * A specific calendar day is not expressible through [StatsTimeRange.resolveBounds] — its DAY
+     * bound is always "today" — so the day-by-day views pass their own bounds here.
+     */
+    internal fun buildSummaryFromEventsWithBounds(
+        range: StatsTimeRange,
+        songs: List<Song>,
+        startBound: Long?,
+        endBound: Long,
+        allEvents: List<PlaybackEvent>,
+        zoneId: ZoneId = ZoneId.systemDefault()
+    ): PlaybackStatsSummary {
         val filteredEvents = allEvents.mapNotNull { event ->
             val start = event.startMillis()
             val end = event.endMillis()

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/di/AppModule.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/di/AppModule.kt
@@ -25,7 +25,9 @@ import com.lostf1sh.pixelplayeross.data.database.LocalPlaylistDao
 import com.lostf1sh.pixelplayeross.data.database.ListenBrainzDao
 import com.lostf1sh.pixelplayeross.data.database.MIGRATION_1_2
 import com.lostf1sh.pixelplayeross.data.database.MIGRATION_2_3
+import com.lostf1sh.pixelplayeross.data.database.MIGRATION_3_4
 import com.lostf1sh.pixelplayeross.data.database.MusicDao
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkDao
 import com.lostf1sh.pixelplayeross.data.database.PixelPlayerDatabase
 import com.lostf1sh.pixelplayeross.data.database.SearchHistoryDao
 import com.lostf1sh.pixelplayeross.data.database.TransitionDao
@@ -40,6 +42,8 @@ import com.lostf1sh.pixelplayeross.data.repository.LyricsRepository
 import com.lostf1sh.pixelplayeross.data.repository.LyricsRepositoryImpl
 import com.lostf1sh.pixelplayeross.data.repository.MediaStoreSongRepository
 import com.lostf1sh.pixelplayeross.data.repository.MusicRepository
+import com.lostf1sh.pixelplayeross.data.repository.AudioBookmarkRepository
+import com.lostf1sh.pixelplayeross.data.repository.AudioBookmarkRepositoryImpl
 import com.lostf1sh.pixelplayeross.data.repository.MusicRepositoryImpl
 import com.lostf1sh.pixelplayeross.data.repository.SongRepository
 import com.lostf1sh.pixelplayeross.data.repository.TransitionRepository
@@ -126,7 +130,7 @@ object AppModule {
             "pixelplayer_database"
         )
             .addCallback(PixelPlayerDatabase.createRuntimeArtifactsCallback())
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
 
         if (BuildConfig.DEBUG) {
@@ -140,6 +144,20 @@ object AppModule {
     @Provides
     fun provideAlbumArtThemeDao(database: PixelPlayerDatabase): AlbumArtThemeDao {
         return database.albumArtThemeDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideAudioBookmarkDao(database: PixelPlayerDatabase): AudioBookmarkDao {
+        return database.audioBookmarkDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideAudioBookmarkRepository(
+        audioBookmarkDao: AudioBookmarkDao
+    ): AudioBookmarkRepository {
+        return AudioBookmarkRepositoryImpl(audioBookmarkDao)
     }
 
     @Singleton

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/di/BackupModule.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/di/BackupModule.kt
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder
 import com.lostf1sh.pixelplayeross.data.backup.format.BackupFormatDetector
 import com.lostf1sh.pixelplayeross.data.backup.model.BackupSection
 import com.lostf1sh.pixelplayeross.data.backup.module.ArtistImagesModuleHandler
+import com.lostf1sh.pixelplayeross.data.backup.module.AudioBookmarksModuleHandler
 import com.lostf1sh.pixelplayeross.data.backup.module.BackupModuleHandler
 import com.lostf1sh.pixelplayeross.data.backup.module.EngagementStatsModuleHandler
 import com.lostf1sh.pixelplayeross.data.backup.module.EqualizerModuleHandler
@@ -55,7 +56,8 @@ object BackupModule {
         playbackHistoryHandler: PlaybackHistoryModuleHandler,
         quickFillHandler: QuickFillModuleHandler,
         artistImagesHandler: ArtistImagesModuleHandler,
-        equalizerHandler: EqualizerModuleHandler
+        equalizerHandler: EqualizerModuleHandler,
+        audioBookmarksHandler: AudioBookmarksModuleHandler
     ): Map<BackupSection, BackupModuleHandler> {
         return mapOf(
             BackupSection.PLAYLISTS to playlistsHandler,
@@ -68,7 +70,8 @@ object BackupModule {
             BackupSection.PLAYBACK_HISTORY to playbackHistoryHandler,
             BackupSection.QUICK_FILL to quickFillHandler,
             BackupSection.ARTIST_IMAGES to artistImagesHandler,
-            BackupSection.EQUALIZER to equalizerHandler
+            BackupSection.EQUALIZER to equalizerHandler,
+            BackupSection.AUDIO_BOOKMARKS to audioBookmarksHandler
         )
     }
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/AppSidebarDrawer.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/AppSidebarDrawer.kt
@@ -32,6 +32,8 @@ import com.lostf1sh.pixelplayeross.R
 sealed class DrawerDestination(val route: String) {
     object Home : DrawerDestination("home")
     object Equalizer : DrawerDestination("equalizer")
+    object AudioBookmarks : DrawerDestination("audio_bookmarks")
+    object MostListened : DrawerDestination("most_listened")
     object Settings : DrawerDestination("settings")
 }
 
@@ -140,6 +142,60 @@ private fun DrawerContent(
             },
             selected = selectedRoute == DrawerDestination.Equalizer.route,
             onClick = { onDestinationSelected(DrawerDestination.Equalizer) },
+            modifier = Modifier.padding(vertical = 4.dp),
+            colors = NavigationDrawerItemDefaults.colors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                unselectedContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0f),
+                unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+            ),
+            shape = RoundedCornerShape(16.dp)
+        )
+
+        NavigationDrawerItem(
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.round_bookmark_24),
+                    contentDescription = stringResource(R.string.bookmarks_title)
+                )
+            },
+            label = {
+                Text(
+                    text = stringResource(R.string.bookmarks_title),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            },
+            selected = selectedRoute == DrawerDestination.AudioBookmarks.route,
+            onClick = { onDestinationSelected(DrawerDestination.AudioBookmarks) },
+            modifier = Modifier.padding(vertical = 4.dp),
+            colors = NavigationDrawerItemDefaults.colors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                unselectedContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0f),
+                unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+            ),
+            shape = RoundedCornerShape(16.dp)
+        )
+
+        NavigationDrawerItem(
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.rounded_monitoring_24),
+                    contentDescription = stringResource(R.string.most_listened_title)
+                )
+            },
+            label = {
+                Text(
+                    text = stringResource(R.string.most_listened_title),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            },
+            selected = selectedRoute == DrawerDestination.MostListened.route,
+            onClick = { onDestinationSelected(DrawerDestination.MostListened) },
             modifier = Modifier.padding(vertical = 4.dp),
             colors = NavigationDrawerItemDefaults.colors(
                 selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/BlurEffectCache.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/BlurEffectCache.kt
@@ -1,0 +1,37 @@
+package com.lostf1sh.pixelplayeross.presentation.components
+
+import android.os.Build
+import android.graphics.RenderEffect as AndroidRenderEffect
+import android.graphics.Shader as AndroidShader
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.asComposeRenderEffect
+
+/**
+ * Caches the (expensive) RenderEffect Java object so a blurred graphicsLayer doesn't allocate a
+ * new native blur every animation frame. Callers should quantize the radius (e.g. to 2px steps)
+ * before calling [get] so this only rebuilds when the blur visibly crosses a step, instead of on
+ * every frame of a continuous animation.
+ *
+ * `RenderEffect` arrived in API 31 while the app supports 30, so [get] returns null below that.
+ * A null `renderEffect` on a graphicsLayer simply draws unblurred, which is the intended fallback
+ * — every call site layers the blur over content that already reads correctly without it.
+ */
+class BlurEffectCache {
+    private var lastRadiusPx: Float = Float.NaN
+    private var cached: RenderEffect? = null
+
+    fun get(radiusPx: Float): RenderEffect? {
+        if (radiusPx <= 0f || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            lastRadiusPx = 0f
+            cached = null
+            return null
+        }
+        if (radiusPx != lastRadiusPx) {
+            lastRadiusPx = radiusPx
+            cached = AndroidRenderEffect
+                .createBlurEffect(radiusPx, radiusPx, AndroidShader.TileMode.CLAMP)
+                .asComposeRenderEffect()
+        }
+        return cached
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/MostListenedEntries.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/MostListenedEntries.kt
@@ -1,0 +1,186 @@
+package com.lostf1sh.pixelplayeross.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.data.database.SongEngagementEntity
+import com.lostf1sh.pixelplayeross.data.model.Artist
+import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.preferences.MostListenedType
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.ThemeStateHolder
+import com.lostf1sh.pixelplayeross.ui.theme.LocalPixelPlayerDarkTheme
+
+/** One row of the Most Listened screen, already collapsed to the selected grouping. */
+data class MostListenedEntry(
+    val key: String,
+    val title: String,
+    val subtitle: String,
+    val artwork: String?,
+    val playCount: Int,
+    val representativeSong: Song,
+    val destinationId: Long,
+)
+
+/**
+ * Collapses per-song play counts into ranked entries for [type].
+ *
+ * Album and artist entries keep the most-played track as their representative so tapping through
+ * lands on real playable content, and their artwork/subtitle come from that track.
+ */
+fun buildMostListenedEntries(
+    songs: List<Song>,
+    engagements: List<SongEngagementEntity>,
+    type: MostListenedType,
+    artists: List<Artist> = emptyList(),
+): List<MostListenedEntry> {
+    val counts = engagements.associate { it.songId to it.playCount.coerceAtLeast(0) }
+    val artistImages = artists.associate { it.id to it.effectiveImageUrl }
+    val playedSongs = songs.filter { (counts[it.id] ?: 0) > 0 }
+    return when (type) {
+        MostListenedType.SONGS -> playedSongs
+            .sortedWith(compareByDescending<Song> { counts[it.id] ?: 0 }.thenBy { it.title })
+            .map { song ->
+                MostListenedEntry(
+                    key = "song:${song.id}",
+                    title = song.title,
+                    subtitle = song.displayArtist,
+                    artwork = song.albumArtUriString,
+                    playCount = counts[song.id] ?: 0,
+                    representativeSong = song,
+                    destinationId = song.id.toLongOrNull() ?: -1L,
+                )
+            }
+
+        MostListenedType.ALBUMS -> playedSongs
+            .groupBy { it.albumId }
+            .mapNotNull { (albumId, albumSongs) ->
+                val representative = albumSongs.maxByOrNull { counts[it.id] ?: 0 } ?: return@mapNotNull null
+                MostListenedEntry(
+                    key = "album:$albumId",
+                    title = representative.album,
+                    subtitle = representative.albumArtist?.takeIf(String::isNotBlank) ?: representative.displayArtist,
+                    artwork = representative.albumArtUriString,
+                    playCount = albumSongs.sumOf { counts[it.id] ?: 0 },
+                    representativeSong = representative,
+                    destinationId = albumId,
+                )
+            }
+            .sortedWith(compareByDescending<MostListenedEntry> { it.playCount }.thenBy { it.title })
+
+        MostListenedType.ARTISTS -> playedSongs
+            .groupBy { it.primaryArtist.id }
+            .mapNotNull { (artistId, artistSongs) ->
+                val representative = artistSongs.maxByOrNull { counts[it.id] ?: 0 } ?: return@mapNotNull null
+                MostListenedEntry(
+                    key = "artist:$artistId",
+                    title = representative.primaryArtist.name,
+                    subtitle = representative.album,
+                    artwork = artistImages[artistId]?.takeIf(String::isNotBlank) ?: representative.albumArtUriString,
+                    playCount = artistSongs.sumOf { counts[it.id] ?: 0 },
+                    representativeSong = representative,
+                    destinationId = artistId,
+                )
+            }
+            .sortedWith(compareByDescending<MostListenedEntry> { it.playCount }.thenBy { it.title })
+    }
+}
+
+@Composable
+fun rememberArtworkColorScheme(artwork: String?, themeStateHolder: ThemeStateHolder): ColorScheme {
+    val pair by remember(artwork, themeStateHolder) {
+        themeStateHolder.getAlbumColorSchemeFlow(artwork.orEmpty())
+    }.collectAsStateWithLifecycle()
+    val dark = LocalPixelPlayerDarkTheme.current
+    return pair?.let { if (dark) it.dark else it.light } ?: MaterialTheme.colorScheme
+}
+
+/**
+ * Artwork that fades into [blendColor] at its trailing edge, so a list row can carry a full-bleed
+ * cover without the text on top of it losing contrast.
+ */
+@Composable
+fun ProgressiveArtworkBlend(
+    model: String?,
+    blendColor: Color,
+    blurEnabled: Boolean,
+    modifier: Modifier = Modifier,
+    horizontal: Boolean = false,
+) {
+    val density = LocalDensity.current
+    val blurCache = remember { BlurEffectCache() }
+    val blurRadiusPx = with(density) { 18.dp.toPx() }
+    val blurEffect = remember(blurRadiusPx) { blurCache.get(blurRadiusPx) }
+    val maskBrush = remember(horizontal) {
+        if (horizontal) {
+            Brush.horizontalGradient(0.28f to Color.Transparent, 1f to Color.Black)
+        } else {
+            Brush.verticalGradient(0.30f to Color.Transparent, 1f to Color.Black)
+        }
+    }
+    val blendBrush = remember(blendColor, horizontal) {
+        if (horizontal) {
+            Brush.horizontalGradient(
+                0f to Color.Transparent,
+                .52f to Color.Transparent,
+                .82f to blendColor.copy(alpha = .92f),
+                1f to blendColor,
+            )
+        } else {
+            Brush.verticalGradient(
+                0f to Color.Transparent,
+                .48f to Color.Transparent,
+                .78f to blendColor.copy(alpha = .92f),
+                1f to blendColor,
+            )
+        }
+    }
+    Box(modifier) {
+        SmartImage(
+            model = model,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
+        if (blurEnabled) {
+            SmartImage(
+                model = model,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        renderEffect = blurEffect
+                        compositingStrategy = CompositingStrategy.Offscreen
+                    }
+                    .drawWithContent {
+                        drawContent()
+                        drawRect(maskBrush, blendMode = BlendMode.DstIn)
+                    },
+            )
+        }
+        Box(Modifier.fillMaxSize().background(blendBrush))
+    }
+}
+
+fun MostListenedType.labelRes(): Int = when (this) {
+    MostListenedType.SONGS -> R.string.most_listened_songs
+    MostListenedType.ALBUMS -> R.string.most_listened_albums
+    MostListenedType.ARTISTS -> R.string.most_listened_artists
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/AddBookmarkDialog.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/AddBookmarkDialog.kt
@@ -1,0 +1,260 @@
+package com.lostf1sh.pixelplayeross.presentation.components.player
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Bookmark
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.lostf1sh.pixelplayeross.data.model.Lyrics
+import java.util.Locale
+
+private val BookmarkTitleWhitespaceRegex = Regex("\\s+")
+
+@Composable
+fun AddBookmarkDialog(
+    currentProgressMs: Long,
+    lyricTitle: String? = null,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val formattedTime = remember(currentProgressMs) {
+        val totalSeconds = currentProgressMs / 1000
+        val minutes = totalSeconds / 60
+        val seconds = totalSeconds % 60
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
+
+    val defaultTitle = remember(formattedTime) { "Bookmark @ $formattedTime" }
+    val availableLyricTitle = remember(lyricTitle) { lyricTitle?.trim()?.takeIf { it.isNotBlank() } }
+    var customTitle by remember(defaultTitle) { mutableStateOf(defaultTitle) }
+    var useLyricTitle by remember(availableLyricTitle) { mutableStateOf(false) }
+    val resolvedTitle = if (useLyricTitle && availableLyricTitle != null) {
+        availableLyricTitle
+    } else {
+        customTitle.trim()
+    }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(useLyricTitle) {
+        if (!useLyricTitle) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Surface(
+                shape = RoundedCornerShape(18.dp),
+                color = MaterialTheme.colorScheme.primaryContainer,
+                tonalElevation = 2.dp
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Bookmark,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(12.dp)
+                        .size(24.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+        },
+        title = {
+            Text(
+                text = "Save bookmark",
+                style = MaterialTheme.typography.titleLarge
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(22.dp),
+                    color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.72f)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Bookmark,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                        Column {
+                            Text(
+                                text = formattedTime,
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                            Text(
+                                text = "Saved playback point",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.72f)
+                            )
+                        }
+                    }
+                }
+
+                if (availableLyricTitle != null) {
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { useLyricTitle = !useLyricTitle },
+                        shape = RoundedCornerShape(24.dp),
+                        color = if (useLyricTitle) {
+                            MaterialTheme.colorScheme.primaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.surfaceContainerHighest
+                        }
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(14.dp)
+                        ) {
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.spacedBy(3.dp)
+                            ) {
+                                Text(
+                                    text = "Use lyric line",
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = if (useLyricTitle) {
+                                        MaterialTheme.colorScheme.onPrimaryContainer
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurface
+                                    }
+                                )
+                                Text(
+                                    text = availableLyricTitle,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontStyle = FontStyle.Italic,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                    color = if (useLyricTitle) {
+                                        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.82f)
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    }
+                                )
+                            }
+                            Switch(
+                                checked = useLyricTitle,
+                                onCheckedChange = { useLyricTitle = it },
+                                colors = SwitchDefaults.colors(
+                                    checkedThumbColor = MaterialTheme.colorScheme.primary,
+                                    checkedTrackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.34f)
+                                )
+                            )
+                        }
+                    }
+                }
+
+                OutlinedTextField(
+                    value = if (useLyricTitle && availableLyricTitle != null) {
+                        availableLyricTitle
+                    } else {
+                        customTitle
+                    },
+                    onValueChange = { customTitle = it },
+                    enabled = !useLyricTitle,
+                    singleLine = true,
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Rounded.Edit,
+                            contentDescription = null
+                        )
+                    },
+                    shape = RoundedCornerShape(18.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        disabledBorderColor = MaterialTheme.colorScheme.outlineVariant,
+                        disabledTextColor = MaterialTheme.colorScheme.onSurface
+                    )
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    if (resolvedTitle.isNotBlank()) {
+                        onSave(resolvedTitle)
+                    }
+                },
+                enabled = resolvedTitle.isNotBlank(),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Cancel")
+            }
+        },
+        shape = RoundedCornerShape(32.dp),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+    )
+}
+
+internal fun resolveLyricBookmarkTitle(
+    lyrics: Lyrics?,
+    timestampMs: Long,
+    lyricsSyncOffsetMs: Int
+): String? {
+    val syncedLines = lyrics?.synced.orEmpty()
+    if (syncedLines.isEmpty()) return null
+
+    val adjustedPositionMs = (timestampMs + lyricsSyncOffsetMs.toLong()).coerceAtLeast(0L)
+    return syncedLines
+        .lastOrNull { it.time.toLong() <= adjustedPositionMs }
+        ?.line
+        ?.trim()
+        ?.replace(BookmarkTitleWhitespaceRegex, " ")
+        ?.takeIf { it.isNotBlank() }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/components/player/FullPlayerContent.kt
@@ -230,6 +230,7 @@ fun FullPlayerContent(
 
     val song = currentSong ?: retainedSong ?: return
     var showSongInfoBottomSheet by remember { mutableStateOf(false) }
+    var showSaveBookmarkDialog by remember { mutableStateOf(false) }
     var showLyricsSheet by remember { mutableStateOf(false) }
     var showArtistPicker by rememberSaveable { mutableStateOf(false) }
     
@@ -730,6 +731,20 @@ fun FullPlayerContent(
                                     .size(42.dp)
                                     .clip(CircleShape)
                                     .background(playerOnAccentColor.copy(alpha = 0.7f))
+                                    .clickable { showSaveBookmarkDialog = true },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.round_bookmark_24),
+                                    contentDescription = stringResource(R.string.bookmark_save_action),
+                                    tint = playerAccentColor
+                                )
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .size(42.dp)
+                                    .clip(CircleShape)
+                                    .background(playerOnAccentColor.copy(alpha = 0.7f))
                                     .clickable {
                                         showSongInfoBottomSheet = true
                                         onShowQueueClicked()
@@ -839,6 +854,20 @@ fun FullPlayerContent(
                 playerViewModel.triggerArtistNavigationFromPlayer(artist.id)
                 showArtistPicker = false
             }
+        )
+    }
+
+    if (showSaveBookmarkDialog) {
+        // Snapshot the position once when the dialog opens so the saved timestamp is the moment
+        // the user tapped, not wherever playback has drifted to by the time they hit save.
+        val bookmarkProgressMs = remember(showSaveBookmarkDialog) { currentPositionProvider() }
+        AddBookmarkDialog(
+            currentProgressMs = bookmarkProgressMs,
+            onSave = { title ->
+                playerViewModel.addBookmark(title, bookmarkProgressMs)
+                showSaveBookmarkDialog = false
+            },
+            onDismiss = { showSaveBookmarkDialog = false }
         )
     }
 }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navigation/AppNavigation.kt
@@ -55,6 +55,10 @@ import com.lostf1sh.pixelplayeross.presentation.screens.SearchScreen
 import com.lostf1sh.pixelplayeross.presentation.screens.StatsScreen
 import com.lostf1sh.pixelplayeross.presentation.screens.DuplicateSongsScreen
 import com.lostf1sh.pixelplayeross.presentation.screens.SettingsScreen
+import com.lostf1sh.pixelplayeross.presentation.screens.AdvancedStatsScreen
+import com.lostf1sh.pixelplayeross.presentation.screens.MostListenedScreen
+import com.lostf1sh.pixelplayeross.presentation.screens.AudioBookmarkFolderScreen
+import com.lostf1sh.pixelplayeross.presentation.screens.AudioBookmarksScreen
 import com.lostf1sh.pixelplayeross.presentation.screens.SettingsCategoryScreen
 import com.lostf1sh.pixelplayeross.presentation.screens.EqualizerScreen
 import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlayerViewModel
@@ -239,7 +243,14 @@ fun AppNavigation(
             }
             composable(
                 route = Screen.SettingsCategory.route,
-                arguments = listOf(navArgument("categoryId") { type = NavType.StringType }),
+                arguments = listOf(
+                    navArgument("categoryId") { type = NavType.StringType },
+                    navArgument("highlightKey") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    }
+                ),
                 enterTransition = { enterTransition() },
                 exitTransition = { exitTransition() },
                 popEnterTransition = { popEnterTransition() },
@@ -252,6 +263,7 @@ fun AppNavigation(
                             categoryId = categoryId,
                             navController = navController,
                             playerViewModel = playerViewModel,
+                            highlightKey = backStackEntry.arguments?.getString("highlightKey"),
                             onBackClick = { navController.popBackStack() }
                         )
                     }
@@ -576,6 +588,58 @@ fun AppNavigation(
                         onBack = { navController.popBackStack() }
                     )
                 }
+            }
+            composable(
+                Screen.MostListened.route,
+                enterTransition = { enterTransition() },
+                exitTransition = { exitTransition() },
+                popEnterTransition = { popEnterTransition() },
+                popExitTransition = { popExitTransition() },
+            ) {
+                ScreenWrapper(navController = navController, playerViewModel = playerViewModel) {
+                    MostListenedScreen(
+                        navController = navController,
+                        playerViewModel = playerViewModel
+                    )
+                }
+            }
+            composable(
+                Screen.AdvancedStats.route,
+                enterTransition = { enterTransition() },
+                exitTransition = { exitTransition() },
+                popEnterTransition = { popEnterTransition() },
+                popExitTransition = { popExitTransition() },
+            ) {
+                ScreenWrapper(navController = navController, playerViewModel = playerViewModel) {
+                    AdvancedStatsScreen(navController = navController)
+                }
+            }
+            composable(
+                Screen.AudioBookmarks.route,
+                enterTransition = { enterTransition() },
+                exitTransition = { exitTransition() },
+                popEnterTransition = { popEnterTransition() },
+                popExitTransition = { popExitTransition() },
+            ) {
+                AudioBookmarksScreen(
+                    navController = navController,
+                    playerViewModel = playerViewModel,
+                    onOpenSidebar = onOpenSidebar
+                )
+            }
+            composable(
+                Screen.AudioBookmarkFolder.route,
+                arguments = listOf(navArgument("songId") { type = NavType.StringType }),
+                enterTransition = { enterTransition() },
+                exitTransition = { exitTransition() },
+                popEnterTransition = { popEnterTransition() },
+                popExitTransition = { popExitTransition() },
+            ) { backStackEntry ->
+                AudioBookmarkFolderScreen(
+                    songId = backStackEntry.arguments?.getString("songId").orEmpty(),
+                    navController = navController,
+                    playerViewModel = playerViewModel
+                )
             }
         }
     }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/navigation/Screen.kt
@@ -1,5 +1,6 @@
 package com.lostf1sh.pixelplayeross.presentation.navigation
 
+import android.net.Uri
 import androidx.compose.runtime.Immutable
 
 
@@ -10,7 +11,7 @@ sealed class Screen(val route: String) {
     object Library : Screen("library")
     object Settings : Screen("settings")
     object Accounts : Screen("settings_accounts")
-    object SettingsCategory : Screen("settings_category/{categoryId}") {
+    object SettingsCategory : Screen("settings_category/{categoryId}?highlightKey={highlightKey}") {
         fun createRoute(categoryId: String) = "settings_category/$categoryId"
     }
     object PaletteStyle : Screen("palette_style_settings")
@@ -49,6 +50,13 @@ sealed class Screen(val route: String) {
     object WordDelimiterConfig : Screen("word_delimiter_config")
     object Equalizer : Screen("equalizer")
     object DeviceCapabilities : Screen("device_capabilities")
+    object AdvancedStats : Screen("advanced_stats")
+    object MostListened : Screen("most_listened")
+    object AudioBookmarks : Screen("audio_bookmarks")
+    object AudioBookmarkFolder : Screen("audio_bookmarks/{songId}") {
+        fun createRoute(songId: String) = "audio_bookmarks/${Uri.encode(songId)}"
+    }
+
     object NavidromeDashboard : Screen("navidrome_dashboard")
     object JellyfinDashboard : Screen("jellyfin_dashboard")
 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AdvancedStatsScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AdvancedStatsScreen.kt
@@ -1,0 +1,1594 @@
+package com.lostf1sh.pixelplayeross.presentation.screens
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.automirrored.rounded.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.AdvancedStatsViewModel
+import com.lostf1sh.pixelplayeross.presentation.navigation.Screen
+import com.lostf1sh.pixelplayeross.data.stats.PlaybackStatsRepository.PlaybackStatsSummary
+import com.lostf1sh.pixelplayeross.data.stats.StatsTimeRange
+import com.lostf1sh.pixelplayeross.presentation.components.CollapsibleCommonTopBar
+import com.lostf1sh.pixelplayeross.presentation.components.RecentlyPlayedRangeSelector
+import com.lostf1sh.pixelplayeross.presentation.components.SmartImage
+import com.lostf1sh.pixelplayeross.presentation.components.SmartImageCompactListTargetSize
+import com.lostf1sh.pixelplayeross.utils.shapes.RoundedStarShape
+import com.lostf1sh.pixelplayeross.R
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+fun rememberGoogleSansFlex(
+    weight: Int,
+    width: Float,
+    rond: Float = 100f
+): FontFamily {
+    return remember(weight, width, rond) {
+        FontFamily(
+            Font(
+                resId = R.font.gflex_variable,
+                weight = FontWeight(weight),
+                variationSettings = FontVariation.Settings(
+                    FontVariation.weight(weight),
+                    FontVariation.width(width),
+                    FontVariation.Setting("ROND", rond)
+                )
+            )
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun AdvancedStatsScreen(
+    navController: NavController,
+    viewModel: AdvancedStatsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val titleFont = rememberGoogleSansFlex(weight = 750, width = 125f)
+    val bodyFont = rememberGoogleSansFlex(weight = 500, width = 100f)
+
+    val density = LocalDensity.current
+    val dailyListState = rememberLazyListState()
+    val habitsListState = rememberLazyListState()
+    val activeListState = if (uiState.activeTab == 0) dailyListState else habitsListState
+    val coroutineScope = rememberCoroutineScope()
+
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val minTopBarHeight = 64.dp + statusBarHeight
+    val maxTopBarHeight = 176.dp
+    val minTopBarHeightPx = with(density) { minTopBarHeight.toPx() }
+    val maxTopBarHeightPx = with(density) { maxTopBarHeight.toPx() }
+    val topBarHeight = remember { Animatable(maxTopBarHeightPx) }
+    var collapseFraction by remember { mutableStateOf(0f) }
+
+    LaunchedEffect(topBarHeight.value, minTopBarHeightPx, maxTopBarHeightPx) {
+        collapseFraction = 1f -
+            ((topBarHeight.value - minTopBarHeightPx) / (maxTopBarHeightPx - minTopBarHeightPx))
+                .coerceIn(0f, 1f)
+    }
+
+    val nestedScrollConnection = remember(activeListState, minTopBarHeightPx, maxTopBarHeightPx) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                val delta = available.y
+                val isScrollingUp = delta < 0
+
+                if (!isScrollingUp &&
+                    (activeListState.firstVisibleItemIndex > 0 || activeListState.firstVisibleItemScrollOffset > 0)
+                ) {
+                    return Offset.Zero
+                }
+
+                val previousHeight = topBarHeight.value
+                val newHeight = (previousHeight + delta).coerceIn(minTopBarHeightPx, maxTopBarHeightPx)
+                val consumed = newHeight - previousHeight
+
+                if (consumed.roundToInt() != 0) {
+                    coroutineScope.launch {
+                        topBarHeight.snapTo(newHeight)
+                    }
+                }
+
+                val canConsume = !(isScrollingUp && newHeight == minTopBarHeightPx)
+                return if (canConsume) Offset(0f, consumed) else Offset.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(activeListState.isScrollInProgress, uiState.activeTab) {
+        if (!activeListState.isScrollInProgress) {
+            val shouldExpand = topBarHeight.value > (minTopBarHeightPx + maxTopBarHeightPx) / 2
+            val canExpand = activeListState.firstVisibleItemIndex == 0 &&
+                activeListState.firstVisibleItemScrollOffset == 0
+            val target = if (shouldExpand && canExpand) maxTopBarHeightPx else minTopBarHeightPx
+
+            if (topBarHeight.value != target) {
+                coroutineScope.launch {
+                    topBarHeight.animateTo(target, spring(stiffness = Spring.StiffnessMedium))
+                }
+            }
+        }
+    }
+
+    val currentTopBarHeightDp = with(density) { topBarHeight.value.toDp() }
+    val tabsHeight = 76.dp
+    val contentTopPadding = currentTopBarHeightDp + tabsHeight + 4.dp
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .nestedScroll(nestedScrollConnection)
+    ) {
+        if (uiState.activeTab == 0) {
+            DailyLogTabContent(
+                uiState = uiState,
+                viewModel = viewModel,
+                listState = dailyListState,
+                topContentPadding = contentTopPadding
+            )
+        } else {
+            HabitsTrendsTabContent(
+                uiState = uiState,
+                viewModel = viewModel,
+                listState = habitsListState,
+                topContentPadding = contentTopPadding
+            )
+        }
+
+        val solidAlpha = (collapseFraction * 2f).coerceIn(0f, 1f)
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = solidAlpha))
+                .padding(bottom = 12.dp)
+                .zIndex(5f)
+        ) {
+            CollapsibleCommonTopBar(
+                title = "Listening Insights",
+                collapseFraction = collapseFraction,
+                headerHeight = currentTopBarHeightDp,
+                onBackClick = { navController.popBackStack() },
+                containerColor = Color.Transparent
+            )
+
+            ExpressiveSegmentedSelector(
+                selectedTabIndex = uiState.activeTab,
+                onTabSelected = { viewModel.selectTab(it) },
+                modifier = Modifier
+                    .height(52.dp)
+                    .padding(horizontal = 16.dp)
+            )
+        }
+
+    }
+}
+
+@Composable
+fun ExpressiveSegmentedSelector(
+    selectedTabIndex: Int,
+    onTabSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    tabs: List<String> = listOf("Daily Log", "Insights")
+) {
+    ButtonGroup(
+        overflowIndicator = { menuState ->
+            ButtonGroupDefaults.OverflowIndicator(menuState)
+        },
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween)
+    ) {
+        tabs.forEachIndexed { index, label ->
+            customItem(
+                buttonGroupContent = {
+                    val selected = selectedTabIndex == index
+                    val interactionSource = remember(index) { MutableInteractionSource() }
+                    ToggleButton(
+                        checked = selected,
+                        onCheckedChange = { onTabSelected(index) },
+                        modifier = Modifier
+                            .weight(if (selected) 1.15f else 1f)
+                            .animateWidth(interactionSource)
+                            .height(52.dp)
+                            .semantics { role = Role.Tab },
+                        shapes = when (index) {
+                            0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                            tabs.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                            else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                        },
+                        colors = ToggleButtonDefaults.toggleButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            contentColor = MaterialTheme.colorScheme.onSurface,
+                            checkedContainerColor = MaterialTheme.colorScheme.primary,
+                            checkedContentColor = MaterialTheme.colorScheme.onPrimary
+                        ),
+                        elevation = null,
+                        contentPadding = PaddingValues(horizontal = 10.dp),
+                        interactionSource = interactionSource
+                    ) {
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontFamily = rememberGoogleSansFlex(
+                                weight = if (selected) 720 else 560,
+                                width = if (selected) 122f else 104f,
+                                rond = if (selected) 92f else 100f
+                            ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                },
+                menuContent = { menuState ->
+                    val selected = selectedTabIndex == index
+                    DropdownMenuItem(
+                        text = { Text(label) },
+                        leadingIcon = {
+                            if (selected) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Check,
+                                    contentDescription = null
+                                )
+                            }
+                        },
+                        onClick = {
+                            onTabSelected(index)
+                            menuState.dismiss()
+                        }
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun DailyLogTabContent(
+    uiState: AdvancedStatsViewModel.AdvancedStatsUiState,
+    viewModel: AdvancedStatsViewModel,
+    listState: LazyListState,
+    topContentPadding: androidx.compose.ui.unit.Dp
+) {
+    LazyColumn(
+        state = listState,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(top = topContentPadding, bottom = 90.dp)
+    ) {
+        // Heatmap Calendar Section
+        item {
+            CalendarHeatmapCard(
+                currentMonth = uiState.currentMonth,
+                selectedDate = uiState.selectedDate,
+                dailyDurations = uiState.dailyDurations,
+                goalTargetMs = uiState.goalMinutes * 60_000L,
+                onDateSelected = { viewModel.selectDate(it) },
+                onPreviousMonth = { viewModel.changeMonth(uiState.currentMonth.minusMonths(1)) },
+                onNextMonth = { viewModel.changeMonth(uiState.currentMonth.plusMonths(1)) }
+            )
+        }
+
+        // Daily Target Goal Card
+        item {
+            val dailyDur = uiState.dailyDurations[uiState.selectedDate] ?: 0L
+            DailyTargetGoalCard(
+                durationMs = dailyDur,
+                goalMinutes = uiState.goalMinutes,
+                goalStreak = uiState.goalStreak,
+                onGoalMinutesSelected = { viewModel.setGoalMinutes(it) }
+            )
+        }
+
+        // Daily Summary Statistics section
+        item {
+            DailySummaryCard(
+                selectedDate = uiState.selectedDate,
+                summary = uiState.selectedDaySummary,
+                isLoading = uiState.isDaySummaryLoading
+            )
+        }
+
+        // Timelapse Section - Rendered directly on the background (Not inside a card)
+        item {
+            DayTimelapseChart(
+                hourlyDistribution = uiState.hourlyDistribution
+            )
+        }
+
+        // Top Songs for Selected Day
+        val topSongs = uiState.selectedDaySummary?.topSongs ?: emptyList()
+        if (topSongs.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Top Songs on this Day",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+            items(topSongs, key = { it.songId }) { songSummary ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(20.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        // Display actual album cover using SmartImage
+                        SmartImage(
+                            model = songSummary.albumArtUri,
+                            contentDescription = null,
+                            modifier = Modifier.size(44.dp),
+                            shape = RoundedCornerShape(12.dp),
+                            targetSize = SmartImageCompactListTargetSize
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(
+                                text = songSummary.title,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontFamily = rememberGoogleSansFlex(weight = 600, width = 100f),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                text = songSummary.artist,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(
+                            horizontalAlignment = Alignment.End
+                        ) {
+                            Text(
+                                text = "${songSummary.playCount} plays",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontFamily = rememberGoogleSansFlex(weight = 650, width = 110f),
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            val minutes = (songSummary.totalDurationMs / 1000) / 60
+                            Text(
+                                text = "${minutes}m",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HabitsTrendsTabContent(
+    uiState: AdvancedStatsViewModel.AdvancedStatsUiState,
+    viewModel: AdvancedStatsViewModel,
+    listState: LazyListState,
+    topContentPadding: androidx.compose.ui.unit.Dp
+) {
+    LazyColumn(
+        state = listState,
+        modifier = Modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(top = topContentPadding, bottom = 90.dp)
+    ) {
+        // Scrollable time range selectors (TabAnimation inside Scrollable TabRow)
+        item {
+            RangeSelectorRow(
+                selectedRange = uiState.selectedRange,
+                onRangeSelected = { viewModel.selectRange(it) }
+            )
+        }
+
+        if (uiState.isRangeSummaryLoading) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(strokeWidth = 3.dp)
+                }
+            }
+        } else {
+            val summary = uiState.rangeSummary
+
+            // Music Personality Card
+            item {
+                val personality = viewModel.getMusicPersonality(summary)
+                MusicPersonalityCard(personality = personality)
+            }
+
+            // Streak Record Card (Vertically stacked, texts stacked to prevent truncation)
+            item {
+                StreakCard(longestStreak = summary?.longestStreakDays ?: 0)
+            }
+
+            // Active Days Card (Stacked vertically, texts stacked to prevent truncation)
+            item {
+                ActiveDaysCard(activeDays = summary?.activeDays ?: 0)
+            }
+
+            // Prime Listening Window Preferences Card
+            item {
+                val peakHour = summary?.peakTimeline?.label
+                PrimeListeningCard(
+                    peakDay = summary?.peakDayLabel,
+                    peakHourLabel = peakHour
+                )
+            }
+
+            // General Habits Info Card
+            item {
+                GeneralHabitsCard(summary = summary)
+            }
+
+            // Top Genres (Progress indicator list)
+            val topGenres = summary?.topGenres ?: emptyList()
+            if (topGenres.isNotEmpty()) {
+                item {
+                    Text(
+                        text = "Top Genres",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 18.dp, top = 8.dp)
+                    )
+                }
+                item {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        shape = RoundedCornerShape(24.dp),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(20.dp)
+                        ) {
+                            val maxDur = topGenres.first().totalDurationMs.coerceAtLeast(1L)
+                            topGenres.forEach { genreSummary ->
+                                val fraction = genreSummary.totalDurationMs.toFloat() / maxDur
+                                val mins = genreSummary.totalDurationMs / 1000 / 60
+                                ComparativeProgressBarItem(
+                                    title = genreSummary.genre,
+                                    subtitle = null, // No subtitle slop
+                                    value = "${mins}m",
+                                    fraction = fraction,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Top Artists
+            val topArtists = summary?.topArtists ?: emptyList()
+            if (topArtists.isNotEmpty()) {
+                item {
+                    Text(
+                        text = "Top Artists",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 18.dp, top = 8.dp)
+                    )
+                }
+                item {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        shape = RoundedCornerShape(24.dp),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(20.dp)
+                        ) {
+                            val maxPlays = topArtists.first().playCount.coerceAtLeast(1)
+                            topArtists.forEach { artistSummary ->
+                                val fraction = artistSummary.playCount.toFloat() / maxPlays
+                                val mins = artistSummary.totalDurationMs / 1000 / 60
+                                ComparativeProgressBarItem(
+                                    title = artistSummary.artist,
+                                    subtitle = null,
+                                    value = "${artistSummary.playCount} plays (${mins}m)",
+                                    fraction = fraction,
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Top Albums
+            val topAlbums = summary?.topAlbums ?: emptyList()
+            if (topAlbums.isNotEmpty()) {
+                item {
+                    Text(
+                        text = "Top Albums",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 18.dp, top = 8.dp)
+                    )
+                }
+                item {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        shape = RoundedCornerShape(24.dp),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(20.dp)
+                        ) {
+                            val maxDur = topAlbums.first().totalDurationMs.coerceAtLeast(1L)
+                            topAlbums.forEach { albumSummary ->
+                                val fraction = albumSummary.totalDurationMs.toFloat() / maxDur
+                                val mins = albumSummary.totalDurationMs / 1000 / 60
+                                ComparativeProgressBarItem(
+                                    title = albumSummary.album,
+                                    subtitle = null,
+                                    value = "${mins}m",
+                                    fraction = fraction,
+                                    color = MaterialTheme.colorScheme.tertiary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun RangeSelectorRow(
+    selectedRange: StatsTimeRange,
+    onRangeSelected: (StatsTimeRange) -> Unit
+) {
+    RecentlyPlayedRangeSelector(
+        selected = selectedRange,
+        onRangeSelected = onRangeSelected,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    )
+}
+
+@Composable
+fun CalendarHeatmapCard(
+    currentMonth: YearMonth,
+    selectedDate: LocalDate,
+    dailyDurations: Map<LocalDate, Long>,
+    goalTargetMs: Long,
+    onDateSelected: (LocalDate) -> Unit,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit
+) {
+    val monthTitleFont = rememberGoogleSansFlex(weight = 700, width = 120f)
+    // Read the locale through the configuration so the month name recomposes when the user
+    // changes their language, instead of sticking at whatever it was on first composition.
+    val locale = LocalConfiguration.current.locales[0]
+    val monthLabel = remember(currentMonth, locale) {
+        currentMonth.month.getDisplayName(TextStyle.FULL, locale) + " " + currentMonth.year
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            // Month selector Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(
+                    onClick = onPreviousMonth,
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ChevronLeft,
+                        contentDescription = "Previous Month"
+                    )
+                }
+                Text(
+                    text = monthLabel,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = monthTitleFont,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                IconButton(
+                    onClick = onNextMonth,
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ChevronRight,
+                        contentDescription = "Next Month"
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Weekday labels
+            val weekdays = listOf("M", "T", "W", "T", "F", "S", "S")
+            Row(modifier = Modifier.fillMaxWidth()) {
+                weekdays.forEach { day ->
+                    Text(
+                        text = day,
+                        modifier = Modifier.weight(1f),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Days Grid
+            val firstDay = currentMonth.atDay(1)
+            val firstDayOfWeek = (firstDay.dayOfWeek.value - 1) % 7
+            val daysInMonth = currentMonth.lengthOfMonth()
+            val totalCells = firstDayOfWeek + daysInMonth
+            val rowsCount = (totalCells + 6) / 7
+
+            val baseColor = MaterialTheme.colorScheme.primary
+
+            for (r in 0 until rowsCount) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    for (c in 0..6) {
+                        val cellIndex = r * 7 + c
+                        if (cellIndex < firstDayOfWeek || cellIndex >= totalCells) {
+                            Box(modifier = Modifier.weight(1f).aspectRatio(1f))
+                        } else {
+                            val dayNum = cellIndex - firstDayOfWeek + 1
+                            val date = currentMonth.atDay(dayNum)
+                            val isSelected = date == selectedDate
+                            val duration = dailyDurations[date] ?: 0L
+
+                            val isTargetMet = duration >= goalTargetMs
+
+                            // Intensity colors - solid containers with differing alphas.
+                            // Fixed bucket thresholds independent of the user's configurable goal.
+                            val highContrastThresholdMs = 45 * 60 * 1000L
+                            val intensityColor = when {
+                                duration <= 0L -> Color.Transparent
+                                duration < 15 * 60 * 1000L -> baseColor.copy(alpha = 0.2f)
+                                duration < highContrastThresholdMs -> baseColor.copy(alpha = 0.5f)
+                                duration < 120 * 60 * 1000L -> baseColor.copy(alpha = 0.8f)
+                                else -> baseColor
+                            }
+
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .aspectRatio(1f)
+                                    .padding(2.dp)
+                                    .clip(RoundedCornerShape(14.dp))
+                                    .background(intensityColor)
+                                    .then(
+                                        if (isSelected) {
+                                            Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
+                                                .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(14.dp))
+                                        } else Modifier
+                                    )
+                                    .clickable { onDateSelected(date) },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Column(
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.Center
+                                ) {
+                                    Text(
+                                        text = dayNum.toString(),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        fontFamily = rememberGoogleSansFlex(weight = if (isSelected) 700 else 500, width = 100f),
+                                        color = if (duration > highContrastThresholdMs && !isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+                                    )
+                                    if (isTargetMet) {
+                                        Box(
+                                            modifier = Modifier
+                                                .padding(top = 2.dp)
+                                                .size(4.dp)
+                                                .background(
+                                                    if (duration > highContrastThresholdMs && !isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary,
+                                                    shape = CircleShape
+                                                )
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DailyTargetGoalCard(
+    durationMs: Long,
+    goalMinutes: Int,
+    goalStreak: Int,
+    onGoalMinutesSelected: (Int) -> Unit
+) {
+    val targetMs = goalMinutes * 60_000L
+    val fraction = (durationMs.toFloat() / targetMs).coerceIn(0f, 1f)
+    val isMet = durationMs >= targetMs
+    var showPresetPicker by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isMet) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainer
+            }
+        )
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = if (isMet) "Daily Goal Achieved" else "Listening Target",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontFamily = rememberGoogleSansFlex(weight = 700, width = 125f),
+                            color = if (isMet) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
+                        )
+                        if (goalStreak > 0) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "🔥 $goalStreak",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontFamily = rememberGoogleSansFlex(weight = 700, width = 110f),
+                                color = if (isMet) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    val targetText = if (isMet) {
+                        "${goalMinutes}m target met"
+                    } else {
+                        val minutesLeft = ((targetMs - durationMs) / 1000 / 60).coerceAtLeast(1)
+                        "${minutesLeft}m remaining"
+                    }
+                    Text(
+                        text = targetText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontFamily = rememberGoogleSansFlex(weight = 500, width = 100f),
+                        color = if (isMet) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    LinearProgressIndicator(
+                        progress = { fraction },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(CircleShape),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = if (isMet) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f) else MaterialTheme.colorScheme.surfaceVariant
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(CircleShape)
+                        .background(
+                            color = if (isMet) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHigh
+                        )
+                        .clickable { showPresetPicker = !showPresetPicker },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = if (isMet) Icons.Rounded.CheckCircle else Icons.Rounded.AccessTime,
+                        contentDescription = "Change listening goal",
+                        tint = if (isMet) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+            }
+
+            if (showPresetPicker) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    com.lostf1sh.pixelplayeross.data.preferences.LISTENING_GOAL_PRESET_MINUTES.forEach { preset ->
+                        FilterChip(
+                            selected = preset == goalMinutes,
+                            onClick = {
+                                onGoalMinutesSelected(preset)
+                                showPresetPicker = false
+                            },
+                            label = { Text("${preset}m") }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DailySummaryCard(
+    selectedDate: LocalDate,
+    summary: PlaybackStatsSummary?,
+    isLoading: Boolean
+) {
+    val numberFont = rememberGoogleSansFlex(weight = 750, width = 135f)
+    val labelFont = rememberGoogleSansFlex(weight = 600, width = 110f)
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Text(
+                text = "Summary",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(80.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(strokeWidth = 3.dp)
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "PLAY TIME",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontFamily = labelFont,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        val totalMin = (summary?.totalDurationMs ?: 0L) / 1000 / 60
+                        val hr = totalMin / 60
+                        val min = totalMin % 60
+                        val durationStr = if (hr > 0) "${hr}h ${min}m" else "${min}m"
+                        Text(
+                            text = durationStr,
+                            style = MaterialTheme.typography.headlineLarge,
+                            fontFamily = numberFont,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "TRACKS PLAYED",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontFamily = labelFont,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = (summary?.totalPlayCount ?: 0).toString(),
+                            style = MaterialTheme.typography.headlineLarge,
+                            fontFamily = numberFont,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DayTimelapseChart(
+    hourlyDistribution: List<Long>
+) {
+    val maxVal = hourlyDistribution.maxOrNull()?.coerceAtLeast(1L) ?: 1L
+    val maxValMin = maxVal / 1000 / 60
+    val maxValDisplay = maxValMin.coerceAtLeast(10L)
+    
+    val yLabel3 = "${maxValDisplay}m"
+    val yLabel2 = "${maxValDisplay * 2 / 3}m"
+    val yLabel1 = "${maxValDisplay / 3}m"
+    val yLabel0 = "0m"
+    
+    val timeLabels = listOf("0-4", "4-8", "8-12", "12-16", "16-20", "20-24")
+    val peakIndex = hourlyDistribution.indexOf(hourlyDistribution.maxOrNull() ?: -1)
+    
+    val fontTitle = rememberGoogleSansFlex(weight = 700, width = 120f)
+    val labelFont = rememberGoogleSansFlex(weight = 500, width = 100f)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp)
+    ) {
+        Text(
+            text = "Listening Hours",
+            style = MaterialTheme.typography.titleMedium,
+            fontFamily = fontTitle,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // Chart row - Perfectly balanced grid lines
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .drawBehind {
+                    val lineColor = Color.Gray.copy(alpha = 0.15f)
+                    val strokeWidth = 1.dp.toPx()
+                    val leftPadding = 40.dp.toPx()
+                    val w = size.width
+                    val h = size.height
+
+                    drawLine(color = lineColor, start = Offset(leftPadding, 0f), end = Offset(w - leftPadding, 0f), strokeWidth = strokeWidth)
+                    drawLine(color = lineColor, start = Offset(leftPadding, h * 0.33f), end = Offset(w - leftPadding, h * 0.33f), strokeWidth = strokeWidth)
+                    drawLine(color = lineColor, start = Offset(leftPadding, h * 0.66f), end = Offset(w - leftPadding, h * 0.66f), strokeWidth = strokeWidth)
+                    drawLine(color = lineColor, start = Offset(leftPadding, h), end = Offset(w - leftPadding, h), strokeWidth = strokeWidth)
+                },
+            verticalAlignment = Alignment.Bottom
+        ) {
+            // Left spacer of 40.dp to balance the right 40.dp Y-axis labels and keep bars centered
+            Spacer(modifier = Modifier.width(40.dp))
+
+            // Bars layout
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                hourlyDistribution.forEachIndexed { index, duration ->
+                    val fraction = duration.toFloat() / maxVal
+                    val barHeightFraction = fraction * 0.7f // Cap at 70% to reserve 30% height for badge
+                    
+                    val animatedFraction by animateFloatAsState(
+                        targetValue = barHeightFraction,
+                        animationSpec = tween(durationMillis = 500, easing = FastOutSlowInEasing),
+                        label = "BarHeightAnimation"
+                    )
+
+                    val isPeak = index == peakIndex && duration > 0L
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                        verticalArrangement = Arrangement.Bottom
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            contentAlignment = Alignment.BottomCenter
+                        ) {
+                            if (animatedFraction > 0.01f) {
+                                // Dynamic bar container
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxHeight(animatedFraction)
+                                        .width(36.dp)
+                                        .clip(CircleShape)
+                                        .background(
+                                            if (isPeak) MaterialTheme.colorScheme.primary
+                                            else MaterialTheme.colorScheme.secondary
+                                        ),
+                                    contentAlignment = Alignment.TopCenter
+                                ) {
+                                    // Checkmark star badge is embedded INSIDE the bar, anchored to top with symmetric padding
+                                    if (isPeak) {
+                                        val starShape = remember { RoundedStarShape(sides = 12, curve = 0.15, rotation = 0f) }
+                                        Box(
+                                            modifier = Modifier
+                                                .padding(top = 4.dp) // Symmetric spacing inside the top of the capsule
+                                                .size(28.dp)
+                                                .background(MaterialTheme.colorScheme.primaryContainer, shape = starShape),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Rounded.Check,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                modifier = Modifier.size(14.dp)
+                                            )
+                                        }
+                                    }
+                                }
+                            } else {
+                                Box(
+                                    modifier = Modifier
+                                        .height(4.dp)
+                                        .width(36.dp)
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                                )
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = timeLabels[index],
+                            style = MaterialTheme.typography.labelSmall,
+                            fontFamily = labelFont,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 11.sp
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            // Y-Axis labels column
+            Column(
+                modifier = Modifier
+                    .width(40.dp)
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.SpaceBetween,
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(yLabel3, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(yLabel2, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(yLabel1, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(yLabel0, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+fun MusicPersonalityCard(
+    personality: AdvancedStatsViewModel.MusicPersonality
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .background(MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.12f), shape = CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                val icon = when (personality.title) {
+                    "The Sonic Explorer" -> Icons.AutoMirrored.Rounded.TrendingUp
+                    "The Loyal Devotee" -> Icons.Rounded.Favorite
+                    "The Music Enthusiast" -> Icons.Rounded.MusicNote
+                    else -> Icons.Rounded.Star
+                }
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "LISTENER ARCHETYPE",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = rememberGoogleSansFlex(weight = 600, width = 110f),
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = personality.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = rememberGoogleSansFlex(weight = 750, width = 125f),
+                    color = MaterialTheme.colorScheme.onTertiaryContainer
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = personality.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.9f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun StreakCard(longestStreak: Int) {
+    val numberFont = rememberGoogleSansFlex(weight = 750, width = 135f)
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        // Vertically stacked structure to prevent text squishing on small screens
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(MaterialTheme.colorScheme.primaryContainer, shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Whatshot,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+                Text(
+                    text = "$longestStreak days",
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontFamily = numberFont,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Streak Record",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "Consecutive days of playback activity",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+fun ActiveDaysCard(activeDays: Int) {
+    val numberFont = rememberGoogleSansFlex(weight = 750, width = 135f)
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        // Vertically stacked structure to prevent text squishing on small screens
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(MaterialTheme.colorScheme.secondaryContainer, shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.CalendarMonth,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+                Text(
+                    text = "$activeDays days",
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontFamily = numberFont,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Active Days",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "Total calendar days with playback activity",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+fun PrimeListeningCard(
+    peakDay: String?,
+    peakHourLabel: String?
+) {
+    val fontTitle = rememberGoogleSansFlex(weight = 700, width = 120f)
+    val fontHighlight = rememberGoogleSansFlex(weight = 750, width = 130f)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Text(
+                text = "Prime Listening Window",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = fontTitle,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Peak Day Preference row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .background(MaterialTheme.colorScheme.primaryContainer, shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Today,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+                Column {
+                    Text(
+                        text = "Your Favorite Day",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = peakDay ?: "No data",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = fontHighlight,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Peak Hour Preference row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .background(MaterialTheme.colorScheme.secondaryContainer, shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.AccessTime,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+                Column {
+                    Text(
+                        text = "Peak Listening Hours",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = peakHourLabel ?: "No data",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = fontHighlight,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun GeneralHabitsCard(
+    summary: PlaybackStatsSummary?
+) {
+    val numberFont = rememberGoogleSansFlex(weight = 750, width = 135f)
+    val labelFont = rememberGoogleSansFlex(weight = 600, width = 110f)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Text(
+                text = "Overview",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = rememberGoogleSansFlex(weight = 700, width = 120f),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "TOTAL TIME",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = labelFont,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    val totalMin = (summary?.totalDurationMs ?: 0L) / 1000 / 60
+                    val hr = totalMin / 60
+                    val min = totalMin % 60
+                    val totalStr = if (hr > 0) "${hr}h ${min}m" else "${min}m"
+                    Text(
+                        text = totalStr,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = numberFont,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+                
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "SESSIONS",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = labelFont,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = (summary?.totalSessions ?: 0).toString(),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = numberFont,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
+                
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "UNIQUE SONGS",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = labelFont,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = (summary?.uniqueSongs ?: 0).toString(),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = numberFont,
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ComparativeProgressBarItem(
+    title: String,
+    subtitle: String?,
+    value: String,
+    fraction: Float,
+    color: Color
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = rememberGoogleSansFlex(weight = 600, width = 100f),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (subtitle != null) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = rememberGoogleSansFlex(weight = 650, width = 110f),
+                color = color
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        LinearProgressIndicator(
+            progress = { fraction },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .clip(CircleShape),
+            color = color,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AudioBookmarkModels.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AudioBookmarkModels.kt
@@ -1,0 +1,290 @@
+package com.lostf1sh.pixelplayeross.presentation.screens
+
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkEntity
+import com.lostf1sh.pixelplayeross.data.model.Song
+import java.util.Locale
+import kotlin.math.abs
+
+const val BookmarkFolderCollapsedCardHeightDp = 96
+const val BookmarkFolderExpandedCardHeightDp = 176
+const val BookmarkFolderVerticalPaddingDp = 8
+const val BookmarkFolderFocusSwitchThresholdDp = 132
+
+const val BookmarksTopBarExpandedHeightDp = 184
+const val BookmarksTopBarMinContentHeightDp = 68
+const val BookmarksTopBarTitleBottomPaddingDp = 8
+const val BookmarksTopBarExpandedTitleContainerHeightDp = 104
+const val BookmarksTopBarCollapsedTitleContainerHeightDp = 56
+const val BookmarksTopBarExpandedTitleVerticalBias = 0.88f
+
+private const val BookmarkTitleWidthAxisMin = 84f
+private const val BookmarkTitleWidthAxisMax = 132f
+private const val BookmarkTitleUnderfilledRatio = 0.64f
+
+data class AudioBookmarkFolder(
+    val song: Song,
+    val bookmarks: List<AudioBookmarkEntity>
+) {
+    val bookmarkCount: Int
+        get() = bookmarks.size
+
+    val latestBookmarkCreatedTime: Long
+        get() = bookmarks.maxOfOrNull { it.createdTime } ?: 0L
+}
+
+data class BookmarkFolderCardPresentation(
+    val cardHeightDp: Int,
+    val artworkSizeDp: Int,
+    val containerCornerRadiusDp: Int,
+    val artworkCornerRadiusDp: Int,
+    val titleWeight: Int,
+    val titleWidth: Float,
+    val titleRond: Float,
+    val supportingWeight: Int,
+    val supportingWidth: Float,
+    val supportingRond: Float,
+    val accentSizeDp: Int,
+    val accentOffsetXDp: Int,
+    val accentOffsetYDp: Int,
+    val accentAlpha: Float
+)
+
+data class BookmarkVisibleItemGeometry(
+    val key: Any,
+    val index: Int,
+    val itemCenterPx: Int,
+    val itemSizePx: Int = 0,
+    val itemEndPx: Int = itemCenterPx + itemSizePx / 2
+)
+
+fun bookmarkFolderCardPresentation(
+    index: Int,
+    bookmarkCount: Int,
+    focusFraction: Float = 0f
+): BookmarkFolderCardPresentation {
+    val expanded = focusFraction >= 0.5f
+
+    return BookmarkFolderCardPresentation(
+        cardHeightDp = if (expanded) BookmarkFolderExpandedCardHeightDp else BookmarkFolderCollapsedCardHeightDp,
+        artworkSizeDp = if (expanded) 86 else 56,
+        containerCornerRadiusDp = if (expanded) 24 else 48,
+        artworkCornerRadiusDp = if (expanded) 14 else 28,
+        titleWeight = if (expanded) 780 else 680,
+        titleWidth = if (expanded) 104f else 124f,
+        titleRond = if (expanded) 100f else 88f,
+        supportingWeight = if (expanded) 620 else 540,
+        supportingWidth = if (expanded) 102f else 112f,
+        supportingRond = if (expanded) 100f else 92f,
+        accentSizeDp = if (expanded) 112 else 74,
+        accentOffsetXDp = if (expanded) 16 else 28,
+        accentOffsetYDp = if (expanded) 6 else 16,
+        accentAlpha = if (expanded) 0.24f else 0.14f
+    )
+}
+
+fun bookmarkFocusedItemKey(
+    visibleItems: List<BookmarkVisibleItemGeometry>,
+    totalItemsCount: Int,
+    viewportCenterPx: Int,
+    canScrollBackward: Boolean,
+    canScrollForward: Boolean,
+    currentFocusedKey: Any? = null,
+    switchThresholdPx: Int = 0,
+    lastFocusableIndex: Int? = null,
+    viewportEndPx: Int? = null,
+    endEdgeFocusThresholdPx: Int = 0
+): Any? {
+    if (visibleItems.isEmpty()) return null
+
+    if (!canScrollBackward) {
+        return visibleItems.minByOrNull { it.index }?.key
+    }
+
+    if (lastFocusableIndex != null && viewportEndPx != null && endEdgeFocusThresholdPx > 0) {
+        visibleItems.firstOrNull { it.index == lastFocusableIndex }?.let { lastFocusableItem ->
+            if (viewportEndPx - lastFocusableItem.itemEndPx >= endEdgeFocusThresholdPx) {
+                return lastFocusableItem.key
+            }
+        }
+    }
+
+    if (!canScrollForward) {
+        val lastItemIndex = totalItemsCount - 1
+        visibleItems.firstOrNull { it.index == lastItemIndex }?.let { return it.key }
+        return visibleItems.maxByOrNull { it.index }?.key
+    }
+
+    val closestItem = visibleItems.minWithOrNull(
+        compareBy<BookmarkVisibleItemGeometry> { abs(it.itemCenterPx - viewportCenterPx) }
+            .thenBy { it.index }
+    ) ?: return null
+    val currentItem = visibleItems.firstOrNull { it.key == currentFocusedKey }
+
+    if (currentItem != null && currentItem.key != closestItem.key) {
+        val currentDistance = abs(currentItem.itemCenterPx - viewportCenterPx)
+        val closestDistance = abs(closestItem.itemCenterPx - viewportCenterPx)
+        if (currentDistance <= closestDistance + switchThresholdPx.coerceAtLeast(0)) {
+            return currentItem.key
+        }
+        return adjacentFocusCandidate(
+            visibleItems = visibleItems,
+            currentItem = currentItem,
+            closestItem = closestItem
+        ).key
+    }
+
+    return closestItem.key
+}
+
+fun bookmarkLastFocusableIndex(folderCount: Int): Int? =
+    if (folderCount > 0) folderCount - 1 else null
+
+fun shouldClearBookmarkSearchFocus(
+    isSearchFocused: Boolean,
+    wasKeyboardVisibleWhileFocused: Boolean,
+    isKeyboardVisible: Boolean
+): Boolean =
+    isSearchFocused && wasKeyboardVisibleWhileFocused && !isKeyboardVisible
+
+private fun adjacentFocusCandidate(
+    visibleItems: List<BookmarkVisibleItemGeometry>,
+    currentItem: BookmarkVisibleItemGeometry,
+    closestItem: BookmarkVisibleItemGeometry
+): BookmarkVisibleItemGeometry {
+    val direction = (closestItem.index - currentItem.index).coerceIn(-1, 1)
+    if (direction == 0) return closestItem
+
+    val targetIndex = currentItem.index + direction
+    return visibleItems.firstOrNull { it.index == targetIndex }
+        ?: visibleItems
+            .filter { (it.index - currentItem.index) * direction > 0 }
+            .minByOrNull { abs(it.index - targetIndex) }
+        ?: closestItem
+}
+
+fun bookmarkStableFocusGeometries(
+    visibleItems: List<BookmarkVisibleItemGeometry>,
+    collapsedItemSizePx: Int
+): List<BookmarkVisibleItemGeometry> {
+    if (collapsedItemSizePx <= 0) return visibleItems
+
+    var expandedHeightBeforePx = 0
+    return visibleItems
+        .sortedBy { it.index }
+        .map { item ->
+            val expandedHeightPx = (item.itemSizePx - collapsedItemSizePx).coerceAtLeast(0)
+            val stableCenterPx = item.itemCenterPx - expandedHeightBeforePx - expandedHeightPx / 2
+            expandedHeightBeforePx += expandedHeightPx
+            item.copy(itemCenterPx = stableCenterPx)
+        }
+}
+
+fun bookmarkTitleWidthAxisForText(
+    title: String,
+    availableWidthDp: Float,
+    baseWidthAxis: Float
+): Float {
+    if (availableWidthDp <= 0f) return baseWidthAxis.coerceIn(BookmarkTitleWidthAxisMin, BookmarkTitleWidthAxisMax)
+
+    val normalizedTitle = title.trim().replace(Regex("\\s+"), " ")
+    if (normalizedTitle.isEmpty()) return baseWidthAxis
+
+    val estimatedTextWidthDp = normalizedTitle.sumOf { char ->
+        when {
+            char.isWhitespace() -> 4
+            char in "ilI.,'`!" -> 5
+            char in "mwMW@#%&" -> 12
+            else -> 9
+        }
+    }.toFloat()
+    val fillRatio = estimatedTextWidthDp / availableWidthDp
+    val adjustment = when {
+        fillRatio > 0.96f -> -((fillRatio - 0.96f) * 18f).coerceIn(8f, 34f)
+        fillRatio < BookmarkTitleUnderfilledRatio -> ((BookmarkTitleUnderfilledRatio - fillRatio) * 40f).coerceIn(4f, 20f)
+        else -> 0f
+    }
+
+    return (baseWidthAxis + adjustment).coerceIn(BookmarkTitleWidthAxisMin, BookmarkTitleWidthAxisMax)
+}
+
+fun bookmarkCardFocusFraction(
+    itemCenterPx: Int,
+    viewportCenterPx: Int,
+    focusDistancePx: Int
+): Float {
+    if (focusDistancePx <= 0) return if (itemCenterPx == viewportCenterPx) 1f else 0f
+    return (1f - abs(itemCenterPx - viewportCenterPx).toFloat() / focusDistancePx.toFloat())
+        .coerceIn(0f, 1f)
+}
+
+fun buildAudioBookmarkFolders(
+    bookmarks: List<AudioBookmarkEntity>,
+    songs: List<Song>,
+    query: String
+): List<AudioBookmarkFolder> {
+    if (bookmarks.isEmpty() || songs.isEmpty()) return emptyList()
+
+    val normalizedQuery = query.trim().lowercase(Locale.getDefault())
+    val bookmarksBySongId = bookmarks
+        .groupBy { it.songId }
+        .mapValues { (_, values) -> values.sortedByDescending { it.createdTime } }
+
+    return songs
+        .mapNotNull { song ->
+            val songBookmarks = bookmarksBySongId[song.id].orEmpty()
+            if (songBookmarks.isEmpty()) {
+                null
+            } else {
+                AudioBookmarkFolder(song, songBookmarks)
+            }
+        }
+        .filter { folder ->
+            normalizedQuery.isEmpty() || folder.matchesQuery(normalizedQuery)
+        }
+        .sortedWith(
+            compareByDescending<AudioBookmarkFolder> { it.bookmarkCount }
+                .thenByDescending { it.latestBookmarkCreatedTime }
+                .thenBy { it.song.title.lowercase(Locale.getDefault()) }
+        )
+}
+
+fun AudioBookmarkFolder.matchesQuery(normalizedQuery: String): Boolean {
+    val song = song
+    return listOfNotNull(
+        song.title,
+        song.displayArtist,
+        song.album,
+        song.genre
+    ).any { it.contains(normalizedQuery, ignoreCase = true) } ||
+        bookmarks.any { bookmark ->
+            bookmark.title.contains(normalizedQuery, ignoreCase = true) ||
+                bookmark.songTitle.contains(normalizedQuery, ignoreCase = true) ||
+                bookmark.artistName.contains(normalizedQuery, ignoreCase = true) ||
+                bookmarkCueSearchLabels(bookmark.timestampMs).any { cueLabel ->
+                    cueLabel.contains(normalizedQuery, ignoreCase = true)
+                }
+        }
+}
+
+private fun bookmarkCueSearchLabels(timestampMs: Long): List<String> {
+    val cueTime = formatBookmarkCueTime(timestampMs)
+    val compactCueTime = cueTime.removePrefix("0")
+    return listOf(
+        cueTime,
+        compactCueTime,
+        "cue $cueTime",
+        "cue $compactCueTime"
+    )
+}
+
+private fun formatBookmarkCueTime(timestampMs: Long): String {
+    val totalSeconds = timestampMs.coerceAtLeast(0L) / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AudioBookmarksScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/AudioBookmarksScreen.kt
@@ -1,0 +1,2056 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.lostf1sh.pixelplayeross.presentation.screens
+
+import android.content.ClipData
+import android.widget.Toast
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.Bookmark
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.FilterAlt
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Sort
+import androidx.compose.material.icons.rounded.SortByAlpha
+import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FloatingActionButtonMenu
+import androidx.compose.material3.FloatingActionButtonMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MotionScheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.ToggleFloatingActionButton
+import androidx.compose.material3.ToggleFloatingActionButtonDefaults
+import androidx.compose.material3.animateFloatingActionButton
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.drawscope.DrawStyle
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp as lerpColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.style.TextGeometricTransform
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.lerp
+import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.media3.common.util.UnstableApi
+import androidx.navigation.NavController
+import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkEntity
+import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.presentation.components.CollapsibleCommonTopBar
+import com.lostf1sh.pixelplayeross.presentation.components.MiniPlayerHeight
+import androidx.compose.material3.ModalBottomSheet
+import com.lostf1sh.pixelplayeross.presentation.components.ScreenWrapper
+import com.lostf1sh.pixelplayeross.presentation.components.SmartImage
+import com.lostf1sh.pixelplayeross.presentation.navigation.Screen
+import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlayerViewModel
+import com.lostf1sh.pixelplayeross.ui.theme.GenreThemeUtils
+import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
+import com.lostf1sh.pixelplayeross.ui.theme.LocalPixelPlayerDarkTheme
+import com.lostf1sh.pixelplayeross.ui.theme.RoundedSans
+import com.lostf1sh.pixelplayeross.ui.theme.MontserratFamily
+import com.lostf1sh.pixelplayeross.ui.theme.MontserratFamily
+import coil.size.Size
+import kotlinx.coroutines.delay
+import java.util.Locale
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+@androidx.annotation.OptIn(UnstableApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AudioBookmarksScreen(
+    navController: NavController,
+    playerViewModel: PlayerViewModel,
+    onOpenSidebar: () -> Unit
+) {
+    val bookmarks by playerViewModel.allBookmarks.collectAsStateWithLifecycle()
+    var query by rememberSaveable { mutableStateOf("") }
+    val songIds = remember(bookmarks) { bookmarks.map { it.songId }.distinct() }
+    val loadedSongs by playerViewModel
+        .getSongsByIds(songIds)
+        .collectAsStateWithLifecycle(initialValue = emptyList())
+    val bookmarkSongs = remember(bookmarks, loadedSongs) {
+        buildBookmarkSongList(bookmarks, loadedSongs)
+    }
+    val rawFolders = remember(bookmarks, bookmarkSongs, query) {
+        buildAudioBookmarkFolders(bookmarks, bookmarkSongs, query)
+    }
+    var sortMode by rememberSaveable { mutableStateOf(BookmarkFolderSortMode.MostMoments) }
+    val folders = remember(rawFolders, sortMode) {
+        sortAudioBookmarkFolders(rawFolders, sortMode)
+    }
+    val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
+    val isMiniplayerVisible = stablePlayerState.currentSong != null
+
+    ScreenWrapper(
+        navController = navController,
+        playerViewModel = playerViewModel
+    ) {
+        val listState = rememberLazyListState()
+        val coroutineScope = rememberCoroutineScope()
+        val motionScheme = remember { MotionScheme.expressive() }
+        var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
+        val floatingControlsBottomPadding by animateDpAsState(
+            targetValue = if (isMiniplayerVisible) MiniPlayerHeight + 14.dp else 14.dp,
+            animationSpec = motionScheme.defaultSpatialSpec(),
+            label = "BookmarkFloatingControlsBottomPadding"
+        )
+        val statusBarTopInset = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+        val topBarHeight = statusBarTopInset + 78.dp
+        val isListScrolled = listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0
+        val topBarSurfaceFraction by animateFloatAsState(
+            targetValue = if (isListScrolled || query.isNotBlank()) 1f else 0f,
+            animationSpec = motionScheme.fastEffectsSpec(),
+            label = "BookmarkKeepTopBarSurfaceFraction"
+        )
+
+        LaunchedEffect(query, sortMode) {
+            if (listState.firstVisibleItemIndex != 0 || listState.firstVisibleItemScrollOffset != 0) {
+                listState.scrollToItem(0)
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                    top = topBarHeight + 12.dp,
+                    bottom = 176.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (folders.isEmpty()) {
+                    item {
+                        BookmarksEmptyState(
+                            title = if (query.isBlank()) "No bookmarked audio yet" else "No bookmark folders found",
+                            subtitle = if (query.isBlank()) {
+                                "Saved moments will appear here grouped by track."
+                            } else {
+                                "Try searching by song, artist, album, cue, or bookmark tag."
+                            }
+                        )
+                    }
+                } else {
+                    itemsIndexed(
+                        items = folders,
+                        key = { _, folder -> folder.song.id },
+                        contentType = { _, _ -> "bookmark_folder" }
+                    ) { index, folder ->
+                        BookmarkFolderCard(
+                            folder = folder,
+                            visualIndex = index,
+                            playerViewModel = playerViewModel,
+                            onClick = {
+                                navController.navigateSafely(Screen.AudioBookmarkFolder.createRoute(folder.song.id))
+                            },
+                            modifier = Modifier
+                                .animateItem(
+                                    fadeInSpec = null,
+                                    fadeOutSpec = null,
+                                    placementSpec = motionScheme.fastSpatialSpec()
+                                )
+                                .padding(horizontal = 18.dp)
+                        )
+                    }
+                }
+                item {
+                    Spacer(Modifier.height(30.dp))
+                }
+            }
+
+            BookmarkKeepSearchTopBar(
+                query = query,
+                onQueryChange = { query = it },
+                surfaceFraction = topBarSurfaceFraction,
+                onNavigationClick = {
+                    if (!navController.popBackStack()) {
+                        onOpenSidebar()
+                    }
+                },
+                onClearQuery = { query = "" },
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .height(topBarHeight)
+            )
+
+            if (fabMenuExpanded) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .zIndex(10f)
+                        .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.42f))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
+                        ) {
+                            fabMenuExpanded = false
+                        }
+                )
+            }
+
+            BookmarkActionFabMenu(
+                expanded = fabMenuExpanded,
+                sortMode = sortMode,
+                hasQuery = query.isNotBlank(),
+                canScrollToTop = isListScrolled,
+                onExpandedChange = { fabMenuExpanded = it },
+                onSortModeChange = { selectedMode ->
+                    sortMode = selectedMode
+                    fabMenuExpanded = false
+                },
+                onClearFilter = {
+                    query = ""
+                    fabMenuExpanded = false
+                },
+                onScrollToTop = {
+                    fabMenuExpanded = false
+                    coroutineScope.launch { listState.animateScrollToItem(0) }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .zIndex(11f)
+                    .navigationBarsPadding()
+                    .padding(end = 20.dp, bottom = floatingControlsBottomPadding)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .height(48.dp)
+                    .background(
+                        brush = Brush.verticalGradient(
+                            listOf(
+                                Color.Transparent,
+                                MaterialTheme.colorScheme.surface
+                            )
+//                            colorStops = arrayOf(
+//                                0.0f to Color.Transparent,
+//                                0.2f to Color.Transparent,
+//                                0.8f to MaterialTheme.colorScheme.surfaceContainerLowest,
+//                                1.0f to MaterialTheme.colorScheme.surfaceContainerLowest
+//                            )
+                        )
+                    )
+            ) {
+
+            }
+        }
+    }
+}
+
+@Composable
+fun AudioBookmarkFolderScreen(
+    songId: String,
+    navController: NavController,
+    playerViewModel: PlayerViewModel
+) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboard.current
+    val coroutineScope = rememberCoroutineScope()
+    val bookmarks by playerViewModel.allBookmarks.collectAsStateWithLifecycle()
+    val songBookmarks = remember(bookmarks, songId) {
+        bookmarks.filter { it.songId == songId }.sortedByDescending { it.createdTime }
+    }
+    val loadedSongs by playerViewModel
+        .getSongsByIds(listOf(songId))
+        .collectAsStateWithLifecycle(initialValue = emptyList())
+    val song = remember(songBookmarks, loadedSongs, songId) {
+        loadedSongs.firstOrNull() ?: songBookmarks.firstOrNull()?.toFallbackSong() ?: Song.emptySong().copy(id = songId)
+    }
+    var actionsBookmark by remember { mutableStateOf<AudioBookmarkEntity?>(null) }
+    var renamingBookmark by remember { mutableStateOf<AudioBookmarkEntity?>(null) }
+
+    ScreenWrapper(
+        navController = navController,
+        playerViewModel = playerViewModel
+    ) {
+        val topBarState = rememberBookmarksCollapsibleTopBarState(maxTopBarHeight = 300.dp)
+        val density = LocalDensity.current
+        val configuration = LocalConfiguration.current
+        val headerImageRequestSize = remember(configuration.screenWidthDp, density.density) {
+            Size(
+                width = with(density) { configuration.screenWidthDp.dp.roundToPx() },
+                height = with(density) { 300.dp.roundToPx() }
+            )
+        }
+        val songScheme = rememberBookmarkCardColorScheme(song, playerViewModel)
+
+        MaterialTheme(colorScheme = songScheme) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .nestedScroll(topBarState.nestedScrollConnection)
+                    .background(MaterialTheme.colorScheme.surface)
+            ) {
+                LazyColumn(
+                    state = topBarState.lazyListState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        top = topBarState.headerHeight + 14.dp,
+                        bottom = 128.dp
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    if (songBookmarks.isEmpty()) {
+                        item(key = "empty_bookmark_folder") {
+                            BookmarksEmptyState(
+                                title = "No moments in this folder",
+                                subtitle = "Bookmarks for this track may have been deleted."
+                            )
+                        }
+                    } else {
+                        item(key = "bookmark_folder_count") {
+                            BookmarkFolderSectionHeader(
+                                bookmarkCount = songBookmarks.size,
+                                modifier = Modifier.padding(horizontal = 20.dp, vertical = 2.dp)
+                            )
+                        }
+
+                        items(
+                            items = songBookmarks,
+                            key = { it.id },
+                            contentType = { "bookmark_moment" }
+                        ) { bookmark ->
+                            BookmarkMomentCard(
+                                bookmark = bookmark,
+                                onPlay = {
+                                    if (song.id.isNotBlank() && song.id != "-1") {
+                                        playerViewModel.playSongAtPosition(song, bookmark.timestampMs)
+                                    } else {
+                                        Toast.makeText(context, "Audio file not found", Toast.LENGTH_SHORT).show()
+                                    }
+                                },
+                                onMoreClick = { actionsBookmark = bookmark },
+                                modifier = Modifier.padding(horizontal = 20.dp)
+                            )
+                        }
+                    }
+                }
+
+                BookmarkFolderTopBar(
+                    song = song,
+                    bookmarkCount = songBookmarks.size,
+                    collapseFraction = topBarState.collapseFraction,
+                    headerHeight = topBarState.headerHeight,
+                    headerImageRequestSize = headerImageRequestSize,
+                    onBackClick = { navController.popBackStack() }
+                )
+            }
+
+            actionsBookmark?.let { bookmark ->
+                BookmarkMomentActionsBottomSheet(
+                    bookmark = bookmark,
+                    onDismiss = { actionsBookmark = null },
+                    onRename = {
+                        actionsBookmark = null
+                        renamingBookmark = bookmark
+                    },
+                    onCopyCue = {
+                        val cueText = "${bookmark.title} - ${formatBookmarkTime(bookmark.timestampMs)}"
+                        coroutineScope.launch {
+                            clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("Bookmark cue", cueText)))
+                        }
+                        actionsBookmark = null
+                        Toast.makeText(context, "Cue copied", Toast.LENGTH_SHORT).show()
+                    },
+                    onDelete = {
+                        actionsBookmark = null
+                        playerViewModel.deleteBookmark(bookmark.id)
+                    }
+                )
+            }
+
+            renamingBookmark?.let { bookmark ->
+                RenameBookmarkDialog(
+                    bookmark = bookmark,
+                    onDismiss = { renamingBookmark = null },
+                    onRename = { title ->
+                        renamingBookmark = null
+                        playerViewModel.renameBookmark(bookmark.id, title)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookmarkFolderTopBar(
+    song: Song,
+    bookmarkCount: Int,
+    collapseFraction: Float,
+    headerHeight: Dp,
+    headerImageRequestSize: Size,
+    onBackClick: () -> Unit
+) {
+    val surfaceColor = MaterialTheme.colorScheme.surface
+    val statusBarColor =
+        if (LocalPixelPlayerDarkTheme.current) Color.Black.copy(alpha = 0.58f)
+        else Color.White.copy(alpha = 0.42f)
+    val solidAlpha = (collapseFraction * 2f).coerceIn(0f, 1f)
+    val expandedContentAlpha = 1f - solidAlpha
+    val subtitle = remember(song.displayArtist, bookmarkCount) {
+        listOf(
+            song.displayArtist.ifBlank { "Unknown artist" },
+            formatBookmarkMomentCount(bookmarkCount)
+        ).joinToString(" - ")
+    }
+    val headerOverlayBrush = remember(surfaceColor, expandedContentAlpha) {
+        Brush.verticalGradient(
+            colors = listOf(
+                Color.Transparent,
+                surfaceColor.copy(alpha = 0.22f * expandedContentAlpha),
+                surfaceColor.copy(alpha = 0.82f * expandedContentAlpha),
+                surfaceColor
+            )
+        )
+    }
+    val statusBarBrush = remember(statusBarColor) {
+        Brush.verticalGradient(colors = listOf(statusBarColor, Color.Transparent))
+    }
+    val expandedStatusBarFallback = remember(statusBarColor, surfaceColor) {
+        statusBarColor.compositeOver(surfaceColor)
+    }
+    val fallbackStatusBarColor = remember(expandedStatusBarFallback, surfaceColor, solidAlpha) {
+        lerpColor(expandedStatusBarFallback, surfaceColor, solidAlpha)
+    }
+
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(headerHeight)
+            .clipToBounds()
+    ) {
+        if (expandedContentAlpha > 0.01f) {
+            SmartImage(
+                model = song.albumArtUriString,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                targetSize = headerImageRequestSize,
+                allowHardware = true,
+                crossfadeDurationMillis = 0,
+                alpha = expandedContentAlpha,
+                placeHolderBackgroundColor = MaterialTheme.colorScheme.primaryContainer,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = 1f + 0.04f * (1f - collapseFraction)
+                        scaleY = 1f + 0.04f * (1f - collapseFraction)
+                    }
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(headerOverlayBrush)
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+                .background(statusBarBrush)
+                .align(Alignment.TopCenter)
+        )
+
+        CollapsibleCommonTopBar(
+            title = song.title.ifBlank { "Bookmarks" },
+            subtitle = subtitle,
+            collapseFraction = collapseFraction,
+            headerHeight = headerHeight,
+            onBackClick = onBackClick,
+            containerColor = surfaceColor.copy(alpha = solidAlpha),
+            collapsedTitleStartPadding = 68.dp,
+            expandedTitleStartPadding = 24.dp,
+            collapsedTitleEndPadding = 24.dp,
+            expandedTitleEndPadding = 28.dp,
+            containerHeightRange = 116.dp to 56.dp,
+            titleStyle = MaterialTheme.typography.headlineMedium.copy(
+                fontFamily = RoundedSans,
+                fontWeight = FontWeight.SemiBold,
+                textGeometricTransform = TextGeometricTransform(scaleX = 1.04f)
+            ),
+            titleScaleRange = 1f to 1f,
+            titleFontSizeRange = 30.sp to 18.sp,
+            maxLines = if (collapseFraction < 0.5f) 2 else 1,
+            collapsedSubtitleMaxLines = 1,
+            expandedSubtitleMaxLines = 2,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            subtitleColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            fadeSubtitleOnCollapse = false,
+            syncStatusBarWithContainer = false
+        )
+    }
+}
+
+@Composable
+private fun BookmarkFolderSectionHeader(
+    bookmarkCount: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 4.dp)
+        ) {
+            Text(
+                text = "Saved moments",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = formatBookmarkMomentCount(bookmarkCount),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+        ) {
+            Text(
+                text = bookmarkCount.toString(),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp)
+            )
+        }
+    }
+}
+
+private fun formatBookmarkMomentCount(count: Int): String =
+    if (count == 1) "1 moment" else "$count moments"
+
+private enum class BookmarkFolderSortMode(
+    val label: String,
+    val contentDescription: String,
+    val icon: ImageVector
+) {
+    MostMoments(
+        label = "Most moments",
+        contentDescription = "Sort bookmarks by most moments",
+        icon = Icons.Rounded.Bookmark
+    ),
+    Recent(
+        label = "Recent",
+        contentDescription = "Sort bookmarks by recent moments",
+        icon = Icons.Rounded.AccessTime
+    ),
+    Title(
+        label = "A-Z",
+        contentDescription = "Sort bookmarks alphabetically",
+        icon = Icons.Rounded.SortByAlpha
+    );
+
+    fun next(): BookmarkFolderSortMode =
+        entries[(ordinal + 1) % entries.size]
+}
+
+private fun sortAudioBookmarkFolders(
+    folders: List<AudioBookmarkFolder>,
+    sortMode: BookmarkFolderSortMode
+): List<AudioBookmarkFolder> =
+    when (sortMode) {
+        BookmarkFolderSortMode.MostMoments -> folders.sortedWith(
+            compareByDescending<AudioBookmarkFolder> { it.bookmarkCount }
+                .thenByDescending { it.latestBookmarkCreatedTime }
+                .thenBy { it.song.title.lowercase(Locale.getDefault()) }
+        )
+
+        BookmarkFolderSortMode.Recent -> folders.sortedWith(
+            compareByDescending<AudioBookmarkFolder> { it.latestBookmarkCreatedTime }
+                .thenByDescending { it.bookmarkCount }
+                .thenBy { it.song.title.lowercase(Locale.getDefault()) }
+        )
+
+        BookmarkFolderSortMode.Title -> folders.sortedWith(
+            compareBy<AudioBookmarkFolder> { it.song.title.lowercase(Locale.getDefault()) }
+                .thenByDescending { it.bookmarkCount }
+                .thenByDescending { it.latestBookmarkCreatedTime }
+        )
+    }
+
+private data class BookmarkTitleTreatment(
+    val fontFamily: FontFamily,
+    val fontWeight: FontWeight,
+    val fontStyle: FontStyle,
+    val fontSizeSp: Int,
+    val lineHeightSp: Int,
+    val scaleX: Float,
+    val fontFeatureSettings: String? = null,
+    val drawStyle: DrawStyle? = null,
+    val colorAlpha: Float = 1f
+)
+
+@Composable
+private fun rememberBookmarkTitleTreatment(
+    visualIndex: Int
+): BookmarkTitleTreatment {
+    val density = LocalDensity.current
+    val oxaniumOutlineStroke = remember(density) {
+        Stroke(width = with(density) { 1.35.dp.toPx() })
+    }
+    val googleSansItalic = rememberBookmarkFlexFont(
+        weight = 800,
+        width = 132f,
+        slant = -9f,
+        rond = 78f
+    )
+    val variant = remember(visualIndex) { Math.floorMod(visualIndex, 4) }
+
+    return when (variant) {
+        0 -> BookmarkTitleTreatment(
+            fontFamily = MontserratFamily,
+            fontWeight = FontWeight.Normal,
+            fontStyle = FontStyle.Normal,
+            fontSizeSp = 21,
+            lineHeightSp = 27,
+            scaleX = 1f,
+            fontFeatureSettings = "liga, calt"
+        )
+
+        1 -> BookmarkTitleTreatment(
+            fontFamily = googleSansItalic,
+            fontWeight = FontWeight.ExtraBold,
+            fontStyle = FontStyle.Italic,
+            fontSizeSp = 25,
+            lineHeightSp = 26,
+            scaleX = 1.04f
+        )
+
+        2 -> BookmarkTitleTreatment(
+            fontFamily = RoundedSans,
+            fontWeight = FontWeight.Bold,
+            fontStyle = FontStyle.Normal,
+            fontSizeSp = 31,
+            lineHeightSp = 31,
+            scaleX = 1.08f,
+            drawStyle = oxaniumOutlineStroke,
+            colorAlpha = 0.82f
+        )
+
+        else -> BookmarkTitleTreatment(
+            fontFamily = MontserratFamily,
+            fontWeight = FontWeight.Bold,
+            fontStyle = FontStyle.Italic,
+            fontSizeSp = 25,
+            lineHeightSp = 26,
+            scaleX = 0.98f
+        )
+    }
+}
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+private fun rememberBookmarkFlexFont(
+    weight: Int,
+    width: Float,
+    slant: Float,
+    rond: Float
+): FontFamily =
+    remember(weight, width, slant, rond) {
+        FontFamily(
+            Font(
+                resId = R.font.gflex_variable,
+                weight = FontWeight(weight),
+                variationSettings = FontVariation.Settings(
+                    FontVariation.weight(weight),
+                    FontVariation.width(width),
+                    FontVariation.slant(slant),
+                    FontVariation.Setting("ROND", rond),
+                    FontVariation.Setting("XTRA", 520f),
+                    FontVariation.Setting("YOPQ", 90f),
+                    FontVariation.Setting("YTLC", 505f)
+                )
+            )
+        )
+    }
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+private fun rememberBookmarkGenreFont(
+    weight: Int,
+    width: Float,
+    grade: Int
+): FontFamily =
+    remember(weight, width, grade) {
+        FontFamily(
+            Font(
+                resId = R.font.genre_variable,
+                weight = FontWeight(weight),
+                variationSettings = FontVariation.Settings(
+                    FontVariation.weight(weight),
+                    FontVariation.width(width),
+                    FontVariation.grade(grade)
+                )
+            )
+        )
+    }
+
+private data class BookmarksCollapsibleTopBarState(
+    val lazyListState: LazyListState,
+    val nestedScrollConnection: NestedScrollConnection,
+    val headerHeight: Dp,
+    val collapseFraction: Float
+)
+
+@Composable
+private fun rememberBookmarksCollapsibleTopBarState(
+    maxTopBarHeight: Dp = 174.dp,
+    minTopBarContentHeight: Dp = 64.dp
+): BookmarksCollapsibleTopBarState {
+    val density = LocalDensity.current
+    val coroutineScope = rememberCoroutineScope()
+    val lazyListState = rememberLazyListState()
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val minTopBarHeight = minTopBarContentHeight + statusBarHeight
+    val minTopBarHeightPx = with(density) { minTopBarHeight.toPx() }
+    val maxTopBarHeightPx = with(density) { maxTopBarHeight.toPx() }
+        .coerceAtLeast(minTopBarHeightPx + 1f)
+    val topBarHeight = remember { Animatable(maxTopBarHeightPx) }
+    var collapseFraction by remember { mutableFloatStateOf(0f) }
+
+    LaunchedEffect(topBarHeight.value, minTopBarHeightPx, maxTopBarHeightPx) {
+        collapseFraction = 1f -
+            ((topBarHeight.value - minTopBarHeightPx) / (maxTopBarHeightPx - minTopBarHeightPx))
+                .coerceIn(0f, 1f)
+    }
+
+    val nestedScrollConnection = remember(lazyListState, minTopBarHeightPx, maxTopBarHeightPx) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                val delta = available.y
+                val isScrollingDown = delta < 0
+
+                if (!isScrollingDown &&
+                    (lazyListState.firstVisibleItemIndex > 0 || lazyListState.firstVisibleItemScrollOffset > 0)
+                ) {
+                    return Offset.Zero
+                }
+
+                val previousHeight = topBarHeight.value
+                val newHeight = (previousHeight + delta).coerceIn(minTopBarHeightPx, maxTopBarHeightPx)
+                val consumed = newHeight - previousHeight
+
+                if (consumed.roundToInt() != 0) {
+                    coroutineScope.launch { topBarHeight.snapTo(newHeight) }
+                }
+
+                val canConsumeScroll = !(isScrollingDown && newHeight == minTopBarHeightPx)
+                return if (canConsumeScroll) Offset(0f, consumed) else Offset.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(lazyListState.isScrollInProgress, minTopBarHeightPx, maxTopBarHeightPx) {
+        if (!lazyListState.isScrollInProgress) {
+            val shouldExpand = topBarHeight.value > (minTopBarHeightPx + maxTopBarHeightPx) / 2f
+            val canExpand = lazyListState.firstVisibleItemIndex == 0 &&
+                lazyListState.firstVisibleItemScrollOffset == 0
+            val targetValue = if (shouldExpand && canExpand) maxTopBarHeightPx else minTopBarHeightPx
+
+            if (topBarHeight.value != targetValue) {
+                coroutineScope.launch {
+                    topBarHeight.animateTo(targetValue, spring(stiffness = Spring.StiffnessMedium))
+                }
+            }
+        }
+    }
+
+    return BookmarksCollapsibleTopBarState(
+        lazyListState = lazyListState,
+        nestedScrollConnection = nestedScrollConnection,
+        headerHeight = with(density) { topBarHeight.value.toDp() },
+        collapseFraction = collapseFraction
+    )
+}
+
+private fun bookmarkExpandedFolderKey(
+    listState: LazyListState,
+    focusableKeys: Set<Any>,
+    currentFocusedKey: Any?,
+    switchThresholdPx: Int,
+    collapsedFolderItemHeightPx: Int,
+    lastFocusableIndex: Int?,
+    endEdgeFocusThresholdPx: Int
+): Any? {
+    val layoutInfo = listState.layoutInfo
+    val viewportCenter = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2
+    val visibleFolders = layoutInfo.visibleItemsInfo
+        .filter { itemInfo -> focusableKeys.contains(itemInfo.key) }
+        .map { itemInfo ->
+            BookmarkVisibleItemGeometry(
+                key = itemInfo.key,
+                index = itemInfo.index,
+                itemCenterPx = itemInfo.offset + itemInfo.size / 2,
+                itemSizePx = itemInfo.size,
+                itemEndPx = itemInfo.offset + itemInfo.size
+            )
+        }
+    val stableFocusFolders = bookmarkStableFocusGeometries(
+        visibleItems = visibleFolders,
+        collapsedItemSizePx = collapsedFolderItemHeightPx
+    )
+
+    return bookmarkFocusedItemKey(
+        visibleItems = stableFocusFolders,
+        totalItemsCount = layoutInfo.totalItemsCount,
+        viewportCenterPx = viewportCenter,
+        canScrollBackward = listState.canScrollBackward,
+        canScrollForward = listState.canScrollForward,
+        currentFocusedKey = currentFocusedKey,
+        switchThresholdPx = switchThresholdPx,
+        lastFocusableIndex = lastFocusableIndex,
+        viewportEndPx = layoutInfo.viewportEndOffset,
+        endEdgeFocusThresholdPx = endEdgeFocusThresholdPx
+    )
+}
+
+@Composable
+private fun BookmarkKeepSearchTopBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    surfaceFraction: Float,
+    onNavigationClick: () -> Unit,
+    onClearQuery: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusManager = LocalFocusManager.current
+    val containerColor = lerpColor(
+        MaterialTheme.colorScheme.background.copy(alpha = 0.82f),
+        MaterialTheme.colorScheme.surfaceContainerHigh,
+        surfaceFraction
+    )
+    val pillColor = lerpColor(
+        MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.82f),
+        MaterialTheme.colorScheme.surfaceContainerHighest,
+        surfaceFraction
+    )
+    val contentColor = lerpColor(
+        MaterialTheme.colorScheme.onBackground,
+        MaterialTheme.colorScheme.onSurface,
+        surfaceFraction
+    )
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = containerColor,
+        contentColor = contentColor,
+        tonalElevation = lerp(0f, 4f, surfaceFraction).dp,
+        shadowElevation = lerp(0f, 2f, surfaceFraction).dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 14.dp, top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding(), end = 14.dp, bottom = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilledIconButton(
+                onClick = onNavigationClick,
+                modifier = Modifier.size(42.dp),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    contentColor = contentColor
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                    contentDescription = "Back"
+                )
+            }
+
+            Surface(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(56.dp),
+                shape = AbsoluteSmoothCornerShape(28.dp, 60),
+                color = pillColor,
+                contentColor = contentColor,
+                tonalElevation = 0.dp,
+                //border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.18f + surfaceFraction * 0.14f))
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(start = 16.dp, end = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(22.dp)
+                    )
+                    BasicTextField(
+                        value = query,
+                        onValueChange = onQueryChange,
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                        textStyle = MaterialTheme.typography.bodyLarge.copy(
+                            fontFamily = RoundedSans,
+                            color = contentColor,
+                            lineHeight = 20.sp,
+                            letterSpacing = 0.sp
+                        ),
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                        keyboardActions = KeyboardActions(
+                            onSearch = { focusManager.clearFocus() }
+                        )
+                    ) { innerTextField ->
+                        Box(
+                            modifier = Modifier.fillMaxWidth(),
+                            contentAlignment = Alignment.CenterStart
+                        ) {
+                            if (query.isBlank()) {
+                                Text(
+                                    text = "Search bookmarks",
+                                    style = MaterialTheme.typography.bodyLarge.copy(
+                                        fontFamily = RoundedSans,
+                                        lineHeight = 20.sp,
+                                        letterSpacing = 0.sp
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+
+                }
+            }
+
+            Surface(
+                modifier = Modifier
+                    .size(42.dp)
+                    .then(
+                        if (query.isNotBlank()) {
+                            Modifier.clickable(onClick = onClearQuery)
+                        } else {
+                            Modifier
+                        }
+                    ),
+                shape = CircleShape,
+                color = if (query.isNotBlank()) {
+                    MaterialTheme.colorScheme.secondaryContainer
+                } else {
+                    MaterialTheme.colorScheme.surfaceContainerLow
+                },
+                contentColor = if (query.isNotBlank()) {
+                    MaterialTheme.colorScheme.onSecondaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                //border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.18f + surfaceFraction * 0.12f))
+            ) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = if (query.isNotBlank()) Icons.Rounded.Close else Icons.Rounded.Bookmark,
+                        contentDescription = if (query.isNotBlank()) "Clear bookmark search" else "Bookmarks",
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookmarkActionFabMenu(
+    expanded: Boolean,
+    sortMode: BookmarkFolderSortMode,
+    hasQuery: Boolean,
+    canScrollToTop: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onSortModeChange: (BookmarkFolderSortMode) -> Unit,
+    onClearFilter: () -> Unit,
+    onScrollToTop: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val fabClosedContainer = MaterialTheme.colorScheme.primary
+    val fabOpenContainer = MaterialTheme.colorScheme.primaryContainer
+    val fabClosedContent = MaterialTheme.colorScheme.onPrimary
+    val fabOpenContent = MaterialTheme.colorScheme.onPrimaryContainer
+    val disabledActionContainer = MaterialTheme.colorScheme.surfaceContainerHigh
+    val disabledActionContent = MaterialTheme.colorScheme.onSurfaceVariant
+
+    FloatingActionButtonMenu(
+        modifier = modifier,
+        expanded = expanded,
+        horizontalAlignment = Alignment.End,
+        button = {
+            ToggleFloatingActionButton(
+                checked = expanded,
+                onCheckedChange = onExpandedChange,
+                containerSize = ToggleFloatingActionButtonDefaults.containerSize(86.dp),
+                containerColor = { progress ->
+                    lerpColor(fabClosedContainer, fabOpenContainer, progress)
+                },
+                modifier = Modifier.animateFloatingActionButton(
+                    visible = true,
+                    alignment = Alignment.BottomEnd
+                )
+            ) {
+                Icon(
+                    imageVector = if (expanded) Icons.Rounded.Close else Icons.Rounded.Sort,
+                    contentDescription = if (expanded) "Close bookmark actions" else "Open bookmark actions",
+                    tint = lerpColor(fabClosedContent, fabOpenContent, checkedProgress)
+                )
+            }
+        }
+    ) {
+        FloatingActionButtonMenuItem(
+            onClick = { onSortModeChange(BookmarkFolderSortMode.MostMoments) },
+            icon = {
+                Icon(
+                    imageVector = if (sortMode == BookmarkFolderSortMode.MostMoments) {
+                        Icons.Rounded.Check
+                    } else {
+                        BookmarkFolderSortMode.MostMoments.icon
+                    },
+                    contentDescription = null
+                )
+            },
+            text = { Text(BookmarkFolderSortMode.MostMoments.label) },
+            containerColor = if (sortMode == BookmarkFolderSortMode.MostMoments) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            },
+            contentColor = if (sortMode == BookmarkFolderSortMode.MostMoments) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            }
+        )
+        FloatingActionButtonMenuItem(
+            onClick = { onSortModeChange(BookmarkFolderSortMode.Recent) },
+            icon = {
+                Icon(
+                    imageVector = if (sortMode == BookmarkFolderSortMode.Recent) {
+                        Icons.Rounded.Check
+                    } else {
+                        BookmarkFolderSortMode.Recent.icon
+                    },
+                    contentDescription = null
+                )
+            },
+            text = { Text(BookmarkFolderSortMode.Recent.label) },
+            containerColor = if (sortMode == BookmarkFolderSortMode.Recent) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            },
+            contentColor = if (sortMode == BookmarkFolderSortMode.Recent) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            }
+        )
+        FloatingActionButtonMenuItem(
+            onClick = { onSortModeChange(BookmarkFolderSortMode.Title) },
+            icon = {
+                Icon(
+                    imageVector = if (sortMode == BookmarkFolderSortMode.Title) {
+                        Icons.Rounded.Check
+                    } else {
+                        BookmarkFolderSortMode.Title.icon
+                    },
+                    contentDescription = null
+                )
+            },
+            text = { Text(BookmarkFolderSortMode.Title.label) },
+            containerColor = if (sortMode == BookmarkFolderSortMode.Title) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            },
+            contentColor = if (sortMode == BookmarkFolderSortMode.Title) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            }
+        )
+        FloatingActionButtonMenuItem(
+            onClick = {
+                if (hasQuery) {
+                    onClearFilter()
+                }
+            },
+            icon = { Icon(Icons.Rounded.Close, contentDescription = null) },
+            text = { Text("Clear filter") },
+            containerColor = if (hasQuery) {
+                MaterialTheme.colorScheme.tertiaryContainer
+            } else {
+                disabledActionContainer
+            },
+            contentColor = if (hasQuery) {
+                MaterialTheme.colorScheme.onTertiaryContainer
+            } else {
+                disabledActionContent
+            }
+        )
+        FloatingActionButtonMenuItem(
+            onClick = {
+                if (canScrollToTop) {
+                    onScrollToTop()
+                }
+            },
+            icon = { Icon(Icons.Rounded.KeyboardArrowUp, contentDescription = null) },
+            text = { Text("Back to top") },
+            containerColor = if (canScrollToTop) {
+                MaterialTheme.colorScheme.secondaryContainer
+            } else {
+                disabledActionContainer
+            },
+            contentColor = if (canScrollToTop) {
+                MaterialTheme.colorScheme.onSecondaryContainer
+            } else {
+                disabledActionContent
+            }
+        )
+    }
+}
+
+@androidx.annotation.OptIn(UnstableApi::class)
+@Composable
+private fun BookmarkFolderCard(
+    folder: AudioBookmarkFolder,
+    visualIndex: Int,
+    playerViewModel: PlayerViewModel,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val songScheme = rememberBookmarkCardColorScheme(folder.song, playerViewModel)
+    val cardHeight = 154.dp
+    val containerShape = AbsoluteSmoothCornerShape(30.dp, 60)
+    val songTitle = folder.song.title.ifBlank { "Unknown audio" }
+    val titleTreatment = rememberBookmarkTitleTreatment(
+        visualIndex = visualIndex
+    )
+    val artistAlbum = remember(folder.song.displayArtist, folder.song.album) {
+        listOf(
+            folder.song.displayArtist.ifBlank { "Unknown artist" },
+            folder.song.album
+        ).filter { it.isNotBlank() }.joinToString(" - ")
+    }
+    val supportingFont = rememberBookmarkFlexFont(
+        weight = 560,
+        width = 106f,
+        slant = 0f,
+        rond = 100f
+    )
+    val monoFont = rememberBookmarkGenreFont(
+        weight = 680,
+        width = 94f,
+        grade = 30
+    )
+    val backgroundBrush = remember(songScheme) {
+        Brush.linearGradient(
+            listOf(
+                songScheme.primaryContainer,
+                songScheme.surfaceContainerLow,
+                songScheme.tertiaryContainer
+            )
+        )
+    }
+
+    MaterialTheme(colorScheme = songScheme) {
+        Surface(
+            onClick = onClick,
+            modifier = modifier
+                .fillMaxWidth()
+                .height(cardHeight),
+            shape = containerShape,
+            color = songScheme.surfaceContainerLow,
+            contentColor = songScheme.onSurface,
+            tonalElevation = 1.dp,
+            border = BorderStroke(1.dp, songScheme.outlineVariant.copy(alpha = 0.28f))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(containerShape)
+                    .background(backgroundBrush)
+            ) {
+//                Text(
+//                    text = folder.bookmarkCount.toString().padStart(2, '0'),
+//                    style = TextStyle(
+//                        fontFamily = monoFont,
+//                        fontWeight = FontWeight.Bold,
+//                        fontSize = 56.sp,
+//                        lineHeight = 52.sp,
+//                        letterSpacing = 0.sp
+//                    ),
+//                    color = songScheme.onSurface.copy(alpha = 0.11f),
+//                    modifier = Modifier
+//                        .align(Alignment.TopEnd)
+//                        .padding(horizontal = 16.dp, vertical = 10.dp)
+//                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(13.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    BookmarkFolderArtworkBlock(
+                        folder = folder,
+                        songScheme = songScheme,
+                        monoFont = monoFont
+                    )
+
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(7.dp),
+                        horizontalAlignment = Alignment.Start
+                    ) {
+//                        Text(
+//                            text = "CUE FOLDER",
+//                            style = MaterialTheme.typography.labelSmall.copy(
+//                                fontFamily = monoFont,
+//                                fontWeight = FontWeight.Bold,
+//                                lineHeight = 13.sp,
+//                                letterSpacing = 0.sp
+//                            ),
+//                            color = songScheme.primary,
+//                            maxLines = 1
+//                        )
+                        Text(
+                            text = songTitle,
+                            style = MaterialTheme.typography.headlineSmall.copy(
+                                fontSize = titleTreatment.fontSizeSp.sp,
+                                lineHeight = titleTreatment.lineHeightSp.sp,
+                                fontStyle = titleTreatment.fontStyle,
+                                letterSpacing = 0.sp,
+                                textGeometricTransform = TextGeometricTransform(scaleX = titleTreatment.scaleX),
+                                fontFeatureSettings = titleTreatment.fontFeatureSettings,
+                                drawStyle = titleTreatment.drawStyle
+                            ),
+                            fontFamily = titleTreatment.fontFamily,
+                            fontWeight = titleTreatment.fontWeight,
+                            color = songScheme.onSurface.copy(alpha = titleTreatment.colorAlpha),
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = artistAlbum,
+                            style = MaterialTheme.typography.bodySmall.copy(lineHeight = 16.sp, letterSpacing = 0.sp),
+                            fontFamily = supportingFont,
+                            fontWeight = FontWeight.Medium,
+                            color = songScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        BookmarkFolderCueChips(
+                            bookmarks = folder.bookmarks,
+                            songScheme = songScheme,
+                            monoFont = monoFont,
+                            horizontalAlignment = Alignment.Start
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookmarkFolderArtworkBlock(
+    folder: AudioBookmarkFolder,
+    songScheme: ColorScheme,
+    monoFont: FontFamily
+) {
+    val artworkShape = AbsoluteSmoothCornerShape(
+        cornerRadiusTL = 22.dp,
+        smoothnessAsPercentTL = 60,
+        cornerRadiusTR = 22.dp,
+        smoothnessAsPercentTR = 60,
+        cornerRadiusBR = 6.dp,
+        smoothnessAsPercentBR = 60,
+        cornerRadiusBL = 6.dp,
+        smoothnessAsPercentBL = 60
+    )
+    val counterShape = AbsoluteSmoothCornerShape(
+        cornerRadiusTL = 6.dp,
+        smoothnessAsPercentTL = 60,
+        cornerRadiusTR = 6.dp,
+        smoothnessAsPercentTR = 60,
+        cornerRadiusBR = 18.dp,
+        smoothnessAsPercentBR = 60,
+        cornerRadiusBL = 18.dp,
+        smoothnessAsPercentBL = 60
+    )
+    Column(
+        modifier = Modifier
+            .width(96.dp)
+            .height(128.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        SmartImage(
+            model = folder.song.albumArtUriString,
+            contentDescription = null,
+            targetSize = Size(144, 144),
+            shape = artworkShape,
+            placeHolderBackgroundColor = songScheme.secondaryContainer,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(86.dp)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(38.dp),
+            shape = counterShape,
+            color = songScheme.primary,
+            contentColor = songScheme.onPrimary
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 6.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.round_bookmark_24),
+                    tint = songScheme.onPrimary,
+                    contentDescription = "",
+                )
+                Text(
+                    text = folder.bookmarkCount.toString(),
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        //fontFamily = monoFont,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = if (folder.bookmarkCount > 999) 14.sp else 17.sp,
+//                        lineHeight = 15.sp,
+//                        letterSpacing = 0.sp
+                    ),
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookmarkFolderCueChips(
+    bookmarks: List<AudioBookmarkEntity>,
+    songScheme: ColorScheme,
+    monoFont: FontFamily,
+    horizontalAlignment: Alignment.Horizontal
+) {
+    val cueLabels = remember(bookmarks) {
+        bookmarks
+            .take(3)
+            .map { formatBookmarkTime(it.timestampMs) }
+    }
+    if (cueLabels.isEmpty()) return
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (horizontalAlignment == Alignment.End) {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+        cueLabels.forEach { cueLabel ->
+            Surface(
+                shape = CircleShape,
+                color = songScheme.surface.copy(alpha = 0.72f),
+                contentColor = songScheme.onSurface
+            ) {
+                Text(
+                    text = cueLabel,
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontFamily = monoFont,
+                        fontWeight = FontWeight.Bold,
+                        lineHeight = 14.sp,
+                        letterSpacing = 0.sp
+                    ),
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    maxLines = 1
+                )
+            }
+        }
+        if (horizontalAlignment == Alignment.Start) {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun BookmarkMomentCard(
+    bookmark: AudioBookmarkEntity,
+    onPlay: () -> Unit,
+    onMoreClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val formattedTime = remember(bookmark.timestampMs) { formatBookmarkTime(bookmark.timestampMs) }
+    val cueLabel = remember(formattedTime) { formattedTime }
+
+    Surface(
+        onClick = onPlay,
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(26.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 8.dp, bottom = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(7.dp)
+            ) {
+                Text(
+                    text = bookmark.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(50),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ) {
+                        Text(
+                            text = cueLabel,
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
+                        )
+                    }
+                }
+            }
+
+            Surface(
+                modifier = Modifier
+                    .width(30.dp)
+                    .height(44.dp),
+                shape = RoundedCornerShape(30.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            ) {
+                IconButton(onClick = onMoreClick) {
+                    Icon(
+                        imageVector = Icons.Rounded.MoreVert,
+                        contentDescription = "Bookmark actions"
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BookmarkMomentActionsBottomSheet(
+    bookmark: AudioBookmarkEntity,
+    onDismiss: () -> Unit,
+    onRename: () -> Unit,
+    onCopyCue: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
+    )
+    val formattedTime = remember(bookmark.timestampMs) { formatBookmarkTime(bookmark.timestampMs) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
+        containerColor = MaterialTheme.colorScheme.surface,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 8.dp)
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                shape = RoundedCornerShape(30.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            ) {
+                Row(
+                    modifier = Modifier.padding(14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Bookmark,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .padding(14.dp)
+                                .size(26.dp)
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(3.dp)
+                    ) {
+                        Text(
+                            text = bookmark.title,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontFamily = RoundedSans,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = "Cue $formattedTime",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+
+            BookmarkMomentPrimaryActions(
+                onRename = onRename,
+                onCopyCue = onCopyCue
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            BookmarkMomentDeleteAction(onDelete = onDelete)
+            Spacer(modifier = Modifier.height(14.dp))
+        }
+    }
+}
+
+@Composable
+private fun BookmarkMomentPrimaryActions(
+    onRename: () -> Unit,
+    onCopyCue: () -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    var clickPending by remember { mutableStateOf(false) }
+
+    val renameInteractionSource = remember { MutableInteractionSource() }
+    val isRenamePressed by renameInteractionSource.collectIsPressedAsState()
+    var renameVisualPressed by remember { mutableStateOf(false) }
+    LaunchedEffect(isRenamePressed) {
+        if (isRenamePressed) {
+            renameVisualPressed = true
+        } else {
+            delay(180)
+            renameVisualPressed = false
+        }
+    }
+
+    val copyInteractionSource = remember { MutableInteractionSource() }
+    val isCopyPressed by copyInteractionSource.collectIsPressedAsState()
+    var copyVisualPressed by remember { mutableStateOf(false) }
+    LaunchedEffect(isCopyPressed) {
+        if (isCopyPressed) {
+            copyVisualPressed = true
+        } else {
+            delay(180)
+            copyVisualPressed = false
+        }
+    }
+
+    val pressSpec = spring<Float>(
+        dampingRatio = 0.8f,
+        stiffness = 300f
+    )
+    val renamePressFraction by animateFloatAsState(
+        targetValue = if (renameVisualPressed) 1f else 0f,
+        animationSpec = pressSpec,
+        label = "BookmarkRenamePressFraction"
+    )
+    val copyPressFraction by animateFloatAsState(
+        targetValue = if (copyVisualPressed) 1f else 0f,
+        animationSpec = pressSpec,
+        label = "BookmarkCopyPressFraction"
+    )
+
+    val renameWeight = (0.5f + 0.08f * renamePressFraction - 0.08f * copyPressFraction).coerceAtLeast(0.1f)
+    val copyWeight = (0.5f + 0.08f * copyPressFraction - 0.08f * renamePressFraction).coerceAtLeast(0.1f)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        BookmarkMomentExpressiveActionButton(
+            modifier = Modifier
+                .weight(renameWeight)
+                .fillMaxHeight(),
+            icon = Icons.Rounded.Edit,
+            label = "Rename",
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            interactionSource = renameInteractionSource,
+            onClick = {
+                if (clickPending) return@BookmarkMomentExpressiveActionButton
+                clickPending = true
+                renameVisualPressed = true
+                coroutineScope.launch {
+                    delay(180)
+                    renameVisualPressed = false
+                    clickPending = false
+                    onRename()
+                }
+            }
+        )
+        BookmarkMomentExpressiveActionButton(
+            modifier = Modifier
+                .weight(copyWeight)
+                .fillMaxHeight(),
+            icon = Icons.Rounded.ContentCopy,
+            label = "Copy cue",
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            interactionSource = copyInteractionSource,
+            onClick = {
+                if (clickPending) return@BookmarkMomentExpressiveActionButton
+                clickPending = true
+                copyVisualPressed = true
+                coroutineScope.launch {
+                    delay(180)
+                    copyVisualPressed = false
+                    clickPending = false
+                    onCopyCue()
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun BookmarkMomentDeleteAction(
+    onDelete: () -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    var clickPending by remember { mutableStateOf(false) }
+    val deleteInteractionSource = remember { MutableInteractionSource() }
+    val isDeletePressed by deleteInteractionSource.collectIsPressedAsState()
+    var deleteVisualPressed by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isDeletePressed) {
+        if (isDeletePressed) {
+            deleteVisualPressed = true
+        } else {
+            delay(180)
+            deleteVisualPressed = false
+        }
+    }
+    val deletePressFraction by animateFloatAsState(
+        targetValue = if (deleteVisualPressed) 1f else 0f,
+        animationSpec = spring(dampingRatio = 0.8f, stiffness = 300f),
+        label = "BookmarkDeletePressFraction"
+    )
+    val deleteContainerColor = lerpColor(
+        MaterialTheme.colorScheme.errorContainer,
+        MaterialTheme.colorScheme.error,
+        deletePressFraction * 0.18f
+    )
+
+    FilledTonalButton(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 66.dp),
+        colors = ButtonDefaults.filledTonalButtonColors(
+            containerColor = deleteContainerColor,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer
+        ),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
+        shape = CircleShape,
+        interactionSource = deleteInteractionSource,
+        onClick = {
+            if (clickPending) return@FilledTonalButton
+            clickPending = true
+            deleteVisualPressed = true
+            coroutineScope.launch {
+                delay(180)
+                deleteVisualPressed = false
+                clickPending = false
+                onDelete()
+            }
+        }
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Delete,
+            contentDescription = "Delete bookmark"
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "Delete",
+            style = MaterialTheme.typography.titleMedium,
+            fontFamily = RoundedSans,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun BookmarkMomentExpressiveActionButton(
+    modifier: Modifier,
+    icon: ImageVector,
+    label: String,
+    containerColor: Color,
+    contentColor: Color,
+    interactionSource: MutableInteractionSource,
+    onClick: () -> Unit
+) {
+    FilledTonalButton(
+        modifier = modifier.heightIn(min = 92.dp),
+        colors = ButtonDefaults.filledTonalButtonColors(
+            containerColor = containerColor,
+            contentColor = contentColor
+        ),
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp),
+        shape = CircleShape,
+        interactionSource = interactionSource,
+        onClick = onClick
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                modifier = Modifier.size(30.dp)
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = RoundedSans,
+                fontWeight = FontWeight.Bold,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun RenameBookmarkDialog(
+    bookmark: AudioBookmarkEntity,
+    onDismiss: () -> Unit,
+    onRename: (String) -> Unit
+) {
+    var title by remember(bookmark.id) { mutableStateOf(bookmark.title) }
+    val trimmedTitle = title.trim()
+    val canRename = trimmedTitle.isNotEmpty() && trimmedTitle != bookmark.title
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        shape = RoundedCornerShape(28.dp),
+        title = {
+            Text(
+                text = "Rename bookmark",
+                fontFamily = RoundedSans,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = "Update the label for this saved cue.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    label = { Text("Bookmark name") },
+                    isError = title.isNotEmpty() && trimmedTitle.isEmpty(),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        focusedLabelColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onRename(trimmedTitle) },
+                enabled = canRename
+            ) {
+                Text("Rename")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel", maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
+        }
+    )
+}
+
+@Composable
+private fun BookmarksEmptyState(
+    title: String,
+    subtitle: String
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp, vertical = 56.dp)
+            .navigationBarsPadding(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Bookmark,
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(18.dp)
+                    .size(32.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(18.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun rememberSongColorScheme(song: Song): ColorScheme {
+    val isDark = LocalPixelPlayerDarkTheme.current
+    val paletteKey = song.genre ?: song.album.ifBlank { song.id }
+    return remember(paletteKey, isDark) {
+        GenreThemeUtils.getGenreColorScheme(
+            genreId = paletteKey,
+            isDark = isDark
+        )
+    }
+}
+
+@Composable
+private fun rememberBookmarkCardColorScheme(
+    song: Song,
+    playerViewModel: PlayerViewModel
+): ColorScheme {
+    val fallbackScheme = rememberSongColorScheme(song)
+    val albumArtUri = song.albumArtUriString?.takeIf { it.isNotBlank() }.orEmpty()
+    val albumColorSchemeFlow = remember(albumArtUri) {
+        playerViewModel.themeStateHolder.getAlbumColorSchemeFlow(albumArtUri)
+    }
+    val albumColorSchemePair by albumColorSchemeFlow.collectAsStateWithLifecycle()
+    val isDark = LocalPixelPlayerDarkTheme.current
+
+    return remember(albumColorSchemePair, isDark, fallbackScheme) {
+        albumColorSchemePair?.let { pair ->
+            if (isDark) pair.dark else pair.light
+        } ?: fallbackScheme
+    }
+}
+
+private fun buildBookmarkSongList(
+    bookmarks: List<AudioBookmarkEntity>,
+    loadedSongs: List<Song>
+): List<Song> {
+    val loadedById = loadedSongs.associateBy { it.id }
+    val fallbackSongs = bookmarks
+        .distinctBy { it.songId }
+        .mapNotNull { bookmark ->
+            if (loadedById.containsKey(bookmark.songId)) {
+                null
+            } else {
+                bookmark.toFallbackSong()
+            }
+        }
+
+    return loadedSongs + fallbackSongs
+}
+
+private fun AudioBookmarkEntity.toFallbackSong(): Song =
+    Song.emptySong().copy(
+        id = songId,
+        title = songTitle,
+        artist = artistName,
+        albumArtUriString = albumArtUri
+    )
+
+private fun formatBookmarkTime(timestampMs: Long): String {
+    val totalSeconds = timestampMs / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/MostListenedScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/MostListenedScreen.kt
@@ -1,0 +1,682 @@
+package com.lostf1sh.pixelplayeross.presentation.screens
+
+import android.app.Activity
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MotionScheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp as lerpDp
+import androidx.compose.ui.zIndex
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.preferences.MostListenedType
+import com.lostf1sh.pixelplayeross.presentation.components.BlurEffectCache
+import com.lostf1sh.pixelplayeross.presentation.components.CollapsibleCommonTopBar
+import com.lostf1sh.pixelplayeross.presentation.components.MiniPlayerHeight
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.ui.draw.scale
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.material3.FloatingActionButtonMenu
+import androidx.compose.material3.FloatingActionButtonMenuItem
+import androidx.compose.material3.ToggleFloatingActionButton
+import androidx.compose.material3.ToggleFloatingActionButtonDefaults
+import androidx.compose.material3.animateFloatingActionButton
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.FilterList
+import com.lostf1sh.pixelplayeross.presentation.components.PlaylistBottomSheet
+import com.lostf1sh.pixelplayeross.presentation.components.SmartImage
+import com.lostf1sh.pixelplayeross.presentation.components.SongInfoBottomSheet
+import kotlinx.collections.immutable.persistentListOf
+import com.lostf1sh.pixelplayeross.presentation.components.ProgressiveArtworkBlend
+import com.lostf1sh.pixelplayeross.presentation.components.buildMostListenedEntries
+import com.lostf1sh.pixelplayeross.presentation.components.rememberArtworkColorScheme
+import com.lostf1sh.pixelplayeross.presentation.components.subcomps.PlayingEqIcon
+import com.lostf1sh.pixelplayeross.presentation.components.MostListenedEntry
+import com.lostf1sh.pixelplayeross.presentation.components.labelRes
+import com.lostf1sh.pixelplayeross.presentation.navigation.Screen
+import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
+import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafelyReplacing
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.MostListenedViewModel
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlayerViewModel
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.PlaylistViewModel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun MostListenedScreen(
+    navController: NavController,
+    playerViewModel: PlayerViewModel,
+    viewModel: MostListenedViewModel = hiltViewModel(),
+    playlistViewModel: PlaylistViewModel = hiltViewModel(),
+) {
+    val songs by playerViewModel.allSongsFlow.collectAsStateWithLifecycle()
+    val artists by playerViewModel.artistsFlow.collectAsStateWithLifecycle()
+    val engagements by viewModel.engagements.collectAsStateWithLifecycle()
+    val selectedType by viewModel.mostListenedType.collectAsStateWithLifecycle()
+    
+    val entries = remember(songs, artists, engagements, selectedType) {
+        buildMostListenedEntries(songs, engagements, selectedType, artists)
+    }
+    val blurEnabled = true
+    val songQueue = remember(entries, selectedType) {
+        if (selectedType == MostListenedType.SONGS) entries.map { it.representativeSong } else emptyList()
+    }
+
+    // Playback state tracking for visual playing indicator & highlights
+    val currentSongId by remember(playerViewModel.stablePlayerState) {
+        playerViewModel.stablePlayerState.map { it.currentSong?.id }.distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = null)
+    
+    val isPlaying by remember(playerViewModel.stablePlayerState) {
+        playerViewModel.stablePlayerState.map { it.isPlaying }.distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = false)
+
+    val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle()
+
+    var showSongInfoBottomSheet by remember { mutableStateOf(false) }
+    var selectedSongForInfo by remember { mutableStateOf<Song?>(null) }
+    var showPlaylistBottomSheet by remember { mutableStateOf(false) }
+    val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
+
+    val bottomBarHeightDp = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
+    val density = LocalDensity.current
+    val coroutineScope = rememberCoroutineScope()
+    val lazyListState = rememberLazyListState()
+    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
+
+    val statusBarHeight = WindowInsets.statusBars
+        .asPaddingValues()
+        .calculateTopPadding()
+    val minTopBarHeight = 64.dp + statusBarHeight
+    val maxTopBarHeight = 150.dp
+
+    val minTopBarHeightPx = with(density) { minTopBarHeight.toPx() }
+    val maxTopBarHeightPx = with(density) { maxTopBarHeight.toPx() }
+
+    val topBarHeight = remember { Animatable(maxTopBarHeightPx) }
+    var collapseFraction by remember { mutableStateOf(0f) }
+
+    LaunchedEffect(topBarHeight.value, minTopBarHeightPx, maxTopBarHeightPx) {
+        collapseFraction = 1f - (
+            (topBarHeight.value - minTopBarHeightPx) / (maxTopBarHeightPx - minTopBarHeightPx)
+            ).coerceIn(0f, 1f)
+    }
+
+    val nestedScrollConnection = remember(minTopBarHeightPx, maxTopBarHeightPx) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                val delta = available.y
+                val isScrollingDown = delta < 0
+
+                if (
+                    !isScrollingDown &&
+                    (lazyListState.firstVisibleItemIndex > 0 || lazyListState.firstVisibleItemScrollOffset > 0)
+                ) {
+                    return Offset.Zero
+                }
+
+                val previousHeight = topBarHeight.value
+                val newHeight = (previousHeight + delta).coerceIn(minTopBarHeightPx, maxTopBarHeightPx)
+                val consumed = newHeight - previousHeight
+
+                if (consumed.roundToInt() != 0) {
+                    coroutineScope.launch {
+                        topBarHeight.snapTo(newHeight)
+                    }
+                }
+
+                val canConsumeScroll = !(isScrollingDown && newHeight == minTopBarHeightPx)
+                return if (canConsumeScroll) Offset(0f, consumed) else Offset.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(lazyListState.isScrollInProgress) {
+        if (!lazyListState.isScrollInProgress) {
+            val shouldExpand = topBarHeight.value > (minTopBarHeightPx + maxTopBarHeightPx) / 2
+            val canExpand =
+                lazyListState.firstVisibleItemIndex == 0 && lazyListState.firstVisibleItemScrollOffset == 0
+            val targetValue = if (shouldExpand && canExpand) maxTopBarHeightPx else minTopBarHeightPx
+
+            if (topBarHeight.value != targetValue) {
+                coroutineScope.launch {
+                    topBarHeight.animateTo(targetValue, spring(stiffness = Spring.StiffnessMedium))
+                }
+            }
+        }
+    }
+
+    val currentTopBarHeightDp = with(density) { topBarHeight.value.toDp() }
+    val contentTopPadding = currentTopBarHeightDp + 8.dp
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .nestedScroll(nestedScrollConnection)
+    ) {
+        LazyColumn(
+            state = lazyListState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                end = 16.dp,
+                top = contentTopPadding,
+                bottom = MiniPlayerHeight + 24.dp
+            ),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (entries.isEmpty()) {
+                item {
+                    Text(
+                        stringResource(R.string.most_listened_empty),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(24.dp),
+                    )
+                }
+            }
+            itemsIndexed(entries, key = { _, entry -> entry.key }) { index, entry ->
+                val isCurrentSong = selectedType == MostListenedType.SONGS && currentSongId == entry.representativeSong.id
+                MostListenedListItem(
+                    index = index,
+                    entry = entry,
+                    isPlaying = isPlaying,
+                    isCurrentSong = isCurrentSong,
+                    blurEnabled = blurEnabled,
+                    playerViewModel = playerViewModel,
+                    onMoreOptionsClick = {
+                        selectedSongForInfo = entry.representativeSong
+                        showSongInfoBottomSheet = true
+                    },
+                    onClick = {
+                        when (selectedType) {
+                            MostListenedType.SONGS -> playerViewModel.playSongs(
+                                songsToPlay = songQueue,
+                                startSong = entry.representativeSong,
+                                queueName = "Most Listened",
+                            )
+                            MostListenedType.ALBUMS -> navController.navigateSafelyReplacing(
+                                Screen.AlbumDetail.createRoute(entry.destinationId),
+                                Screen.AlbumDetail.route,
+                            )
+                            MostListenedType.ARTISTS -> navController.navigateSafelyReplacing(
+                                Screen.ArtistDetail.createRoute(entry.destinationId),
+                                Screen.ArtistDetail.route,
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        // Pinned Collapsible TopBar
+        val solidAlpha = (collapseFraction * 2f).coerceIn(0f, 1f)
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = solidAlpha))
+                .zIndex(5f)
+        ) {
+            CollapsibleCommonTopBar(
+                title = stringResource(R.string.most_listened_title),
+                collapseFraction = collapseFraction,
+                headerHeight = currentTopBarHeightDp,
+                onBackClick = { navController.popBackStack() },
+                containerColor = Color.Transparent,
+                syncStatusBarWithContainer = true,
+                containerHeightRange = 64.dp to 56.dp
+            )
+        }
+
+        // Dimming overlay when FAB is expanded
+        if (fabMenuExpanded) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.32f))
+                    .zIndex(10f)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) {
+                        fabMenuExpanded = false
+                    }
+            )
+        }
+
+        // Floating Action Button Menu for filters
+        val isMiniplayerVisible = currentSongId != null
+        val motionScheme = remember { MotionScheme.expressive() }
+        val floatingControlsBottomPadding by animateDpAsState(
+            targetValue = if (isMiniplayerVisible) MiniPlayerHeight + 16.dp else 16.dp,
+            animationSpec = motionScheme.defaultSpatialSpec(),
+            label = "MostListenedFloatingControlsBottomPadding"
+        )
+        
+        val fabClosedContainer = MaterialTheme.colorScheme.primary
+        val fabOpenContainer = MaterialTheme.colorScheme.primaryContainer
+        val fabClosedContent = MaterialTheme.colorScheme.onPrimary
+        val fabOpenContent = MaterialTheme.colorScheme.onPrimaryContainer
+
+        FloatingActionButtonMenu(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .zIndex(11f)
+                .navigationBarsPadding()
+                .padding(end = 20.dp, bottom = floatingControlsBottomPadding),
+            expanded = fabMenuExpanded,
+            horizontalAlignment = Alignment.End,
+            button = {
+                ToggleFloatingActionButton(
+                    checked = fabMenuExpanded,
+                    onCheckedChange = { fabMenuExpanded = it },
+                    containerSize = ToggleFloatingActionButtonDefaults.containerSize(80.dp),
+                    containerColor = { progress ->
+                        androidx.compose.ui.graphics.lerp(fabClosedContainer, fabOpenContainer, progress)
+                    },
+                    modifier = Modifier.animateFloatingActionButton(
+                        visible = true,
+                        alignment = Alignment.BottomEnd
+                    )
+                ) {
+                    Icon(
+                        imageVector = if (fabMenuExpanded) Icons.Rounded.Close else Icons.Rounded.FilterList,
+                        contentDescription = if (fabMenuExpanded) "Close filter menu" else "Open filter menu",
+                        tint = androidx.compose.ui.graphics.lerp(fabClosedContent, fabOpenContent, checkedProgress),
+                        modifier = Modifier.size(36.dp)
+                    )
+                }
+            }
+        ) {
+            MostListenedType.entries.forEach { type ->
+                val isSelected = selectedType == type
+                FloatingActionButtonMenuItem(
+                    onClick = {
+                        viewModel.setMostListenedType(type)
+                        fabMenuExpanded = false
+                    },
+                    icon = {
+                        val iconScale by animateFloatAsState(
+                            targetValue = if (isSelected) 1.25f else 1.0f,
+                            animationSpec = spring(
+                                dampingRatio = Spring.DampingRatioMediumBouncy,
+                                stiffness = Spring.StiffnessLow
+                            ),
+                            label = "fabMenuItemIconScale$type"
+                        )
+                        Icon(
+                            imageVector = type.localIcon(),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .scale(iconScale)
+                                .size(20.dp)
+                        )
+                    },
+                    text = {
+                        Text(
+                            text = stringResource(type.labelRes()),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium
+                        )
+                    },
+                    containerColor = if (isSelected) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLowest
+                    },
+                    contentColor = if (isSelected) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    }
+                )
+            }
+        }
+
+        // Bottom Sheets
+        if (showSongInfoBottomSheet && selectedSongForInfo != null) {
+            val song = selectedSongForInfo!!
+            val context = LocalContext.current
+            SongInfoBottomSheet(
+                song = song,
+                isFavorite = favoriteSongIds.contains(song.id),
+                onToggleFavorite = {
+                    playerViewModel.toggleFavoriteSpecificSong(song)
+                },
+                onDismiss = {
+                    showSongInfoBottomSheet = false
+                    showPlaylistBottomSheet = false
+                },
+                onPlaySong = {
+                    playerViewModel.playSongs(listOf(song), song, "Most Listened Item")
+                },
+                onAddToQueue = {
+                    playerViewModel.addSongToQueue(song)
+                },
+                onAddNextToQueue = {
+                    playerViewModel.addSongNextToQueue(song)
+                },
+                onAddToPlayList = {
+                    showPlaylistBottomSheet = true
+                },
+                onDeleteFromDevice = playerViewModel::deleteFromDevice,
+                onNavigateToAlbum = {
+                    navController.navigateSafely(Screen.AlbumDetail.createRoute(song.albumId))
+                    showSongInfoBottomSheet = false
+                },
+                onNavigateToArtist = {
+                    navController.navigateSafely(Screen.ArtistDetail.createRoute(song.artistId))
+                    showSongInfoBottomSheet = false
+                },
+                onNavigateToArtistById = { artistId ->
+                    navController.navigateSafely(Screen.ArtistDetail.createRoute(artistId))
+                    showSongInfoBottomSheet = false
+                },
+                onNavigateToGenre = {
+                    song.genre?.let {
+                        navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                    }
+                    showSongInfoBottomSheet = false
+                },
+                onEditSong = { newTitle, newArtist, newAlbum, newAlbumArtist, newComposer, newGenre, newLyrics, newTrackNumber, newDiscNumber, replayGainTrackGainDb, replayGainAlbumGainDb, coverArtUpdate ->
+                    playerViewModel.editSongMetadata(
+                        song,
+                        newTitle,
+                        newArtist,
+                        newAlbum,
+                        newAlbumArtist,
+                        newComposer,
+                        newGenre,
+                        newLyrics,
+                        newTrackNumber,
+                        newDiscNumber,
+                        replayGainTrackGainDb,
+                        replayGainAlbumGainDb,
+                        coverArtUpdate
+                    )
+                },
+                removeFromListTrigger = {}
+            )
+
+            if (showPlaylistBottomSheet) {
+                PlaylistBottomSheet(
+                    playlistUiState = playlistUiState,
+                    songs = persistentListOf(song),
+                    onDismiss = { showPlaylistBottomSheet = false },
+                    bottomBarHeight = bottomBarHeightDp,
+                    playerViewModel = playerViewModel,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LazyItemScope.MostListenedListItem(
+    index: Int,
+    entry: MostListenedEntry,
+    isPlaying: Boolean,
+    isCurrentSong: Boolean,
+    blurEnabled: Boolean,
+    playerViewModel: PlayerViewModel,
+    onMoreOptionsClick: () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val motionScheme = remember { MotionScheme.expressive() }
+    val scheme = rememberArtworkColorScheme(entry.artwork, playerViewModel.themeStateHolder)
+    
+    val transition = updateTransition(
+        targetState = isCurrentSong,
+        label = "MostListenedListItemHighlightTransition"
+    )
+    val highlightProgress by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 400) },
+        label = "highlightProgress"
+    ) { highlighted ->
+        if (highlighted) 1f else 0f
+    }
+
+    val animatedCornerRadius = lerpDp(24.dp, 50.dp, highlightProgress)
+    val animatedAlbumCornerRadius = lerpDp(12.dp, 50.dp, highlightProgress)
+    
+    val surfaceShape = remember(animatedCornerRadius) {
+        RoundedCornerShape(animatedCornerRadius)
+    }
+
+    val albumShape = remember(animatedAlbumCornerRadius) {
+        RoundedCornerShape(animatedAlbumCornerRadius)
+    }
+
+    val highlightBorderWidth = lerpDp(0.dp, 2.dp, highlightProgress)
+    val highlightBorderColor = scheme.primary.copy(alpha = highlightProgress)
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(88.dp)
+            .animateItem(placementSpec = motionScheme.fastSpatialSpec())
+            .then(
+                if (highlightProgress > 0.01f) {
+                    Modifier.border(
+                        width = highlightBorderWidth,
+                        color = highlightBorderColor,
+                        shape = surfaceShape
+                    )
+                } else {
+                    Modifier
+                }
+            ),
+        shape = surfaceShape,
+        colors = CardDefaults.cardColors(containerColor = scheme.primaryContainer),
+        onClick = onClick
+    ) {
+        Box(Modifier.fillMaxSize()) {
+            val blendColor = scheme.primaryContainer
+            val blendBrush = remember(blendColor) {
+                Brush.horizontalGradient(
+                    0f to Color.Transparent,
+                    0.15f to Color.Transparent,
+                    0.45f to blendColor.copy(alpha = 0.90f),
+                    0.65f to blendColor,
+                    1f to blendColor
+                )
+            }
+
+            if (entry.artwork != null) {
+                ProgressiveArtworkBlend(
+                    model = entry.artwork,
+                    blendColor = blendColor,
+                    blurEnabled = blurEnabled,
+                    horizontal = true,
+                    modifier = Modifier.fillMaxSize()
+                )
+                Box(Modifier.fillMaxSize().background(blendBrush))
+            }
+
+            // Foreground content Row
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Rank Badge - 3:4 Aspect Ratio vertical pill, wide enough for previous size
+                Box(
+                    modifier = Modifier
+                        .width(36.dp)
+                        .height(48.dp)
+                        .background(scheme.primary, RoundedCornerShape(percent = 50)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "${index + 1}",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Black,
+                        color = scheme.onPrimary
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                // Artwork Thumbnail (unaffected by hazeEffect because it's drawn in the foreground Row!)
+                Box(
+                    modifier = Modifier
+                        .size(50.dp)
+                        .background(MaterialTheme.colorScheme.surfaceVariant, albumShape)
+                ) {
+                    SmartImage(
+                        model = entry.artwork,
+                        contentDescription = entry.title,
+                        shape = albumShape,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                // Text details (Title & Subtitle)
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = entry.title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = scheme.onPrimaryContainer,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = entry.subtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = scheme.onPrimaryContainer.copy(alpha = 0.78f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                // Playing EQ Icon
+                if (isCurrentSong) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    PlayingEqIcon(
+                        modifier = Modifier.size(width = 18.dp, height = 16.dp),
+                        color = scheme.primary,
+                        isPlaying = isPlaying
+                    )
+                }
+
+                // Options (three dots menu - updated to 3:4 aspect ratio vertical pill)
+                Spacer(modifier = Modifier.width(8.dp))
+                FilledIconButton(
+                    onClick = onMoreOptionsClick,
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = scheme.onPrimaryContainer.copy(alpha = 0.08f),
+                        contentColor = scheme.onPrimaryContainer
+                    ),
+                    shape = RoundedCornerShape(percent = 50),
+                    modifier = Modifier
+                        .width(30.dp)
+                        .height(40.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.MoreVert,
+                        contentDescription = stringResource(R.string.most_listened_cd_more_options, entry.title),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun MostListenedType.localIcon() = when (this) {
+    MostListenedType.SONGS -> Icons.Rounded.MusicNote
+    MostListenedType.ALBUMS -> Icons.Rounded.Album
+    MostListenedType.ARTISTS -> Icons.Rounded.Person
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsCategoryScreen.kt
@@ -1,6 +1,7 @@
 package com.lostf1sh.pixelplayeross.presentation.screens
 
 import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
+import com.lostf1sh.pixelplayeross.presentation.settings.search.settingHighlight
 import com.lostf1sh.pixelplayeross.presentation.components.BackupModuleSelectionDialog
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -183,6 +184,7 @@ fun SettingsCategoryScreen(
     playerViewModel: PlayerViewModel,
     settingsViewModel: SettingsViewModel = hiltViewModel(),
     statsViewModel: com.lostf1sh.pixelplayeross.presentation.viewmodel.StatsViewModel = hiltViewModel(),
+    highlightKey: String? = null,
     onBackClick: () -> Unit
 ) {
     val category = SettingsCategory.fromId(categoryId) ?: return
@@ -385,6 +387,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_library_structure)) {
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_excluded_directories_title),
+                                    modifier = Modifier.settingHighlight("item_library_excluded_directories", highlightKey),
                                     subtitle = stringResource(R.string.setcat_excluded_directories_subtitle),
                                     leadingIcon = { Icon(Icons.Outlined.Folder, null, tint = MaterialTheme.colorScheme.secondary) },
                                     trailingIcon = { Icon(Icons.Rounded.ChevronRight, stringResource(R.string.cd_open), tint = MaterialTheme.colorScheme.onSurfaceVariant) },
@@ -395,6 +398,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_artists_title),
+                                    modifier = Modifier.settingHighlight("item_library_artists", highlightKey),
                                     subtitle = stringResource(R.string.setcat_artists_subtitle),
                                     leadingIcon = { Icon(Icons.Outlined.Person, null, tint = MaterialTheme.colorScheme.secondary) },
                                     trailingIcon = { Icon(Icons.Rounded.ChevronRight, stringResource(R.string.cd_open), tint = MaterialTheme.colorScheme.onSurfaceVariant) },
@@ -405,6 +409,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_filtering)) {
                                 SliderSettingsItem(
                                     label = stringResource(R.string.setcat_min_song_duration),
+                                    modifier = Modifier.settingHighlight("item_library_min_duration", highlightKey),
                                     value = minSongDurationDraft,
                                     valueRange = 0f..120000f,
                                     steps = 23,
@@ -419,6 +424,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SliderSettingsItem(
                                     label = stringResource(R.string.setcat_min_tracks_per_album),
+                                    modifier = Modifier.settingHighlight("item_library_min_tracks", highlightKey),
                                     value = minTracksPerAlbumDraft,
                                     valueRange = 1f..5f,
                                     steps = 3,
@@ -433,6 +439,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SliderSettingsItem(
                                     label = stringResource(R.string.setcat_album_art_cache_limit),
+                                    modifier = Modifier.settingHighlight("item_library_art_cache_limit", highlightKey),
                                     value = albumArtCacheLimitDraft,
                                     valueRange = 50f..1500f,
                                     steps = 28,
@@ -449,6 +456,7 @@ fun SettingsCategoryScreen(
 
                             SettingsSubsection(title = stringResource(R.string.setcat_sync_scanning)) {
                                 RefreshLibraryItem(
+                                    modifier = Modifier.settingHighlight("item_library_refresh", highlightKey),
                                     isSyncing = isSyncing,
                                     syncProgress = syncProgress,
                                     activeOperationLabel = if (isSyncing) syncIndicatorLabel else null,
@@ -467,6 +475,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_auto_scan_lrc_title),
+                                    modifier = Modifier.settingHighlight("item_library_auto_scan_lrc", highlightKey),
                                     subtitle = stringResource(R.string.setcat_auto_scan_lrc_subtitle),
                                     checked = uiState.autoScanLrcFiles,
                                     onCheckedChange = { settingsViewModel.setAutoScanLrcFiles(it) },
@@ -474,6 +483,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_find_duplicates_title),
+                                    modifier = Modifier.settingHighlight("item_library_find_duplicates", highlightKey),
                                     subtitle = stringResource(R.string.setcat_find_duplicates_subtitle),
                                     leadingIcon = { Icon(Icons.Outlined.Folder, null, tint = MaterialTheme.colorScheme.secondary) },
                                     trailingIcon = { Icon(Icons.Rounded.ChevronRight, stringResource(R.string.cd_open), tint = MaterialTheme.colorScheme.onSurfaceVariant) },
@@ -484,6 +494,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_online_services)) {
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_external_lyrics_title),
+                                    modifier = Modifier.settingHighlight("item_library_external_lyrics", highlightKey),
                                     subtitle = stringResource(R.string.setcat_external_lyrics_subtitle),
                                     checked = uiState.externalLyricsEnabled,
                                     onCheckedChange = { settingsViewModel.setExternalLyricsEnabled(it) },
@@ -491,6 +502,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_external_artist_images_title),
+                                    modifier = Modifier.settingHighlight("item_library_external_artist_images", highlightKey),
                                     subtitle = stringResource(R.string.setcat_external_artist_images_subtitle),
                                     checked = uiState.externalArtistImagesEnabled,
                                     onCheckedChange = { settingsViewModel.setExternalArtistImagesEnabled(it) },
@@ -504,6 +516,7 @@ fun SettingsCategoryScreen(
                             ) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_lyrics_source_priority_label),
+                                    modifier = Modifier.settingHighlight("item_library_lyrics_source_priority", highlightKey),
                                     description = stringResource(R.string.setcat_lyrics_source_priority_desc),
                                     options = mapOf(
                                         LyricsSourcePreference.EMBEDDED_FIRST.name to stringResource(R.string.setcat_lyrics_embedded_first),
@@ -520,6 +533,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_reset_imported_lyrics_title),
+                                    modifier = Modifier.settingHighlight("item_library_reset_imported_lyrics", highlightKey),
                                     subtitle = stringResource(R.string.setcat_reset_imported_lyrics_subtitle),
                                     leadingIcon = { Icon(Icons.Outlined.ClearAll, null, tint = MaterialTheme.colorScheme.secondary) },
                                     onClick = { showClearLyricsDialog = true }
@@ -533,6 +547,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_global_theme)) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_app_theme_label),
+                                    modifier = Modifier.settingHighlight("item_appearance_app_theme", highlightKey),
                                     description = stringResource(R.string.setcat_app_theme_desc),
                                     options = mapOf(
                                         AppThemeMode.LIGHT to stringResource(R.string.setcat_theme_light),
@@ -545,6 +560,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_smooth_corners_title),
+                                    modifier = Modifier.settingHighlight("item_appearance_smooth_corners", highlightKey),
                                     subtitle = stringResource(R.string.setcat_smooth_corners_subtitle),
                                     checked = useSmoothCorners,
                                     onCheckedChange = settingsViewModel::setUseSmoothCorners,
@@ -555,6 +571,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_now_playing)) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_player_theme_label),
+                                    modifier = Modifier.settingHighlight("item_appearance_player_theme", highlightKey),
                                     description = stringResource(R.string.setcat_player_theme_desc),
                                     options = mapOf(
                                         ThemePreference.ALBUM_ART to stringResource(R.string.setcat_player_theme_album_art),
@@ -566,6 +583,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_show_player_file_info_title),
+                                    modifier = Modifier.settingHighlight("item_appearance_show_player_file_info", highlightKey),
                                     subtitle = stringResource(R.string.setcat_show_player_file_info_subtitle),
                                     checked = uiState.showPlayerFileInfo,
                                     onCheckedChange = { settingsViewModel.setShowPlayerFileInfo(it) },
@@ -573,6 +591,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_album_art_palette_title),
+                                    modifier = Modifier.settingHighlight("item_appearance_album_art_palette", highlightKey),
                                     subtitle = stringResource(R.string.setcat_album_art_palette_subtitle, uiState.albumArtPaletteStyle.label),
                                     leadingIcon = { Icon(Icons.Outlined.Style, null, tint = MaterialTheme.colorScheme.secondary) },
                                     trailingIcon = { Icon(Icons.Rounded.ChevronRight, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
@@ -580,6 +599,7 @@ fun SettingsCategoryScreen(
                                 )
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_carousel_style_label),
+                                    modifier = Modifier.settingHighlight("item_appearance_carousel_style", highlightKey),
                                     description = stringResource(R.string.setcat_carousel_style_desc),
                                     options = mapOf(
                                         CarouselStyle.NO_PEEK to stringResource(R.string.setcat_carousel_no_peek),
@@ -594,6 +614,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_home_collage)) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_collage_pattern_label),
+                                    modifier = Modifier.settingHighlight("item_appearance_collage_pattern", highlightKey),
                                     description = stringResource(R.string.setcat_collage_pattern_desc),
                                     options = CollagePattern.entries.associate { it.storageKey to it.label },
                                     selectedKey = uiState.collagePattern.storageKey,
@@ -604,6 +625,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_auto_rotate_patterns_title),
+                                    modifier = Modifier.settingHighlight("item_appearance_collage_auto_rotate", highlightKey),
                                     subtitle = stringResource(R.string.setcat_auto_rotate_patterns_subtitle),
                                     checked = uiState.collageAutoRotate,
                                     onCheckedChange = { settingsViewModel.setCollageAutoRotate(it) },
@@ -614,6 +636,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_navigation_bar)) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_navbar_style_label),
+                                    modifier = Modifier.settingHighlight("item_appearance_navbar_style", highlightKey),
                                     description = stringResource(R.string.setcat_navbar_style_desc),
                                     options = mapOf(
                                         NavBarStyle.DEFAULT to stringResource(R.string.setcat_navbar_style_default),
@@ -625,6 +648,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_compact_mode_title),
+                                    modifier = Modifier.settingHighlight("item_appearance_navbar_compact", highlightKey),
                                     subtitle = stringResource(R.string.setcat_compact_mode_subtitle),
                                     checked = uiState.navBarCompactMode,
                                     onCheckedChange = { settingsViewModel.setNavBarCompactMode(it) },
@@ -638,6 +662,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_navbar_corner_title),
+                                    modifier = Modifier.settingHighlight("item_appearance_navbar_corner", highlightKey),
                                     subtitle = stringResource(R.string.setcat_navbar_corner_subtitle),
                                     leadingIcon = { Icon(painterResource(R.drawable.rounded_rounded_corner_24), null, tint = MaterialTheme.colorScheme.secondary) },
                                     trailingIcon = { Icon(Icons.Rounded.ChevronRight, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
@@ -648,6 +673,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_lyrics_screen)) {
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_immersive_lyrics_title),
+                                    modifier = Modifier.settingHighlight("item_appearance_immersive_lyrics", highlightKey),
                                     subtitle = stringResource(R.string.setcat_immersive_lyrics_subtitle),
                                     checked = uiState.immersiveLyricsEnabled,
                                     onCheckedChange = { settingsViewModel.setImmersiveLyricsEnabled(it) },
@@ -677,6 +703,7 @@ fun SettingsCategoryScreen(
                             ) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_default_tab_label),
+                                    modifier = Modifier.settingHighlight("item_appearance_default_tab", highlightKey),
                                     description = stringResource(R.string.setcat_default_tab_desc),
                                     options = mapOf(
                                         LaunchTab.HOME to stringResource(R.string.tab_home),
@@ -689,6 +716,7 @@ fun SettingsCategoryScreen(
                                 )
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_library_navigation_label),
+                                    modifier = Modifier.settingHighlight("item_appearance_library_navigation", highlightKey),
                                     description = stringResource(R.string.setcat_library_navigation_desc),
                                     options = mapOf(
                                         LibraryNavigationMode.TAB_ROW to stringResource(R.string.setcat_library_nav_tab_row),
@@ -704,6 +732,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_background_playback)) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_keep_playing_label),
+                                    modifier = Modifier.settingHighlight("item_playback_keep_playing_bg", highlightKey),
                                     description = stringResource(R.string.setcat_keep_playing_desc),
                                     options = mapOf("true" to stringResource(R.string.label_on), "false" to stringResource(R.string.label_off)),
                                     selectedKey = if (uiState.keepPlayingInBackground) "true" else "false",
@@ -715,6 +744,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_replaygain_section)) {
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_replaygain_enable_title),
+                                    modifier = Modifier.settingHighlight("item_playback_replaygain", highlightKey),
                                     subtitle = stringResource(R.string.setcat_replaygain_enable_subtitle),
                                     checked = uiState.replayGainEnabled,
                                     onCheckedChange = { settingsViewModel.setReplayGainEnabled(it) },
@@ -727,6 +757,7 @@ fun SettingsCategoryScreen(
                                 ) {
                                     ThemeSelectorItem(
                                         label = stringResource(R.string.setcat_gain_mode_label),
+                                        modifier = Modifier.settingHighlight("item_playback_gain_mode", highlightKey),
                                         description = stringResource(R.string.setcat_gain_mode_desc),
                                         options = mapOf("track" to stringResource(R.string.setcat_gain_mode_track), "album" to stringResource(R.string.setcat_gain_mode_album)),
                                         selectedKey = if (uiState.replayGainUseAlbumGain) "album" else "track",
@@ -739,6 +770,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_headphones)) {
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_headphones_resume_title),
+                                    modifier = Modifier.settingHighlight("item_playback_headphones_resume", highlightKey),
                                     subtitle = stringResource(R.string.setcat_headphones_resume_subtitle),
                                     checked = uiState.resumeOnHeadsetReconnect,
                                     onCheckedChange = { settingsViewModel.setResumeOnHeadsetReconnect(it) },
@@ -749,6 +781,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_queue_transitions)) {
                                 ThemeSelectorItem(
                                     label = stringResource(R.string.setcat_crossfade_label),
+                                    modifier = Modifier.settingHighlight("item_playback_crossfade", highlightKey),
                                     description = stringResource(R.string.setcat_crossfade_desc),
                                     options = mapOf("true" to stringResource(R.string.label_enabled), "false" to stringResource(R.string.label_disabled)),
                                     selectedKey = if (uiState.isCrossfadeEnabled) "true" else "false",
@@ -758,6 +791,7 @@ fun SettingsCategoryScreen(
                                 if (uiState.isCrossfadeEnabled) {
                                     SliderSettingsItem(
                                         label = stringResource(R.string.setcat_crossfade_duration),
+                                        modifier = Modifier.settingHighlight("item_playback_crossfade_duration", highlightKey),
                                         value = uiState.crossfadeDuration.toFloat(),
                                         valueRange = 1000f..12000f,
                                         steps= 10,
@@ -767,6 +801,7 @@ fun SettingsCategoryScreen(
                                 }
                                 SliderSettingsItem(
                                     label = stringResource(R.string.setcat_playback_speed),
+                                    modifier = Modifier.settingHighlight("item_playback_speed", highlightKey),
                                     value = playbackSpeed,
                                     valueRange = 0.5f..2.0f,
                                     steps = 5,
@@ -775,6 +810,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_hifi_mode_title),
+                                    modifier = Modifier.settingHighlight("item_playback_hifi_mode", highlightKey),
                                     subtitle = if (uiState.hiFiModeDeviceSupported)
                                         stringResource(R.string.setcat_hifi_mode_subtitle_supported)
                                     else
@@ -786,6 +822,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_persistent_shuffle_title),
+                                    modifier = Modifier.settingHighlight("item_playback_persistent_shuffle", highlightKey),
                                     subtitle = stringResource(R.string.setcat_persistent_shuffle_subtitle),
                                     checked = uiState.persistentShuffleEnabled,
                                     onCheckedChange = { settingsViewModel.setPersistentShuffleEnabled(it) },
@@ -793,6 +830,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_show_queue_history_title),
+                                    modifier = Modifier.settingHighlight("item_playback_show_queue_history", highlightKey),
                                     subtitle = stringResource(R.string.setcat_show_queue_history_subtitle),
                                     checked = uiState.showQueueHistory,
                                     onCheckedChange = { settingsViewModel.setShowQueueHistory(it) },
@@ -807,6 +845,7 @@ fun SettingsCategoryScreen(
                             ) {
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_folder_back_gesture_title),
+                                    modifier = Modifier.settingHighlight("item_behavior_folder_back_gesture", highlightKey),
                                     subtitle = stringResource(R.string.setcat_folder_back_gesture_subtitle),
                                     checked = uiState.folderBackGestureNavigation,
                                     onCheckedChange = { settingsViewModel.setFolderBackGestureNavigation(it) },
@@ -824,6 +863,7 @@ fun SettingsCategoryScreen(
                             ) {
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_tap_bg_closes_title),
+                                    modifier = Modifier.settingHighlight("item_behavior_tap_bg_closes", highlightKey),
                                     subtitle = stringResource(R.string.setcat_tap_bg_closes_subtitle),
                                     checked = uiState.tapBackgroundClosesPlayer,
                                     onCheckedChange = { settingsViewModel.setTapBackgroundClosesPlayer(it) },
@@ -836,6 +876,7 @@ fun SettingsCategoryScreen(
                             ) {
                                 SwitchSettingItem(
                                     title = stringResource(R.string.setcat_haptic_feedback_title),
+                                    modifier = Modifier.settingHighlight("item_behavior_haptics", highlightKey),
                                     subtitle = stringResource(R.string.setcat_haptic_feedback_subtitle),
                                     checked = uiState.hapticsEnabled,
                                     onCheckedChange = { settingsViewModel.setHapticsEnabled(it) },
@@ -854,6 +895,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_create_backup)) {
                                 ActionSettingsItem(
                                     title = stringResource(R.string.setcat_export_backup_title),
+                                    modifier = Modifier.settingHighlight("item_backup_export", highlightKey),
                                     subtitle = stringResource(
                                         R.string.setcat_export_backup_subtitle,
                                         buildBackupSelectionSummary(context, exportSections)
@@ -877,6 +919,7 @@ fun SettingsCategoryScreen(
                             ) {
                                 ActionSettingsItem(
                                     title = stringResource(R.string.setcat_import_backup_title),
+                                    modifier = Modifier.settingHighlight("item_backup_import", highlightKey),
                                     subtitle = stringResource(R.string.setcat_import_backup_subtitle),
                                     icon = {
                                         Icon(
@@ -895,6 +938,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_experiments)) {
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_experimental_title),
+                                    modifier = Modifier.settingHighlight("item_developer_experimental", highlightKey),
                                     subtitle = stringResource(R.string.setcat_experimental_subtitle),
                                     leadingIcon = { Icon(Icons.Rounded.Science, null, tint = MaterialTheme.colorScheme.secondary) },
                                     trailingIcon = { Icon(Icons.Rounded.ChevronRight, stringResource(R.string.cd_open), tint = MaterialTheme.colorScheme.onSurfaceVariant) },
@@ -902,6 +946,7 @@ fun SettingsCategoryScreen(
                                 )
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_test_setup_title),
+                                    modifier = Modifier.settingHighlight("item_developer_test_setup", highlightKey),
                                     subtitle = stringResource(R.string.setcat_test_setup_subtitle),
                                     leadingIcon = { Icon(Icons.Rounded.Science, null, tint = MaterialTheme.colorScheme.tertiary) },
                                     onClick = {
@@ -913,6 +958,7 @@ fun SettingsCategoryScreen(
                             SettingsSubsection(title = stringResource(R.string.setcat_maintenance)) {
                                 ActionSettingsItem(
                                     title = stringResource(R.string.setcat_force_daily_mix_title),
+                                    modifier = Modifier.settingHighlight("item_developer_force_daily_mix", highlightKey),
                                     subtitle = stringResource(R.string.setcat_force_daily_mix_subtitle),
                                     icon = { Icon(painterResource(R.drawable.rounded_instant_mix_24), null, tint = MaterialTheme.colorScheme.secondary) },
                                     primaryActionLabel = stringResource(R.string.setcat_regenerate_daily_mix_action),
@@ -920,6 +966,7 @@ fun SettingsCategoryScreen(
                                 )
                                 ActionSettingsItem(
                                     title = stringResource(R.string.setcat_force_stats_title),
+                                    modifier = Modifier.settingHighlight("item_developer_force_stats", highlightKey),
                                     subtitle = stringResource(R.string.setcat_force_stats_subtitle),
                                     icon = { Icon(painterResource(R.drawable.rounded_monitoring_24), null, tint = MaterialTheme.colorScheme.secondary) },
                                     primaryActionLabel = stringResource(R.string.setcat_regenerate_stats_action),
@@ -927,6 +974,7 @@ fun SettingsCategoryScreen(
                                 )
                                 ActionSettingsItem(
                                     title = stringResource(R.string.setcat_force_palette_title),
+                                    modifier = Modifier.settingHighlight("item_developer_force_palette", highlightKey),
                                     subtitle = if (paletteRegenerateTargets.isEmpty()) {
                                         stringResource(R.string.setcat_force_palette_empty)
                                     } else {
@@ -947,6 +995,7 @@ fun SettingsCategoryScreen(
                             ) {
                                 SettingsItem(
                                     title = stringResource(R.string.setcat_trigger_crash_title),
+                                    modifier = Modifier.settingHighlight("item_developer_trigger_crash", highlightKey),
                                     subtitle = stringResource(R.string.setcat_trigger_crash_subtitle),
                                     leadingIcon = { Icon(Icons.Outlined.Warning, null, tint = MaterialTheme.colorScheme.error) },
                                     onClick = { settingsViewModel.triggerTestCrash() }

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsComponents.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsComponents.kt
@@ -98,12 +98,13 @@ fun SettingsItem(
         subtitle: String,
         leadingIcon: @Composable () -> Unit,
         trailingIcon: @Composable () -> Unit = {},
+        modifier: Modifier = Modifier,
         onClick: () -> Unit
 ) {
     Surface(
             color = MaterialTheme.colorScheme.surfaceContainer,
             modifier =
-                    Modifier.fillMaxWidth()
+                    modifier.fillMaxWidth()
                             .clip(RoundedCornerShape(10.dp))
                             .clickable(onClick = onClick)
     ) {
@@ -146,14 +147,15 @@ fun SwitchSettingItem(
         checked: Boolean,
         onCheckedChange: (Boolean) -> Unit,
         leadingIcon: @Composable (() -> Unit)? = null,
-        enabled: Boolean = true
+        enabled: Boolean = true,
+        modifier: Modifier = Modifier
 ) {
     val view = LocalView.current
     val appHapticsConfig = LocalAppHapticsConfig.current
 
     Surface(
             color = MaterialTheme.colorScheme.surfaceContainer,
-            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+            modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
     ) {
         Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -234,7 +236,8 @@ fun ThemeSelectorItem(
         options: Map<String, String>,
         selectedKey: String,
         onSelectionChanged: (String) -> Unit,
-        leadingIcon: @Composable () -> Unit
+        leadingIcon: @Composable () -> Unit,
+        modifier: Modifier = Modifier
 ) {
     var showSheet by remember { mutableStateOf(false) }
     val selectedOption = options[selectedKey] ?: selectedKey
@@ -242,7 +245,7 @@ fun ThemeSelectorItem(
     Surface(
             color = MaterialTheme.colorScheme.surfaceContainer,
             modifier =
-                    Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp)).clickable {
+                    modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp)).clickable {
                         showSheet = true
                     }
     ) {
@@ -375,11 +378,12 @@ fun SliderSettingsItem(
         steps: Int,
         onValueChange: (Float) -> Unit,
         onValueChangeFinished: (() -> Unit)? = null,
-        valueText: (Float) -> String
+        valueText: (Float) -> String,
+        modifier: Modifier = Modifier
 ) {
     Surface(
             color = MaterialTheme.colorScheme.surfaceContainer,
-            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+            modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -420,11 +424,12 @@ fun RefreshLibraryItem(
         syncProgress: SyncProgress,
         activeOperationLabel: String? = null,
         onFullSync: () -> Unit,
-        onRebuild: () -> Unit
+        onRebuild: () -> Unit,
+        modifier: Modifier = Modifier
 ) {
     Surface(
             color = MaterialTheme.colorScheme.surfaceContainer,
-            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+            modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -653,11 +658,12 @@ fun ActionSettingsItem(
     onPrimaryAction: () -> Unit,
     secondaryActionLabel: String? = null,
     onSecondaryAction: (() -> Unit)? = null,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier
 ) {
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainer,
-        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+        modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/SettingsScreen.kt
@@ -2,6 +2,24 @@ package com.lostf1sh.pixelplayeross.presentation.screens
 
 import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import com.lostf1sh.pixelplayeross.presentation.settings.search.SettingsFuzzySearchEngine
+import com.lostf1sh.pixelplayeross.presentation.settings.search.SettingsRegistry
+import com.lostf1sh.pixelplayeross.presentation.settings.search.SettingsSearchResultsContent
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.MutableTransitionState
@@ -188,6 +206,28 @@ fun SettingsScreen(
         }
     }
 
+    val context = LocalContext.current
+    var searchQuery by rememberSaveable { mutableStateOf("") }
+    var isSearchActive by rememberSaveable { mutableStateOf(false) }
+
+    val searchFocusRequester = remember { FocusRequester() }
+    LaunchedEffect(isSearchActive) {
+        if (isSearchActive) {
+            // The overlay animates in before the field is laid out; focusing immediately drops
+            // the request and leaves the keyboard closed.
+            kotlinx.coroutines.delay(150)
+            searchFocusRequester.requestFocus()
+        }
+    }
+
+    val searchResults = remember(searchQuery) {
+        if (searchQuery.isNotBlank()) {
+            SettingsFuzzySearchEngine.search(context, searchQuery, SettingsRegistry.allSettings)
+        } else {
+            emptyList()
+        }
+    }
+
     Box(
             modifier =
                     Modifier.nestedScroll(nestedScrollConnection).fillMaxSize().graphicsLayer {
@@ -207,6 +247,37 @@ fun SettingsScreen(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.fillMaxSize()
         ) {
+            item {
+                Surface(
+                    onClick = { isSearchActive = true },
+                    shape = RoundedCornerShape(28.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 20.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Search,
+                            contentDescription = stringResource(R.string.search),
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(
+                            text = stringResource(R.string.settings_search_hint),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f)
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+            }
             item {
                 val isDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
                 ExpressiveSettingsGroup {
@@ -288,6 +359,95 @@ fun SettingsScreen(
                 headerHeight = currentTopBarHeightDp,
                 onBackClick = onNavigationIconClick
         )
+
+        AnimatedVisibility(
+            visible = isSearchActive,
+            enter = fadeIn(tween(250)) + slideInVertically(initialOffsetY = { -it / 4 }),
+            exit = fadeOut(tween(200)) + slideOutVertically(targetOffsetY = { -it / 4 }),
+            modifier = Modifier
+                .fillMaxSize()
+                .zIndex(100f)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surface)
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .statusBarsPadding()
+                                .fillMaxWidth()
+                                .height(64.dp)
+                                .padding(horizontal = 8.dp)
+                        ) {
+                            IconButton(onClick = {
+                                isSearchActive = false
+                                searchQuery = ""
+                            }) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                                    contentDescription = stringResource(R.string.auth_cd_back),
+                                    tint = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+
+                            OutlinedTextField(
+                                value = searchQuery,
+                                onValueChange = { searchQuery = it },
+                                placeholder = {
+                                    Text(
+                                        text = stringResource(R.string.settings_search_hint),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f)
+                                    )
+                                },
+                                singleLine = true,
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedIndicatorColor = Color.Transparent,
+                                    unfocusedIndicatorColor = Color.Transparent
+                                ),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .focusRequester(searchFocusRequester)
+                            )
+
+                            if (searchQuery.isNotEmpty()) {
+                                IconButton(onClick = { searchQuery = "" }) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Close,
+                                        contentDescription = stringResource(R.string.cd_clear_search),
+                                        tint = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    SettingsSearchResultsContent(
+                        query = searchQuery,
+                        results = searchResults,
+                        uiState = uiState,
+                        settingsViewModel = settingsViewModel,
+                        navController = navController,
+                        contentPadding = PaddingValues(
+                            top = 16.dp,
+                            bottom = 16.dp + MiniPlayerHeight,
+                            start = 16.dp,
+                            end = 16.dp
+                        ),
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+        }
 
         var isTransitioning by remember { mutableStateOf(true) }
         LaunchedEffect(Unit) {
@@ -454,7 +614,7 @@ fun ExpressiveSettingsGroup(content: @Composable () -> Unit) {
     }
 }
 
-private fun getCategoryColors(category: SettingsCategory, isDark: Boolean): Pair<Color, Color> {
+internal fun getCategoryColors(category: SettingsCategory, isDark: Boolean): Pair<Color, Color> {
     return if (isDark) {
         when (category) {
             SettingsCategory.LIBRARY -> Color(0xFF004A77) to Color(0xFFC2E7FF) 

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/StatsScreen.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/screens/StatsScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AutoGraph
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CalendarMonth
+import com.lostf1sh.pixelplayeross.presentation.navigation.Screen
+import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
 import androidx.compose.material.icons.outlined.Hearing
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.rounded.Refresh
@@ -357,6 +359,20 @@ fun StatsScreen(
                         onBackClick = { navController.popBackStack() },
                         containerColor = Color.Transparent,
                         actions = {
+                            FilledIconButton(
+                                modifier = Modifier
+                                    .padding(end = 8.dp),
+                                onClick = { navController.navigateSafely(Screen.AdvancedStats.route) },
+                                colors = IconButtonDefaults.filledIconButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                    contentColor = MaterialTheme.colorScheme.onSurface
+                                )
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.CalendarMonth,
+                                    contentDescription = stringResource(R.string.advanced_stats_title)
+                                )
+                            }
                             FilledIconButton(
                                 modifier = Modifier
                                     .padding(end = 12.dp),

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingHighlightModifier.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingHighlightModifier.kt
@@ -1,0 +1,73 @@
+package com.lostf1sh.pixelplayeross.presentation.settings.search
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+/**
+ * Marks a settings row as targetable by settings search.
+ *
+ * When [highlightKey] matches [itemKey] the row scrolls itself into view and pulses twice in the
+ * primary colour, so a user arriving from a search result can see which of a dozen near-identical
+ * rows the result meant. Every category page renders its rows inside a single lazy item, so
+ * scrolling is done with a [BringIntoViewRequester] rather than by list index — that keeps this
+ * working when rows are added, reordered, or conditionally hidden.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.settingHighlight(
+    itemKey: String,
+    highlightKey: String?,
+    onHighlightFinished: (() -> Unit)? = null
+): Modifier = composed {
+    val isTarget = remember(itemKey, highlightKey) { highlightKey == itemKey }
+
+    val highlightAlpha = remember { Animatable(0f) }
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    val primaryColor = MaterialTheme.colorScheme.primary
+
+    LaunchedEffect(isTarget) {
+        if (!isTarget) return@LaunchedEffect
+
+        // Let the screen transition settle before moving the list, otherwise the scroll is
+        // computed against a layout that is still animating in.
+        delay(350)
+        bringIntoViewRequester.bringIntoView()
+
+        highlightAlpha.animateTo(0.60f, tween(250, easing = FastOutSlowInEasing))
+        highlightAlpha.animateTo(0.20f, tween(250, easing = FastOutSlowInEasing))
+        highlightAlpha.animateTo(0.50f, tween(250, easing = FastOutSlowInEasing))
+        highlightAlpha.animateTo(0f, tween(2000, easing = FastOutSlowInEasing))
+
+        onHighlightFinished?.invoke()
+    }
+
+    val base = Modifier.bringIntoViewRequester(bringIntoViewRequester)
+
+    if (highlightAlpha.value > 0f) {
+        val color = primaryColor.copy(alpha = highlightAlpha.value)
+        base.drawWithContent {
+            drawContent()
+            drawRoundRect(
+                color = color,
+                topLeft = Offset.Zero,
+                size = size,
+                cornerRadius = CornerRadius(16.dp.toPx(), 16.dp.toPx())
+            )
+        }
+    } else {
+        base
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingSpec.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingSpec.kt
@@ -1,0 +1,67 @@
+package com.lostf1sh.pixelplayeross.presentation.settings.search
+
+import androidx.annotation.StringRes
+import com.lostf1sh.pixelplayeross.presentation.model.SettingsCategory
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.SettingsUiState
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.SettingsViewModel
+
+enum class SettingType {
+    SWITCH,
+    NAVIGABLE_CARD
+}
+
+/**
+ * One searchable entry in the settings tree.
+ *
+ * A spec describes where a setting lives ([category] + [subscreenRoute]) and how it should be
+ * presented in search results ([type]). Titles and subtitles come either from a string resource
+ * or, for settings whose label is composed at the call site, from a static string.
+ */
+data class SettingSpec(
+    val id: String,
+    val itemKey: String = "setting_$id",
+    @StringRes val titleRes: Int? = null,
+    val titleStatic: String? = null,
+    @StringRes val subtitleRes: Int? = null,
+    val subtitleStatic: String? = null,
+    val category: SettingsCategory,
+    val subscreenRoute: String,
+    val type: SettingType,
+    @StringRes val keywordsRes: List<Int> = emptyList(),
+    val keywordsStatic: List<String> = emptyList(),
+    /**
+     * Whether [subscreenRoute] accepts a `highlightKey` query argument. Only category pages do;
+     * appending it to a route that does not declare the argument would fail to match.
+     */
+    val supportsHighlight: Boolean = true,
+    val getValue: ((SettingsUiState) -> Boolean)? = null,
+    val onToggle: ((SettingsViewModel, Boolean) -> Unit)? = null
+) {
+    fun getTitle(context: android.content.Context): String =
+        titleStatic ?: titleRes?.let { context.getString(it) } ?: ""
+
+    fun getSubtitle(context: android.content.Context): String? =
+        subtitleStatic ?: subtitleRes?.let { context.getString(it) }
+
+    /**
+     * The route to open when a result is tapped. The target screen reads `highlightKey` and
+     * pulses the matching row so the user can see which setting the result referred to.
+     */
+    fun createNavigationRoute(): String = when {
+        !supportsHighlight -> subscreenRoute
+        subscreenRoute.contains("?") -> "$subscreenRoute&highlightKey=$itemKey"
+        else -> "$subscreenRoute?highlightKey=$itemKey"
+    }
+}
+
+data class SearchResultItem(
+    val spec: SettingSpec,
+    val score: Float,
+    val matchedTitle: String,
+    val matchedSubtitle: String?
+)
+
+data class SearchResultSection(
+    @StringRes val titleRes: Int,
+    val items: List<SearchResultItem>
+)

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingsFuzzySearchEngine.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingsFuzzySearchEngine.kt
@@ -1,0 +1,179 @@
+package com.lostf1sh.pixelplayeross.presentation.settings.search
+
+import android.content.Context
+import com.lostf1sh.pixelplayeross.R
+import java.text.Normalizer
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Scores every [SettingSpec] in the registry against a query and splits the survivors into a
+ * "top matches" and a "related" section.
+ *
+ * Matching is diacritic-insensitive and falls back to per-token Levenshtein similarity, so
+ * typos and partial words still find a setting. Exact and prefix matches short-circuit to a
+ * fixed score rather than going through the token loop.
+ */
+object SettingsFuzzySearchEngine {
+
+    private const val RELATED_THRESHOLD = 0.35f
+    private const val TOP_MATCH_THRESHOLD = 0.70f
+
+    fun search(
+        context: Context,
+        query: String,
+        registry: List<SettingSpec>
+    ): List<SearchResultSection> {
+        val rawQuery = query.trim()
+        if (rawQuery.isBlank()) return emptyList()
+
+        val normalizedQuery = normalize(rawQuery)
+        val queryTokens = normalizedQuery.split("\\s+".toRegex()).filter { it.isNotBlank() }
+
+        val scoredResults = registry.mapNotNull { spec ->
+            val title = spec.getTitle(context)
+            val subtitle = spec.getSubtitle(context) ?: ""
+            val categoryTitle = runCatching { context.getString(spec.category.titleRes) }.getOrDefault("")
+
+            val keywordStrings = spec.keywordsRes.mapNotNull { id ->
+                runCatching { context.getString(id) }.getOrNull()
+            } + spec.keywordsStatic
+
+            val score = calculateScore(
+                query = normalizedQuery,
+                queryTokens = queryTokens,
+                title = title,
+                subtitle = subtitle,
+                categoryTitle = categoryTitle,
+                keywords = keywordStrings
+            )
+
+            if (score >= RELATED_THRESHOLD) {
+                SearchResultItem(
+                    spec = spec,
+                    score = score,
+                    matchedTitle = title,
+                    matchedSubtitle = subtitle.ifBlank { null }
+                )
+            } else {
+                null
+            }
+        }.sortedByDescending { it.score }
+
+        if (scoredResults.isEmpty()) return emptyList()
+
+        val topMatches = scoredResults.filter { it.score >= TOP_MATCH_THRESHOLD }
+        val relatedMatches = scoredResults.filter { it.score < TOP_MATCH_THRESHOLD }
+
+        return buildList {
+            if (topMatches.isNotEmpty()) {
+                add(SearchResultSection(R.string.settings_search_section_top_matches, topMatches))
+            }
+            if (relatedMatches.isNotEmpty()) {
+                add(SearchResultSection(R.string.settings_search_section_related, relatedMatches))
+            }
+        }
+    }
+
+    private fun calculateScore(
+        query: String,
+        queryTokens: List<String>,
+        title: String,
+        subtitle: String,
+        categoryTitle: String,
+        keywords: List<String>
+    ): Float {
+        val normTitle = normalize(title)
+        val normSubtitle = normalize(subtitle)
+        val normCategory = normalize(categoryTitle)
+        val normKeywords = keywords.map { normalize(it) }
+
+        if (normTitle == query) return 1.0f
+        if (normTitle.startsWith(query)) return 0.95f
+
+        for (kw in normKeywords) {
+            if (kw == query) return 0.92f
+            if (kw.startsWith(query)) return 0.88f
+        }
+
+        if (normTitle.contains(query)) return 0.85f
+
+        for (kw in normKeywords) {
+            if (kw.contains(query)) return 0.82f
+        }
+
+        if (normSubtitle.contains(query)) return 0.75f
+        if (normCategory.contains(query)) return 0.65f
+
+        var totalTokenScore = 0f
+        for (token in queryTokens) {
+            var bestTokenMatch = 0f
+
+            for (tt in normTitle.split("\\s+".toRegex())) {
+                if (tt.startsWith(token)) {
+                    bestTokenMatch = max(bestTokenMatch, 0.8f)
+                } else if (tt.contains(token)) {
+                    bestTokenMatch = max(bestTokenMatch, 0.7f)
+                } else {
+                    val sim = similarity(token, tt)
+                    if (sim >= 0.7f) bestTokenMatch = max(bestTokenMatch, sim * 0.75f)
+                }
+            }
+
+            for (kw in normKeywords) {
+                for (kwt in kw.split("\\s+".toRegex())) {
+                    if (kwt.startsWith(token)) {
+                        bestTokenMatch = max(bestTokenMatch, 0.75f)
+                    } else {
+                        val sim = similarity(token, kwt)
+                        if (sim >= 0.7f) bestTokenMatch = max(bestTokenMatch, sim * 0.7f)
+                    }
+                }
+            }
+
+            if (bestTokenMatch < 0.6f && normSubtitle.isNotBlank()) {
+                for (st in normSubtitle.split("\\s+".toRegex())) {
+                    if (st.startsWith(token)) {
+                        bestTokenMatch = max(bestTokenMatch, 0.6f)
+                    }
+                }
+            }
+
+            totalTokenScore += bestTokenMatch
+        }
+
+        val averageTokenScore = if (queryTokens.isNotEmpty()) totalTokenScore / queryTokens.size else 0f
+        return averageTokenScore.coerceIn(0f, 1f)
+    }
+
+    private fun normalize(text: String): String {
+        val decomposed = Normalizer.normalize(text.lowercase(Locale.ROOT), Normalizer.Form.NFD)
+        return decomposed.replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "").trim()
+    }
+
+    private fun similarity(s1: String, s2: String): Float {
+        if (s1.isBlank() || s2.isBlank()) return 0f
+        if (s1 == s2) return 1.0f
+        val distance = levenshteinDistance(s1, s2)
+        return 1.0f - (distance.toFloat() / max(s1.length, s2.length).toFloat())
+    }
+
+    private fun levenshteinDistance(s1: String, s2: String): Int {
+        val dp = Array(s1.length + 1) { IntArray(s2.length + 1) }
+
+        for (i in 0..s1.length) dp[i][0] = i
+        for (j in 0..s2.length) dp[0][j] = j
+
+        for (i in 1..s1.length) {
+            for (j in 1..s2.length) {
+                val cost = if (s1[i - 1] == s2[j - 1]) 0 else 1
+                dp[i][j] = min(
+                    dp[i - 1][j] + 1,
+                    min(dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+                )
+            }
+        }
+        return dp[s1.length][s2.length]
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingsRegistry.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingsRegistry.kt
@@ -1,0 +1,610 @@
+package com.lostf1sh.pixelplayeross.presentation.settings.search
+
+import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.presentation.model.SettingsCategory
+import com.lostf1sh.pixelplayeross.presentation.navigation.Screen
+
+/**
+ * Flat index of every setting reachable from the settings tree, used to power settings search.
+ *
+ * Each entry mirrors a row rendered by `SettingsCategoryScreen`; `itemKey` is the contract
+ * between the two — search navigates with it, and the screen pulses the row tagged with the
+ * same key via `Modifier.settingHighlight`. Adding a row to a category screen means adding it
+ * here too, otherwise it stays unsearchable.
+ *
+ * `keywordsStatic` carries the words users actually type but that do not appear in the label
+ * (synonyms, the old name of a feature, the hardware it affects).
+ */
+object SettingsRegistry {
+
+    private val libraryRoute = Screen.SettingsCategory.createRoute(SettingsCategory.LIBRARY.id)
+    private val appearanceRoute = Screen.SettingsCategory.createRoute(SettingsCategory.APPEARANCE.id)
+    private val playbackRoute = Screen.SettingsCategory.createRoute(SettingsCategory.PLAYBACK.id)
+    private val behaviorRoute = Screen.SettingsCategory.createRoute(SettingsCategory.BEHAVIOR.id)
+    private val backupRoute = Screen.SettingsCategory.createRoute(SettingsCategory.BACKUP_RESTORE.id)
+    private val developerRoute = Screen.SettingsCategory.createRoute(SettingsCategory.DEVELOPER.id)
+
+    val allSettings: List<SettingSpec> by lazy {
+        buildList {
+            addAll(librarySettings)
+            addAll(appearanceSettings)
+            addAll(playbackSettings)
+            addAll(behaviorSettings)
+            addAll(backupSettings)
+            addAll(developerSettings)
+            addAll(standaloneSettings)
+        }
+    }
+
+    private val librarySettings = listOf(
+        SettingSpec(
+            id = "library_excluded_directories",
+            itemKey = "item_library_excluded_directories",
+            titleRes = R.string.setcat_excluded_directories_title,
+            subtitleRes = R.string.setcat_excluded_directories_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("folders", "exclude", "ignore", "blocked", "hidden", "scan")
+        ),
+        SettingSpec(
+            id = "library_artists",
+            itemKey = "item_library_artists",
+            titleRes = R.string.setcat_artists_title,
+            subtitleRes = R.string.setcat_artists_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("artist", "separator", "delimiter", "split", "featuring")
+        ),
+        SettingSpec(
+            id = "library_min_duration",
+            itemKey = "item_library_min_duration",
+            titleRes = R.string.setcat_min_song_duration,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("duration", "short", "filter", "seconds", "length", "skip clips")
+        ),
+        SettingSpec(
+            id = "library_min_tracks",
+            itemKey = "item_library_min_tracks",
+            titleRes = R.string.setcat_min_tracks_per_album,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("album", "tracks", "minimum", "singles", "filter")
+        ),
+        SettingSpec(
+            id = "library_art_cache_limit",
+            itemKey = "item_library_art_cache_limit",
+            titleRes = R.string.setcat_album_art_cache_limit,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("cache", "storage", "artwork", "cover", "megabytes", "space")
+        ),
+        SettingSpec(
+            id = "library_refresh",
+            itemKey = "item_library_refresh",
+            titleRes = R.string.setcat_sync_scanning,
+            subtitleRes = R.string.setcat_sync_full_rescan_label,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("rescan", "refresh", "sync", "rebuild", "reindex", "missing songs")
+        ),
+        SettingSpec(
+            id = "library_auto_scan_lrc",
+            itemKey = "item_library_auto_scan_lrc",
+            titleRes = R.string.setcat_auto_scan_lrc_title,
+            subtitleRes = R.string.setcat_auto_scan_lrc_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("lrc", "lyrics", "scan", "local lyrics"),
+            getValue = { it.autoScanLrcFiles },
+            onToggle = { vm, value -> vm.setAutoScanLrcFiles(value) }
+        ),
+        SettingSpec(
+            id = "library_find_duplicates",
+            itemKey = "item_library_find_duplicates",
+            titleRes = R.string.setcat_find_duplicates_title,
+            subtitleRes = R.string.setcat_find_duplicates_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("duplicate", "copies", "same song", "cleanup")
+        ),
+        SettingSpec(
+            id = "library_external_lyrics",
+            itemKey = "item_library_external_lyrics",
+            titleRes = R.string.setcat_external_lyrics_title,
+            subtitleRes = R.string.setcat_external_lyrics_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("lrclib", "online lyrics", "internet", "network", "fetch"),
+            getValue = { it.externalLyricsEnabled },
+            onToggle = { vm, value -> vm.setExternalLyricsEnabled(value) }
+        ),
+        SettingSpec(
+            id = "library_external_artist_images",
+            itemKey = "item_library_external_artist_images",
+            titleRes = R.string.setcat_external_artist_images_title,
+            subtitleRes = R.string.setcat_external_artist_images_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("deezer", "artist image", "photo", "online", "artwork"),
+            getValue = { it.externalArtistImagesEnabled },
+            onToggle = { vm, value -> vm.setExternalArtistImagesEnabled(value) }
+        ),
+        SettingSpec(
+            id = "library_lyrics_source_priority",
+            itemKey = "item_library_lyrics_source_priority",
+            titleRes = R.string.setcat_lyrics_source_priority_label,
+            subtitleRes = R.string.setcat_lyrics_source_priority_desc,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("lyrics", "priority", "embedded", "order", "source")
+        ),
+        SettingSpec(
+            id = "library_reset_imported_lyrics",
+            itemKey = "item_library_reset_imported_lyrics",
+            titleRes = R.string.setcat_reset_imported_lyrics_title,
+            subtitleRes = R.string.setcat_reset_imported_lyrics_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = libraryRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("lyrics", "reset", "clear", "delete", "imported")
+        )
+    )
+
+    private val appearanceSettings = listOf(
+        SettingSpec(
+            id = "appearance_app_theme",
+            itemKey = "item_appearance_app_theme",
+            titleRes = R.string.setcat_app_theme_label,
+            subtitleRes = R.string.setcat_app_theme_desc,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("dark mode", "light", "night", "theme", "system")
+        ),
+        SettingSpec(
+            id = "appearance_smooth_corners",
+            itemKey = "item_appearance_smooth_corners",
+            titleRes = R.string.setcat_smooth_corners_title,
+            subtitleRes = R.string.setcat_smooth_corners_subtitle,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("squircle", "rounded", "corners", "shape")
+        ),
+        SettingSpec(
+            id = "appearance_player_theme",
+            itemKey = "item_appearance_player_theme",
+            titleRes = R.string.setcat_player_theme_label,
+            subtitleRes = R.string.setcat_player_theme_desc,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("player", "album art", "dynamic color", "monet", "colours")
+        ),
+        SettingSpec(
+            id = "appearance_show_player_file_info",
+            itemKey = "item_appearance_show_player_file_info",
+            titleRes = R.string.setcat_show_player_file_info_title,
+            subtitleRes = R.string.setcat_show_player_file_info_subtitle,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("bitrate", "format", "codec", "file info", "flac", "quality"),
+            getValue = { it.showPlayerFileInfo },
+            onToggle = { vm, value -> vm.setShowPlayerFileInfo(value) }
+        ),
+        SettingSpec(
+            id = "appearance_album_art_palette",
+            itemKey = "item_appearance_album_art_palette",
+            titleRes = R.string.setcat_album_art_palette_title,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = Screen.PaletteStyle.route,
+            type = SettingType.NAVIGABLE_CARD,
+
+            supportsHighlight = false,
+            keywordsStatic = listOf("palette", "colors", "album art", "extraction", "vibrant")
+        ),
+        SettingSpec(
+            id = "appearance_carousel_style",
+            itemKey = "item_appearance_carousel_style",
+            titleRes = R.string.setcat_carousel_style_label,
+            subtitleRes = R.string.setcat_carousel_style_desc,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("carousel", "peek", "swipe", "player art")
+        ),
+        SettingSpec(
+            id = "appearance_collage_pattern",
+            itemKey = "item_appearance_collage_pattern",
+            titleRes = R.string.setcat_collage_pattern_label,
+            subtitleRes = R.string.setcat_collage_pattern_desc,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("collage", "home", "grid", "mosaic", "pattern")
+        ),
+        SettingSpec(
+            id = "appearance_collage_auto_rotate",
+            itemKey = "item_appearance_collage_auto_rotate",
+            titleRes = R.string.setcat_auto_rotate_patterns_title,
+            subtitleRes = R.string.setcat_auto_rotate_patterns_subtitle,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("collage", "rotate", "shuffle", "home", "pattern"),
+            getValue = { it.collageAutoRotate },
+            onToggle = { vm, value -> vm.setCollageAutoRotate(value) }
+        ),
+        SettingSpec(
+            id = "appearance_navbar_style",
+            itemKey = "item_appearance_navbar_style",
+            titleRes = R.string.setcat_navbar_style_label,
+            subtitleRes = R.string.setcat_navbar_style_desc,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("navigation bar", "navbar", "bottom bar", "full width")
+        ),
+        SettingSpec(
+            id = "appearance_navbar_compact",
+            itemKey = "item_appearance_navbar_compact",
+            titleRes = R.string.setcat_compact_mode_title,
+            subtitleRes = R.string.setcat_compact_mode_subtitle,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("navbar", "compact", "small", "labels", "bottom bar"),
+            getValue = { it.navBarCompactMode },
+            onToggle = { vm, value -> vm.setNavBarCompactMode(value) }
+        ),
+        SettingSpec(
+            id = "appearance_navbar_corner",
+            itemKey = "item_appearance_navbar_corner",
+            titleRes = R.string.setcat_navbar_corner_title,
+            subtitleRes = R.string.setcat_navbar_corner_subtitle,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = Screen.NavBarCrRad.route,
+            type = SettingType.NAVIGABLE_CARD,
+
+            supportsHighlight = false,
+            keywordsStatic = listOf("navbar", "corner", "radius", "rounded")
+        ),
+        SettingSpec(
+            id = "appearance_immersive_lyrics",
+            itemKey = "item_appearance_immersive_lyrics",
+            titleRes = R.string.setcat_immersive_lyrics_title,
+            subtitleRes = R.string.setcat_immersive_lyrics_subtitle,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("lyrics", "immersive", "fullscreen", "hide controls"),
+            getValue = { it.immersiveLyricsEnabled },
+            onToggle = { vm, value -> vm.setImmersiveLyricsEnabled(value) }
+        ),
+        SettingSpec(
+            id = "appearance_default_tab",
+            itemKey = "item_appearance_default_tab",
+            titleRes = R.string.setcat_default_tab_label,
+            subtitleRes = R.string.setcat_default_tab_desc,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("startup", "launch", "start screen", "default tab", "home")
+        ),
+        SettingSpec(
+            id = "appearance_library_navigation",
+            itemKey = "item_appearance_library_navigation",
+            titleRes = R.string.setcat_library_navigation_label,
+            subtitleRes = R.string.setcat_library_navigation_desc,
+            category = SettingsCategory.APPEARANCE,
+            subscreenRoute = appearanceRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("library", "tabs", "pill", "navigation")
+        )
+    )
+
+    private val playbackSettings = listOf(
+        SettingSpec(
+            id = "playback_keep_playing_bg",
+            itemKey = "item_playback_keep_playing_bg",
+            titleRes = R.string.setcat_keep_playing_label,
+            subtitleRes = R.string.setcat_keep_playing_desc,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("background", "keep playing", "swipe away", "stop", "kill")
+        ),
+        SettingSpec(
+            id = "playback_replaygain",
+            itemKey = "item_playback_replaygain",
+            titleRes = R.string.setcat_replaygain_enable_title,
+            subtitleRes = R.string.setcat_replaygain_enable_subtitle,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("replaygain", "volume", "normalization", "loudness", "gain"),
+            getValue = { it.replayGainEnabled },
+            onToggle = { vm, value -> vm.setReplayGainEnabled(value) }
+        ),
+        SettingSpec(
+            id = "playback_gain_mode",
+            itemKey = "item_playback_gain_mode",
+            titleRes = R.string.setcat_gain_mode_label,
+            subtitleRes = R.string.setcat_gain_mode_desc,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("replaygain", "track gain", "album gain", "volume")
+        ),
+        SettingSpec(
+            id = "playback_headphones_resume",
+            itemKey = "item_playback_headphones_resume",
+            titleRes = R.string.setcat_headphones_resume_title,
+            subtitleRes = R.string.setcat_headphones_resume_subtitle,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("headphones", "bluetooth", "earbuds", "resume", "reconnect"),
+            getValue = { it.resumeOnHeadsetReconnect },
+            onToggle = { vm, value -> vm.setResumeOnHeadsetReconnect(value) }
+        ),
+        SettingSpec(
+            id = "playback_crossfade",
+            itemKey = "item_playback_crossfade",
+            titleRes = R.string.setcat_crossfade_label,
+            subtitleRes = R.string.setcat_crossfade_desc,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("crossfade", "fade", "transition", "gapless", "blend")
+        ),
+        SettingSpec(
+            id = "playback_crossfade_duration",
+            itemKey = "item_playback_crossfade_duration",
+            titleRes = R.string.setcat_crossfade_duration,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("crossfade", "duration", "seconds", "fade length")
+        ),
+        SettingSpec(
+            id = "playback_speed",
+            itemKey = "item_playback_speed",
+            titleRes = R.string.setcat_playback_speed,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("speed", "tempo", "faster", "slower", "rate", "pitch")
+        ),
+        SettingSpec(
+            id = "playback_hifi_mode",
+            itemKey = "item_playback_hifi_mode",
+            titleRes = R.string.setcat_hifi_mode_title,
+            subtitleRes = R.string.setcat_hifi_mode_subtitle_supported,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("hi-fi", "hifi", "hi res", "bit perfect", "offload", "quality"),
+            getValue = { it.hiFiModeEnabled },
+            onToggle = { vm, value -> vm.setHiFiModeEnabled(value) }
+        ),
+        SettingSpec(
+            id = "playback_persistent_shuffle",
+            itemKey = "item_playback_persistent_shuffle",
+            titleRes = R.string.setcat_persistent_shuffle_title,
+            subtitleRes = R.string.setcat_persistent_shuffle_subtitle,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("shuffle", "random", "remember", "persistent"),
+            getValue = { it.persistentShuffleEnabled },
+            onToggle = { vm, value -> vm.setPersistentShuffleEnabled(value) }
+        ),
+        SettingSpec(
+            id = "playback_show_queue_history",
+            itemKey = "item_playback_show_queue_history",
+            titleRes = R.string.setcat_show_queue_history_title,
+            subtitleRes = R.string.setcat_show_queue_history_subtitle,
+            category = SettingsCategory.PLAYBACK,
+            subscreenRoute = playbackRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("queue", "history", "played", "previous"),
+            getValue = { it.showQueueHistory },
+            onToggle = { vm, value -> vm.setShowQueueHistory(value) }
+        )
+    )
+
+    private val behaviorSettings = listOf(
+        SettingSpec(
+            id = "behavior_folder_back_gesture",
+            itemKey = "item_behavior_folder_back_gesture",
+            titleRes = R.string.setcat_folder_back_gesture_title,
+            subtitleRes = R.string.setcat_folder_back_gesture_subtitle,
+            category = SettingsCategory.BEHAVIOR,
+            subscreenRoute = behaviorRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("back", "gesture", "folders", "navigation", "up"),
+            getValue = { it.folderBackGestureNavigation },
+            onToggle = { vm, value -> vm.setFolderBackGestureNavigation(value) }
+        ),
+        SettingSpec(
+            id = "behavior_tap_bg_closes",
+            itemKey = "item_behavior_tap_bg_closes",
+            titleRes = R.string.setcat_tap_bg_closes_title,
+            subtitleRes = R.string.setcat_tap_bg_closes_subtitle,
+            category = SettingsCategory.BEHAVIOR,
+            subscreenRoute = behaviorRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("tap", "dismiss", "close player", "background", "gesture"),
+            getValue = { it.tapBackgroundClosesPlayer },
+            onToggle = { vm, value -> vm.setTapBackgroundClosesPlayer(value) }
+        ),
+        SettingSpec(
+            id = "behavior_haptics",
+            itemKey = "item_behavior_haptics",
+            titleRes = R.string.setcat_haptic_feedback_title,
+            subtitleRes = R.string.setcat_haptic_feedback_subtitle,
+            category = SettingsCategory.BEHAVIOR,
+            subscreenRoute = behaviorRoute,
+            type = SettingType.SWITCH,
+            keywordsStatic = listOf("haptics", "vibration", "vibrate", "feedback", "buzz"),
+            getValue = { it.hapticsEnabled },
+            onToggle = { vm, value -> vm.setHapticsEnabled(value) }
+        )
+    )
+
+    private val backupSettings = listOf(
+        SettingSpec(
+            id = "backup_export",
+            itemKey = "item_backup_export",
+            titleRes = R.string.setcat_export_backup_title,
+            category = SettingsCategory.BACKUP_RESTORE,
+            subscreenRoute = backupRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("backup", "export", "save", "pxpl", "playlists", "transfer")
+        ),
+        SettingSpec(
+            id = "backup_import",
+            itemKey = "item_backup_import",
+            titleRes = R.string.setcat_import_backup_title,
+            subtitleRes = R.string.setcat_import_backup_subtitle,
+            category = SettingsCategory.BACKUP_RESTORE,
+            subscreenRoute = backupRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("restore", "import", "backup", "recover", "migrate")
+        )
+    )
+
+    private val developerSettings = listOf(
+        SettingSpec(
+            id = "developer_experimental",
+            itemKey = "item_developer_experimental",
+            titleRes = R.string.setcat_experimental_title,
+            subtitleRes = R.string.setcat_experimental_subtitle,
+            category = SettingsCategory.DEVELOPER,
+            subscreenRoute = Screen.Experimental.route,
+            type = SettingType.NAVIGABLE_CARD,
+
+            supportsHighlight = false,
+            keywordsStatic = listOf("experimental", "beta", "flags", "labs")
+        ),
+        SettingSpec(
+            id = "developer_test_setup",
+            itemKey = "item_developer_test_setup",
+            titleRes = R.string.setcat_test_setup_title,
+            subtitleRes = R.string.setcat_test_setup_subtitle,
+            category = SettingsCategory.DEVELOPER,
+            subscreenRoute = developerRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("setup", "onboarding", "first run", "wizard", "reset")
+        ),
+        SettingSpec(
+            id = "developer_force_daily_mix",
+            itemKey = "item_developer_force_daily_mix",
+            titleRes = R.string.setcat_force_daily_mix_title,
+            subtitleRes = R.string.setcat_force_daily_mix_subtitle,
+            category = SettingsCategory.DEVELOPER,
+            subscreenRoute = developerRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("daily mix", "regenerate", "refresh", "recommendations")
+        ),
+        SettingSpec(
+            id = "developer_force_stats",
+            itemKey = "item_developer_force_stats",
+            titleRes = R.string.setcat_force_stats_title,
+            subtitleRes = R.string.setcat_force_stats_subtitle,
+            category = SettingsCategory.DEVELOPER,
+            subscreenRoute = developerRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("stats", "statistics", "listening", "recalculate")
+        ),
+        SettingSpec(
+            id = "developer_force_palette",
+            itemKey = "item_developer_force_palette",
+            titleRes = R.string.setcat_force_palette_title,
+            subtitleRes = R.string.setcat_force_palette_subtitle,
+            category = SettingsCategory.DEVELOPER,
+            subscreenRoute = developerRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("palette", "colors", "regenerate", "album art")
+        ),
+        SettingSpec(
+            id = "developer_trigger_crash",
+            itemKey = "item_developer_trigger_crash",
+            titleRes = R.string.setcat_trigger_crash_title,
+            subtitleRes = R.string.setcat_trigger_crash_subtitle,
+            category = SettingsCategory.DEVELOPER,
+            subscreenRoute = developerRoute,
+            type = SettingType.NAVIGABLE_CARD,
+            keywordsStatic = listOf("crash", "test", "diagnostics", "exception")
+        )
+    )
+
+    /** Categories that open a dedicated screen instead of a `SettingsCategoryScreen` page. */
+    private val standaloneSettings = listOf(
+        SettingSpec(
+            id = "equalizer",
+            itemKey = "item_equalizer",
+            titleRes = R.string.settings_category_equalizer_title,
+            subtitleRes = R.string.settings_category_equalizer_subtitle,
+            category = SettingsCategory.EQUALIZER,
+            subscreenRoute = Screen.Equalizer.route,
+            type = SettingType.NAVIGABLE_CARD,
+
+            supportsHighlight = false,
+            keywordsStatic = listOf("equalizer", "eq", "bass", "treble", "preset", "audio effects")
+        ),
+        SettingSpec(
+            id = "device_capabilities",
+            itemKey = "item_device_capabilities",
+            titleRes = R.string.settings_category_device_capabilities_title,
+            subtitleRes = R.string.settings_category_device_capabilities_subtitle,
+            category = SettingsCategory.DEVICE_CAPABILITIES,
+            subscreenRoute = Screen.DeviceCapabilities.route,
+            type = SettingType.NAVIGABLE_CARD,
+
+            supportsHighlight = false,
+            keywordsStatic = listOf("device", "capabilities", "codec", "hardware", "support", "offload")
+        ),
+        SettingSpec(
+            id = "accounts",
+            itemKey = "item_accounts",
+            titleRes = R.string.settings_accounts_row_title,
+            subtitleRes = R.string.settings_accounts_row_subtitle,
+            category = SettingsCategory.LIBRARY,
+            subscreenRoute = Screen.Accounts.route,
+            type = SettingType.NAVIGABLE_CARD,
+
+            supportsHighlight = false,
+            keywordsStatic = listOf(
+                "account", "login", "navidrome", "subsonic", "jellyfin",
+                "listenbrainz", "scrobble", "server", "sync"
+            )
+        ),
+        SettingSpec(
+            id = "about",
+            itemKey = "item_about",
+            titleRes = R.string.setcat_about_pixelplayer_title,
+            subtitleRes = R.string.setcat_about_pixelplayer_subtitle,
+            category = SettingsCategory.ABOUT,
+            subscreenRoute = Screen.About.route,
+            type = SettingType.NAVIGABLE_CARD,
+
+            supportsHighlight = false,
+            keywordsStatic = listOf("about", "version", "license", "credits", "github", "source")
+        )
+    )
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingsSearchComponents.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/settings/search/SettingsSearchComponents.kt
@@ -1,0 +1,302 @@
+package com.lostf1sh.pixelplayeross.presentation.settings.search
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.SearchOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.lostf1sh.pixelplayeross.R
+import com.lostf1sh.pixelplayeross.presentation.model.SettingsCategory
+import com.lostf1sh.pixelplayeross.presentation.navigation.navigateSafely
+import com.lostf1sh.pixelplayeross.presentation.screens.ExpressiveSettingsGroup
+import com.lostf1sh.pixelplayeross.presentation.screens.getCategoryColors
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.SettingsUiState
+import com.lostf1sh.pixelplayeross.presentation.viewmodel.SettingsViewModel
+
+/**
+ * Renders scored search results grouped by the category each setting lives in.
+ *
+ * The engine returns results split into top/related sections, but showing both splits side by
+ * side reads as duplication when a setting scores near the boundary. Instead the sections are
+ * flattened in score order and regrouped by category, keeping the first (highest-scoring)
+ * occurrence of each setting.
+ */
+@Composable
+fun SettingsSearchResultsContent(
+    query: String,
+    results: List<SearchResultSection>,
+    uiState: SettingsUiState,
+    settingsViewModel: SettingsViewModel,
+    navController: NavController,
+    contentPadding: PaddingValues,
+    modifier: Modifier = Modifier
+) {
+    if (results.isEmpty()) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(contentPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier.padding(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.SearchOff,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    modifier = Modifier.size(48.dp)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.settings_search_no_results, query),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+        return
+    }
+
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+
+    val groupedByCategory = LinkedHashMap<SettingsCategory, MutableList<SearchResultItem>>()
+    val seenKeys = mutableSetOf<String>()
+    for (section in results) {
+        for (resultItem in section.items) {
+            if (seenKeys.add(resultItem.spec.itemKey)) {
+                groupedByCategory.getOrPut(resultItem.spec.category) { mutableListOf() }
+                    .add(resultItem)
+            }
+        }
+    }
+
+    LazyColumn(
+        contentPadding = contentPadding,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier.fillMaxSize()
+    ) {
+        groupedByCategory.forEach { (category, items) ->
+            item(key = "header_${category.id}") {
+                Text(
+                    text = stringResource(category.titleRes),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                )
+            }
+
+            item(key = "group_${category.id}") {
+                ExpressiveSettingsGroup {
+                    val total = items.size
+                    items.forEachIndexed { index, resultItem ->
+                        val spec = resultItem.spec
+                        val accentColor = getCategoryColors(spec.category, isDark).first
+
+                        val shape = when {
+                            total == 1 -> RoundedCornerShape(24.dp)
+                            index == 0 -> RoundedCornerShape(
+                                topStart = 24.dp, topEnd = 24.dp, bottomStart = 4.dp, bottomEnd = 4.dp
+                            )
+                            index == total - 1 -> RoundedCornerShape(
+                                topStart = 4.dp, topEnd = 4.dp, bottomStart = 24.dp, bottomEnd = 24.dp
+                            )
+                            else -> RoundedCornerShape(4.dp)
+                        }
+
+                        val navigate: () -> Unit = { navController.navigateSafely(spec.createNavigationRoute()) }
+
+                        when (spec.type) {
+                            SettingType.SWITCH -> SearchResultSwitchItem(
+                                title = resultItem.matchedTitle,
+                                subtitle = resultItem.matchedSubtitle,
+                                accentColor = accentColor,
+                                checked = spec.getValue?.invoke(uiState) == true,
+                                onToggle = { checked -> spec.onToggle?.invoke(settingsViewModel, checked) },
+                                onCardClick = navigate,
+                                shape = shape
+                            )
+                            SettingType.NAVIGABLE_CARD -> SearchResultNavigableItem(
+                                title = resultItem.matchedTitle,
+                                subtitle = resultItem.matchedSubtitle,
+                                accentColor = accentColor,
+                                onClick = navigate,
+                                shape = shape
+                            )
+                        }
+
+                        if (index < total - 1) {
+                            Spacer(modifier = Modifier.height(2.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchResultSwitchItem(
+    title: String,
+    subtitle: String?,
+    accentColor: Color,
+    checked: Boolean,
+    onToggle: (Boolean) -> Unit,
+    onCardClick: () -> Unit,
+    shape: Shape
+) {
+    SearchResultRow(
+        title = title,
+        subtitle = subtitle,
+        accentColor = accentColor,
+        onClick = onCardClick,
+        shape = shape
+    ) {
+        Switch(
+            checked = checked,
+            onCheckedChange = onToggle,
+            thumbContent = {
+                AnimatedContent(
+                    targetState = checked,
+                    transitionSpec = { fadeIn(tween(100)) togetherWith fadeOut(tween(100)) },
+                    label = "search_switch_thumb_icon"
+                ) { isChecked ->
+                    Icon(
+                        imageVector = if (isChecked) Icons.Rounded.Check else Icons.Rounded.Close,
+                        contentDescription = null,
+                        modifier = Modifier.size(SwitchDefaults.IconSize)
+                    )
+                }
+            },
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                checkedTrackColor = MaterialTheme.colorScheme.primary,
+                checkedIconColor = MaterialTheme.colorScheme.primary,
+                uncheckedThumbColor = MaterialTheme.colorScheme.onSurface,
+                uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+                uncheckedIconColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        )
+    }
+}
+
+@Composable
+private fun SearchResultNavigableItem(
+    title: String,
+    subtitle: String?,
+    accentColor: Color,
+    onClick: () -> Unit,
+    shape: Shape
+) {
+    SearchResultRow(
+        title = title,
+        subtitle = subtitle,
+        accentColor = accentColor,
+        onClick = onClick,
+        shape = shape
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.ChevronRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}
+
+@Composable
+private fun SearchResultRow(
+    title: String,
+    subtitle: String?,
+    accentColor: Color,
+    onClick: () -> Unit,
+    shape: Shape,
+    trailing: @Composable () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        shape = shape,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(3.dp)
+                    .heightIn(min = 24.dp, max = 48.dp)
+                    .clip(CircleShape)
+                    .background(accentColor)
+            )
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            trailing()
+        }
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/AdvancedStatsViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/AdvancedStatsViewModel.kt
@@ -1,0 +1,234 @@
+package com.lostf1sh.pixelplayeross.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lostf1sh.pixelplayeross.data.model.Song
+import com.lostf1sh.pixelplayeross.data.preferences.DEFAULT_LISTENING_GOAL_MINUTES
+import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
+import com.lostf1sh.pixelplayeross.data.repository.MusicRepository
+import com.lostf1sh.pixelplayeross.data.stats.PlaybackStatsRepository
+import com.lostf1sh.pixelplayeross.data.stats.PlaybackStatsRepository.PlaybackStatsSummary
+import com.lostf1sh.pixelplayeross.data.stats.StatsTimeRange
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import java.time.YearMonth
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+@HiltViewModel
+class AdvancedStatsViewModel @Inject constructor(
+    private val playbackStatsRepository: PlaybackStatsRepository,
+    private val musicRepository: MusicRepository,
+    private val userPreferencesRepository: UserPreferencesRepository
+) : ViewModel() {
+
+    data class MusicPersonality(
+        val title: String,
+        val description: String,
+        val emoji: String
+    )
+
+    data class AdvancedStatsUiState(
+        val currentMonth: YearMonth = YearMonth.now(),
+        val selectedDate: LocalDate = LocalDate.now(),
+        val dailyDurations: Map<LocalDate, Long> = emptyMap(),
+        val selectedDaySummary: PlaybackStatsSummary? = null,
+        val hourlyDistribution: List<Long> = List(6) { 0L }, // 6 buckets of 4 hours
+        val isLoading: Boolean = false,
+        val isDaySummaryLoading: Boolean = false,
+        
+        // Redesign states
+        val activeTab: Int = 0, // 0 = Daily Heatmap, 1 = Habits & Insights
+        val selectedRange: StatsTimeRange = StatsTimeRange.WEEK,
+        val rangeSummary: PlaybackStatsSummary? = null,
+        val isRangeSummaryLoading: Boolean = false,
+
+        // Listening goal (gamification)
+        val goalMinutes: Int = DEFAULT_LISTENING_GOAL_MINUTES,
+        val goalStreak: Int = 0
+    )
+
+    private val _uiState = MutableStateFlow(AdvancedStatsUiState())
+    val uiState: StateFlow<AdvancedStatsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadMonthData(YearMonth.now())
+        loadSelectedDayData(LocalDate.now())
+        loadRangeData(StatsTimeRange.WEEK)
+
+        userPreferencesRepository.listeningGoalMinutesFlow
+            .onEach { minutes ->
+                _uiState.update { it.copy(goalMinutes = minutes) }
+                refreshGoalStreak(minutes)
+            }
+            .launchIn(viewModelScope)
+
+        playbackStatsRepository.refreshFlow
+            .onEach { refreshGoalStreak(_uiState.value.goalMinutes) }
+            .launchIn(viewModelScope)
+    }
+
+    fun setGoalMinutes(minutes: Int) {
+        viewModelScope.launch {
+            userPreferencesRepository.setListeningGoalMinutes(minutes)
+        }
+    }
+
+    private fun refreshGoalStreak(goalMinutes: Int) {
+        viewModelScope.launch {
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    playbackStatsRepository.getGoalStreak(goalMinutes * 60_000L)
+                }
+            }.onSuccess { streak ->
+                _uiState.update { it.copy(goalStreak = streak) }
+            }.onFailure { t ->
+                Timber.e(t, "Failed to compute goal streak")
+            }
+        }
+    }
+
+    fun selectTab(tabIndex: Int) {
+        _uiState.update { it.copy(activeTab = tabIndex) }
+        if (tabIndex == 1 && _uiState.value.rangeSummary == null) {
+            loadRangeData(_uiState.value.selectedRange)
+        }
+    }
+
+    fun selectRange(range: StatsTimeRange) {
+        _uiState.update { it.copy(selectedRange = range) }
+        loadRangeData(range)
+    }
+
+    fun selectDate(date: LocalDate) {
+        _uiState.update { it.copy(selectedDate = date) }
+        loadSelectedDayData(date)
+    }
+
+    fun changeMonth(month: YearMonth) {
+        _uiState.update { it.copy(currentMonth = month) }
+        loadMonthData(month)
+    }
+
+    private fun loadMonthData(month: YearMonth) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    val start = month.atDay(1)
+                    val end = month.atEndOfMonth()
+                    playbackStatsRepository.getDailyPlaybackDurationMap(start, end)
+                }
+            }.onSuccess { map ->
+                _uiState.update { it.copy(dailyDurations = map, isLoading = false) }
+            }.onFailure { t ->
+                Timber.e(t, "Failed to load daily durations map")
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    private fun loadSelectedDayData(date: LocalDate) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDaySummaryLoading = true) }
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    val songs = musicRepository.getAllSongsOnce()
+                    val summary = playbackStatsRepository.loadDaySummary(date, songs)
+                    
+                    val events = playbackStatsRepository.exportEventsForBackup()
+                    val zoneId = java.time.ZoneId.systemDefault()
+                    val startOfDay = date.atStartOfDay(zoneId).toInstant().toEpochMilli()
+                    val endOfDay = date.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
+
+                    val buckets = MutableList(6) { 0L }
+                    for (event in events) {
+                        if (event.timestamp in startOfDay until endOfDay) {
+                            val localTime = java.time.Instant.ofEpochMilli(event.timestamp).atZone(zoneId).toLocalTime()
+                            val hour = localTime.hour
+                            val bucketIndex = (hour / 4).coerceIn(0, 5)
+                            buckets[bucketIndex] += event.durationMs
+                        }
+                    }
+                    Pair(summary, buckets)
+                }
+            }.onSuccess { (summary, buckets) ->
+                _uiState.update { it.copy(selectedDaySummary = summary, hourlyDistribution = buckets, isDaySummaryLoading = false) }
+            }.onFailure { t ->
+                Timber.e(t, "Failed to load selected day data")
+                _uiState.update { it.copy(isDaySummaryLoading = false) }
+            }
+        }
+    }
+
+    private fun loadRangeData(range: StatsTimeRange) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRangeSummaryLoading = true) }
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    val songs = musicRepository.getAllSongsOnce()
+                    playbackStatsRepository.loadSummary(range, songs)
+                }
+            }.onSuccess { summary ->
+                _uiState.update { it.copy(rangeSummary = summary, isRangeSummaryLoading = false) }
+            }.onFailure { t ->
+                Timber.e(t, "Failed to load range stats summary for %s", range)
+                _uiState.update { it.copy(isRangeSummaryLoading = false) }
+            }
+        }
+    }
+
+    fun getMusicPersonality(summary: PlaybackStatsSummary?): MusicPersonality {
+        if (summary == null || summary.totalPlayCount == 0) {
+            return MusicPersonality(
+                title = "The Melodic Voyager",
+                description = "Your listening patterns are taking shape. Keep enjoying your music to reveal your listener archetype!",
+                emoji = "🎧"
+            )
+        }
+        
+        val uniqueSongs = summary.uniqueSongs
+        val totalPlays = summary.totalPlayCount
+        val uniqueRatio = uniqueSongs.toDouble() / totalPlays.coerceAtLeast(1)
+        val peakDay = summary.peakDayLabel ?: ""
+        
+        return when {
+            uniqueRatio > 0.65 -> MusicPersonality(
+                title = "The Sonic Explorer",
+                description = "You love discovery! You constantly seek out different tracks rather than playing the same ones on repeat.",
+                emoji = "🧭"
+            )
+            uniqueRatio < 0.25 -> MusicPersonality(
+                title = "The Loyal Devotee",
+                description = "You find comfort in the classics. You have a curated circle of favorite tracks that you love repeating.",
+                emoji = "❤️"
+            )
+            summary.averageDailyDurationMs > 2.5 * 3600 * 1000L -> MusicPersonality(
+                title = "The Music Enthusiast",
+                description = "Music is the soundtrack to your life! You spend hours every day immersed in different melodies.",
+                emoji = "🎵"
+            )
+            peakDay.contains("Friday", ignoreCase = true) || 
+            peakDay.contains("Saturday", ignoreCase = true) || 
+            peakDay.contains("Sunday", ignoreCase = true) -> MusicPersonality(
+                title = "The Weekend Viber",
+                description = "You let loose with music on the weekends! Your listening activity spikes when it's time to relax.",
+                emoji = "🎉"
+            )
+            else -> MusicPersonality(
+                title = "The Balanced Listener",
+                description = "You keep a perfectly balanced habit. Music accompanies you in just the right moments to keep your day smooth.",
+                emoji = "🎶"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/MostListenedViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/MostListenedViewModel.kt
@@ -1,0 +1,33 @@
+package com.lostf1sh.pixelplayeross.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lostf1sh.pixelplayeross.data.database.EngagementDao
+import com.lostf1sh.pixelplayeross.data.database.SongEngagementEntity
+import com.lostf1sh.pixelplayeross.data.preferences.MostListenedType
+import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class MostListenedViewModel @Inject constructor(
+    engagementDao: EngagementDao,
+    private val userPreferencesRepository: UserPreferencesRepository
+) : ViewModel() {
+
+    val engagements: StateFlow<List<SongEngagementEntity>> = engagementDao.getAllEngagementsFlow()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val mostListenedType: StateFlow<MostListenedType> = userPreferencesRepository.mostListenedTypeFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MostListenedType.SONGS)
+
+    fun setMostListenedType(type: MostListenedType) {
+        viewModelScope.launch {
+            userPreferencesRepository.setMostListenedType(type)
+        }
+    }
+}

--- a/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModel.kt
@@ -46,6 +46,8 @@ import com.lostf1sh.pixelplayeross.data.model.Genre
 import com.lostf1sh.pixelplayeross.data.model.Lyrics
 import com.lostf1sh.pixelplayeross.data.model.LyricsSourcePreference
 import com.lostf1sh.pixelplayeross.data.model.SearchFilterType
+import com.lostf1sh.pixelplayeross.data.database.AudioBookmarkEntity
+import com.lostf1sh.pixelplayeross.data.repository.AudioBookmarkRepository
 import com.lostf1sh.pixelplayeross.data.model.Song
 import com.lostf1sh.pixelplayeross.data.model.SortOption
 import com.lostf1sh.pixelplayeross.data.model.toLibraryTabIdOrNull
@@ -274,8 +276,23 @@ class PlayerViewModel @Inject constructor(
     val multiSelectionStateHolder: MultiSelectionStateHolder,
     val playlistSelectionStateHolder: PlaylistSelectionStateHolder,
     private val sessionToken: SessionToken,
-    private val mediaControllerFactory: com.lostf1sh.pixelplayeross.data.media.MediaControllerFactory
+    private val mediaControllerFactory: com.lostf1sh.pixelplayeross.data.media.MediaControllerFactory,
+    private val bookmarkRepository: AudioBookmarkRepository
 ) : ViewModel() {
+
+    private companion object {
+        /**
+         * Upper bound on how many songs the "shuffle all" entry points pull from the repository.
+         * Libraries at or below this size get their entire catalogue in the queue.
+         *
+         * The bound only exists as a safety valve for extreme libraries: every queue item is
+         * serialized into the playback snapshot on each persist and shipped to session
+         * controllers, so an unbounded queue would make those proportional costs pathological.
+         * Queue construction itself already scales — shuffling yields cooperatively and media
+         * items attach in batches.
+         */
+        const val SHUFFLE_ALL_SONG_LIMIT = 10_000
+    }
 
     private val _playerUiState = MutableStateFlow(PlayerUiState())
     val playerUiState: StateFlow<PlayerUiState> = _playerUiState.asStateFlow()
@@ -373,6 +390,13 @@ class PlayerViewModel @Inject constructor(
             else musicRepository.getArtistsForSong(idLong).map { it.toImmutableList() }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), persistentListOf())
+
+    val allBookmarks: StateFlow<List<AudioBookmarkEntity>> = bookmarkRepository.getAllBookmarksFlow()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
 
     private val _sheetState = MutableStateFlow(PlayerSheetState.COLLAPSED)
     val sheetState: StateFlow<PlayerSheetState> = _sheetState.asStateFlow()
@@ -1254,7 +1278,7 @@ class PlayerViewModel @Inject constructor(
         Timber.tag("ShuffleDebug").d("shuffleAllSongs called.")
         
         viewModelScope.launch {
-            val randomSongs = musicRepository.getRandomSongs(limit = 500)
+            val randomSongs = musicRepository.getRandomSongs(limit = SHUFFLE_ALL_SONG_LIMIT)
             if (randomSongs.isNotEmpty()) {
                 playSongsShuffled(randomSongs, queueName, startAtZero = true)
             }
@@ -1274,7 +1298,7 @@ class PlayerViewModel @Inject constructor(
         val action: () -> Unit = {
             Timber.d("[TileDebug] action() invoked")
             viewModelScope.launch {
-                var songs = musicRepository.getRandomSongs(limit = 500)
+                var songs = musicRepository.getRandomSongs(limit = SHUFFLE_ALL_SONG_LIMIT)
                 Timber.d("[TileDebug] Repository returned ${songs.size} random songs immediately")
 
                 if (songs.isEmpty()) {
@@ -1283,7 +1307,7 @@ class PlayerViewModel @Inject constructor(
                     songs = withTimeoutOrNull(30_000L) {
                         var refreshedSongs = emptyList<Song>()
                         while (refreshedSongs.isEmpty()) {
-                            refreshedSongs = musicRepository.getRandomSongs(limit = 500)
+                            refreshedSongs = musicRepository.getRandomSongs(limit = SHUFFLE_ALL_SONG_LIMIT)
                             if (refreshedSongs.isEmpty()) {
                                 delay(500L)
                             }
@@ -1315,7 +1339,7 @@ class PlayerViewModel @Inject constructor(
 
     fun playRandomSong() {
         viewModelScope.launch {
-            val randomSongs = musicRepository.getRandomSongs(limit = 500)
+            val randomSongs = musicRepository.getRandomSongs(limit = SHUFFLE_ALL_SONG_LIMIT)
             if (randomSongs.isNotEmpty()) {
                 playSongsShuffled(randomSongs, "All Songs (Shuffled)", startAtZero = true)
             }
@@ -3004,6 +3028,63 @@ class PlayerViewModel @Inject constructor(
             playSongsAction()
         }
     }
+
+    fun addBookmark(title: String, timestampMs: Long) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val currentSong = stablePlayerState.value.currentSong ?: return@launch
+            bookmarkRepository.insertBookmark(
+                AudioBookmarkEntity(
+                    songId = currentSong.id,
+                    songTitle = currentSong.title,
+                    artistName = currentSong.displayArtist,
+                    albumArtUri = currentSong.albumArtUriString,
+                    title = title,
+                    timestampMs = timestampMs
+                )
+            )
+        }
+    }
+
+    fun deleteBookmark(id: Long) {
+        viewModelScope.launch(Dispatchers.IO) {
+            bookmarkRepository.deleteBookmark(id)
+        }
+    }
+
+    fun renameBookmark(id: Long, title: String) {
+        val trimmedTitle = title.trim()
+        if (trimmedTitle.isEmpty()) return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val bookmark = bookmarkRepository.getBookmarkById(id) ?: return@launch
+            bookmarkRepository.insertBookmark(bookmark.copy(title = trimmedTitle))
+        }
+    }
+
+    /**
+     * Starts [song] at [startPositionMs], reusing the current media item when it is already the
+     * one playing so jumping between bookmarks inside a track does not restart it.
+     */
+    fun playSongAtPosition(song: Song, startPositionMs: Long) {
+        viewModelScope.launch {
+            val controller = mediaController ?: return@launch
+            val bookmarkStartPositionMs = startPositionMs.coerceAtLeast(0L)
+            if (controller.currentMediaItem?.mediaId == song.id) {
+                controller.seekTo(bookmarkStartPositionMs)
+                controller.play()
+            } else {
+                val mediaItem = buildResolvedPlaybackMediaItem(song)
+                controller.setMediaItem(mediaItem, bookmarkStartPositionMs)
+                controller.prepare()
+                controller.play()
+            }
+            _isSheetVisible.value = true
+            _sheetState.value = PlayerSheetState.EXPANDED
+        }
+    }
+
+    fun getSongsByIds(songIds: List<String>): Flow<List<Song>> =
+        musicRepository.getSongsByIds(songIds)
 
     private suspend fun buildResolvedPlaybackMediaItem(song: Song): MediaItem {
         val mediaItem = MediaItemBuilder.build(song)

--- a/app/src/main/res/drawable/round_bookmark_24.xml
+++ b/app/src/main/res/drawable/round_bookmark_24.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17,3H7c-1.1,0 -2,0.9 -2,2v16l7,-3 7,3V5c0,-1.1 -0.9,-2 -2,-2z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -244,4 +244,13 @@
     <string name="cd_toggle_grid_list">Toggle grid/list view</string>
     <string name="cd_genre_illustration">Genre illustration</string>
     <string name="dash_last_synced_format">Last synced: %1$s</string>
+    <string name="bookmarks_title">Bookmarks</string>
+    <string name="bookmark_save_action">Save bookmark</string>
+    <string name="advanced_stats_title">Advanced stats</string>
+    <string name="most_listened_title">Most listened</string>
+    <string name="most_listened_songs">Songs</string>
+    <string name="most_listened_albums">Albums</string>
+    <string name="most_listened_artists">Artists</string>
+    <string name="most_listened_empty">Nothing here yet. Play some music and your most listened tracks will show up.</string>
+    <string name="most_listened_cd_more_options">More options for %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -244,4 +244,8 @@
     <string name="cd_remove_from_history">Remove from history</string>
     <string name="cd_clear_search">Clear search</string>
     <string name="backup_history_modules_line">%1$d modules · v%2$s · schema v%3$d</string>
+    <string name="settings_search_hint">Search settings</string>
+    <string name="settings_search_no_results">No settings match “%1$s”</string>
+    <string name="settings_search_section_top_matches">Top matches</string>
+    <string name="settings_search_section_related">Related</string>
 </resources>

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/backup/model/BackupSectionTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/backup/model/BackupSectionTest.kt
@@ -47,8 +47,8 @@ class BackupSectionTest {
     }
 
     @Test
-    fun `there are exactly 11 backup sections`() {
-        assertEquals(11, BackupSection.entries.size)
+    fun `there are exactly 12 backup sections`() {
+        assertEquals(12, BackupSection.entries.size)
     }
 
     @Test
@@ -56,6 +56,12 @@ class BackupSectionTest {
         assertEquals(3, BackupSection.QUICK_FILL.sinceVersion)
         assertEquals(3, BackupSection.ARTIST_IMAGES.sinceVersion)
         assertEquals(3, BackupSection.EQUALIZER.sinceVersion)
+    }
+
+    @Test
+    fun `audio bookmarks section is schema v4`() {
+        assertEquals(4, BackupSection.AUDIO_BOOKMARKS.sinceVersion)
+        assertEquals("audio_bookmarks", BackupSection.AUDIO_BOOKMARKS.key)
     }
 
     @Test

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/data/repository/MusicRepositoryImplTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/data/repository/MusicRepositoryImplTest.kt
@@ -54,6 +54,7 @@ class MusicRepositoryImplTest {
         )
         every { mockMusicDao.getAllArtistsRaw() } returns flowOf(dummyArtists)
         coEvery { mockMusicDao.getDistinctParentDirectories() } returns listOf("/music/folder1", "/music/folder2")
+        every { mockMusicDao.getDistinctParentDirectoriesFlow() } returns flowOf(listOf("/music/folder1", "/music/folder2"))
         every { mockMusicDao.getAllSongArtistCrossRefs() } returns flowOf(emptyList())
         every { mockMusicDao.getAllSongs(any(), any()) } answers {
             println("getAllSongs called with: ${args[0]}, ${args[1]}")
@@ -122,6 +123,7 @@ class MusicRepositoryImplTest {
         every { mockUserPreferencesRepository.initialSetupDoneFlow } returns flowOf(true)
         every { mockUserPreferencesRepository.isFolderFilterActiveFlow } returns flowOf(true)
         coEvery { mockMusicDao.getDistinctParentDirectories() } returns listOf("/allowed/path", "/forbidden/path")
+        every { mockMusicDao.getDistinctParentDirectoriesFlow() } returns flowOf(listOf("/allowed/path", "/forbidden/path"))
 
         val result: List<Song> = musicRepository.getAudioFiles().first()
 

--- a/app/src/test/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/lostf1sh/pixelplayeross/presentation/viewmodel/PlayerViewModelTest.kt
@@ -14,6 +14,7 @@ import com.lostf1sh.pixelplayeross.data.model.SortOption
 import com.lostf1sh.pixelplayeross.data.model.StorageFilter
 import com.lostf1sh.pixelplayeross.data.preferences.ThemePreferencesRepository
 import com.lostf1sh.pixelplayeross.data.preferences.UserPreferencesRepository
+import com.lostf1sh.pixelplayeross.data.repository.AudioBookmarkRepository
 import com.lostf1sh.pixelplayeross.data.repository.MusicRepository
 import io.mockk.*
 import androidx.media3.session.MediaController
@@ -63,6 +64,10 @@ class PlayerViewModelTest {
     private val mockUserPreferencesRepository: UserPreferencesRepository = mockk(relaxed = true)
     private val mockThemePreferencesRepository: ThemePreferencesRepository = mockk(relaxed = true)
     private val mockAlbumArtThemeDao: AlbumArtThemeDao = mockk(relaxed = true)
+    private val mockBookmarkRepository: AudioBookmarkRepository = mockk(relaxed = true)
+
+    /** Mirrors PlayerViewModel.SHUFFLE_ALL_SONG_LIMIT, which is private to the ViewModel. */
+    private val EXPECTED_SHUFFLE_ALL_LIMIT = 10_000
     private val mockContext: Context = mockk(relaxed = true)
 
     private val mockSyncManager: SyncManager = mockk(relaxed = true)
@@ -229,7 +234,8 @@ class PlayerViewModelTest {
             mockMultiSelectionStateHolder,
             mockPlaylistSelectionStateHolder,
             sessionToken,
-            mockMediaControllerFactory
+            mockMediaControllerFactory,
+            mockBookmarkRepository
         )
     }
 
@@ -466,13 +472,13 @@ class PlayerViewModelTest {
         @Test
         fun `shuffleAllSongs calls prepareShuffledQueue with random songs at index zero`() = runTest {
             val randomSongs = listOf(song2, song3, song1)
-            coEvery { mockMusicRepository.getRandomSongs(500) } returns randomSongs
+            coEvery { mockMusicRepository.getRandomSongs(EXPECTED_SHUFFLE_ALL_LIMIT) } returns randomSongs
             stubShuffledPlayback(randomSongs, startSong = song2)
 
             playerViewModel.shuffleAllSongs()
             advanceUntilIdle()
 
-            coVerify { mockMusicRepository.getRandomSongs(500) }
+            coVerify { mockMusicRepository.getRandomSongs(EXPECTED_SHUFFLE_ALL_LIMIT) }
             coVerify {
                 mockQueueStateHolder.prepareShuffledQueueSuspending(
                     randomSongs,
@@ -484,7 +490,7 @@ class PlayerViewModelTest {
         @Test
         fun `playRandomSong calls prepareShuffledQueue with startAtZero`() = runTest {
             val randomSongs = listOf(song3, song1, song2)
-            coEvery { mockMusicRepository.getRandomSongs(500) } returns randomSongs
+            coEvery { mockMusicRepository.getRandomSongs(EXPECTED_SHUFFLE_ALL_LIMIT) } returns randomSongs
             stubShuffledPlayback(randomSongs, startSong = song3)
 
             playerViewModel.playRandomSong()
@@ -563,13 +569,13 @@ class PlayerViewModelTest {
         @Test
         fun `triggerShuffleAllFromTile uses repository sample and startAtZero`() = runTest {
             val songs = listOf(song1, song2, song3)
-            coEvery { mockMusicRepository.getRandomSongs(500) } returns songs
+            coEvery { mockMusicRepository.getRandomSongs(EXPECTED_SHUFFLE_ALL_LIMIT) } returns songs
             stubShuffledPlayback(songs, startSong = song1)
 
             playerViewModel.triggerShuffleAllFromTile()
             advanceUntilIdle()
 
-            coVerify { mockMusicRepository.getRandomSongs(500) }
+            coVerify { mockMusicRepository.getRandomSongs(EXPECTED_SHUFFLE_ALL_LIMIT) }
             coVerify {
                 mockQueueStateHolder.prepareShuffledQueueSuspending(
                     songs,


### PR DESCRIPTION
Four new features, plus two fixes that turned up along the way.

**Settings search.** Type "vibration" or "bitrate" into the settings screen and you land on the row you wanted, which pulses so you can tell which of a dozen similar toggles the result meant. Matching is fuzzy and diacritic-insensitive, so typos and partial words still find things. `SettingsRegistry` is a flat index of every settings row — adding a row to a category screen means adding it there too, or it stays unsearchable.

**Audio bookmarks.** Save a moment inside a track from the player and jump back to it later. Rows snapshot the title, artist and artwork at save time, so a bookmark still renders after the file is moved, retagged or removed. Included in backup/restore. In the sidebar.

**Advanced stats.** Listening heatmap, a daily goal with a streak, habit insights. Reachable from the calendar icon on the stats screen.

**Most listened.** Play counts grouped by song, album or artist. In the sidebar.

**Fixes.** The cached directory filter was computed once, eagerly, before the first sync — on some devices that left it filtering against an empty folder list, so tapping a song gave you a queue of exactly that song. It now watches the songs table and skips the work entirely when nothing is blocked. Separately, shuffle-all was capped at 500 songs; that bound only exists as a safety valve for enormous libraries, so it's now 10,000.

### Reviewer notes

- **Database goes to v3 → v4**, backup schema 3 → 4, both additive (`MIGRATION_3_4` creates the `audio_bookmarks` table). Debug builds use `fallbackToDestructiveMigration`, so **the migration has not actually been exercised against a real v3 database** — worth running a release build over an existing install before this ships.
- `SettingsComponents.kt` gained `modifier` params on six components so category rows can be tagged for highlighting. Existing call sites all use named arguments, so nothing shifted positionally.
- `getCategoryColors` in `SettingsScreen.kt` went from private to internal.
- Search highlights scroll into view with a `BringIntoViewRequester` rather than a list index, because every category page renders its rows inside a single lazy item. That also keeps it working when rows are reordered or conditionally hidden.
- The blurred artwork behind Most Listened rows uses platform `RenderEffect`, which is API 31+, so it's guarded and simply draws unblurred on 30.
- I have not driven the UI through the new screens. Build, lint and 422 unit tests are clean, and the app installs and launches without crashing on a physical device, but the screens themselves want eyes on them.